### PR TITLE
phpstan is now installed with phive rather than composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Note: Can be used with `nvuillam/mega-linter@insiders` in your GitHub Action meg
 - Add eslint-plugin-jsx-a11y dependency
 - Rename default PHPStan config file, from `phpstan.neon` to `phpstan.neon.dist` accordingly to [PHPStan resolution priority](https://phpstan.org/config-reference#config-file)
 - Allows `list_of_files` cli_lint_mode on PHPSTAN linter to improve performance compare to `file` mode
+- `phpstan` is now installed with `phive` rather than `composer` (reduces disk usage)
 
 - Linter versions upgrades
   - [cfn-lint](https://github.com/martysweet/cfn-lint) from 0.54.1 to **0.54.2** on 2021-09-23

--- a/Dockerfile
+++ b/Dockerfile
@@ -392,10 +392,8 @@ RUN phive --no-progress install phpcs -g --trust-gpg-keys 31C7E470E2138192
 
 
 # phpstan installation
-RUN composer global require phpstan/phpstan \
-    && composer global config bin-dir --absolute
+RUN phive --no-progress install phpstan -g --trust-gpg-keys CF1A108D0E7AE720
 
-ENV PATH="/root/.composer/vendor/bin:$PATH"
 
 # psalm installation
 RUN phive --no-progress install psalm -g --trust-gpg-keys 8A03EA3B385DBAA1,12CE0F1D262429A5

--- a/flavors/php/Dockerfile
+++ b/flavors/php/Dockerfile
@@ -220,10 +220,8 @@ RUN phive --no-progress install phpcs -g --trust-gpg-keys 31C7E470E2138192
 
 
 # phpstan installation
-RUN composer global require phpstan/phpstan \
-    && composer global config bin-dir --absolute
+RUN phive --no-progress install phpstan -g --trust-gpg-keys CF1A108D0E7AE720
 
-ENV PATH="/root/.composer/vendor/bin:$PATH"
 
 # psalm installation
 RUN phive --no-progress install psalm -g --trust-gpg-keys 8A03EA3B385DBAA1,12CE0F1D262429A5

--- a/megalinter/descriptors/php.megalinter-descriptor.yml
+++ b/megalinter/descriptors/php.megalinter-descriptor.yml
@@ -107,9 +107,7 @@ linters:
     install:
       dockerfile:
         - |
-          RUN composer global require phpstan/phpstan \
-              && composer global config bin-dir --absolute
-        - ENV PATH="/root/.composer/vendor/bin:$PATH"
+          RUN phive --no-progress install phpstan -g --trust-gpg-keys CF1A108D0E7AE720
     ide:
       idea:
         - name: PHPStan / Psalm / Generics


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #822 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Add install command into Dockerfile: `RUN phive --no-progress install phpstan -g --trust-gpg-keys CF1A108D0E7AE720`

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [X] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
