### PR TITLE
PHPCS allows list_of_files mode to scan in one call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Note: Can be used with `nvuillam/mega-linter@insiders` in your GitHub Action meg
 - Rename default PHPStan config file, from `phpstan.neon` to `phpstan.neon.dist` accordingly to [PHPStan resolution priority](https://phpstan.org/config-reference#config-file)
 - Allows `list_of_files` cli_lint_mode on PHPSTAN linter to improve performance compare to `file` mode
 - `phpstan` is now installed with `phive` rather than `composer` (reduces disk usage)
+- Allows `list_of_files` cli_lint_mode on PHPCS linter to improve performance compare to `file` mode
 
 - Linter versions upgrades
   - [cfn-lint](https://github.com/martysweet/cfn-lint) from 0.54.1 to **0.54.2** on 2021-09-23

--- a/docs/descriptors/php_phpcs.md
+++ b/docs/descriptors/php_phpcs.md
@@ -64,7 +64,7 @@ This linter is available in the following flavours
 <!-- /* cSpell:disable */ -->
 ### How the linting is performed
 
-- phpcs is called one time by identified file
+- phpcs is called once with the list of files as arguments
 
 ### Example calls
 
@@ -74,6 +74,10 @@ phpcs myfile.php
 
 ```shell
 phpcs --standard=phpcs.xml myfile.php
+```
+
+```shell
+phpcs --standard=phpcs.xml mydir/ myfile.php
 ```
 
 

--- a/megalinter/descriptors/php.megalinter-descriptor.yml
+++ b/megalinter/descriptors/php.megalinter-descriptor.yml
@@ -58,10 +58,12 @@ linters:
     linter_rules_configuration_url: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file
     linter_rules_inline_disable_url: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-parts-of-a-file
     config_file_name: phpcs.xml
+    cli_lint_mode: list_of_files
     cli_config_arg_name: "--standard="
     examples:
       - "phpcs myfile.php"
       - "phpcs --standard=phpcs.xml myfile.php"
+      - "phpcs --standard=phpcs.xml mydir/ myfile.php"
     install:
       dockerfile:
         - |

--- a/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
@@ -6585,7 +6585,7 @@
     },
     "PHP_PHPCS_CLI_LINT_MODE": {
       "$id": "#/properties/PHP_PHPCS_CLI_LINT_MODE",
-      "default": "file",
+      "default": "list_of_files",
       "enum": [
         "file",
         "list_of_files",


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #825 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. switch default `cli_lint_mode` to `list_of_files` in `megalinter/descriptors/php.megalinter-descriptor.yml`

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
