### PR TITLE
Fix typo error in environment variable to activate TAP reporter

### DIFF
--- a/megalinter/reporters/TapReporter.py
+++ b/megalinter/reporters/TapReporter.py
@@ -26,7 +26,7 @@ class TapReporter(Reporter):
             if config.get("OUTPUT_DETAIL", "") == "detailed":
                 self.report_type = "detailed"
         # Mega-Linter vars (false by default)
-        elif config.get("TEXT_REPORTER", "false") == "true":
+        elif config.get("TAP_REPORTER", "false") == "true":
             self.is_active = True
         else:
             self.is_active = False


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #744 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Replace `TEXT_REPORTER` by `TAP_REPORTER`

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
