### PR TITLE
Correct spelling of `containername` argument.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,7 +5,7 @@
   require_serial: true
   args:
     - mega-linter-runner
-    - --containername "megalinter-$(basename "$PWD")"
+    - --container-name "megalinter-$(basename "$PWD")"
     - --remove-container
     - --fix
     - --env
@@ -35,7 +35,7 @@
   require_serial: true
   args:
     - mega-linter-runner
-    - --containername "megalinter-all-$(basename "$PWD")"
+    - --container-name "megalinter-all-$(basename "$PWD")"
     - --remove-container
     - --fix
     - --env

--- a/mega-linter-runner/README.md
+++ b/mega-linter-runner/README.md
@@ -105,7 +105,7 @@ The options are only related to mega-linter-runner. For MegaLinter options, plea
 | `-h` <br/> `--help`    | Show mega-linter-runner help                                                                                       | <!-- -->          |
 | `-v` <br/> `--version` | Show mega-linter-runner version                                                                                    | <!-- -->          |
 | `-i` <br/> `--install` | Generate MegaLinter configuration files                                                                            | <!-- -->          |
-| `--containername`      | Specify MegaLinter container name                                                                                  | <!-- -->          |
+| `--container-name`     | Specify MegaLinter container name                                                                                  | <!-- -->          |
 | `--remove-container`   | Remove MegaLinter Docker container when done                                                                       | <!-- -->          |
 
 _You can also use `npx mega-linter-runner` if you do not want to install the package_

--- a/mega-linter-runner/lib/options.js
+++ b/mega-linter-runner/lib/options.js
@@ -122,7 +122,8 @@ module.exports = optionator({
       description: "Upgrade local repository MegaLinter configuration",
     },
     {
-      option: "containername",
+      option: "container-name",
+      alias: "containername",
       type: "String",
       description: "Specify MegaLinter container name",
     },

--- a/mega-linter-runner/lib/runner.js
+++ b/mega-linter-runner/lib/runner.js
@@ -124,8 +124,8 @@ ERROR: Docker engine has not been found on your system.
     if (options["removeContainer"]) {
       commandArgs.push("--rm");
     }
-    if (options.containername) {
-      commandArgs.push(...["--name", options.containername]);
+    if (options["containerName"]) {
+      commandArgs.push(...["--name", options["containerName"]]);
     }
     commandArgs.push(...["-v", "/var/run/docker.sock:/var/run/docker.sock:rw"]);
     commandArgs.push(...["-v", `${lintPath}:/tmp/lint:rw`]);


### PR DESCRIPTION
Fixes #1570.

## Proposed Changes

1. Spell the new mega-linter-runner argument `container-name` for consistency with the package name, mega-linter-runner, and to spare users from needing to add `containername` as a CSpell exception.
2. Remove the CSpell exception for `containername` to prove that no references were missed and as a regression test.
3. Make minor formatting improvements to runner.js for consistency with #1563 based on my code review feedback on #1561.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
