### PR TITLE
Disable PHP Memory Limit in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -269,7 +269,9 @@ RUN wget --tries=5 -q -O phive.phar https://phar.io/releases/phive.phar \
     && mv phive.phar /usr/local/bin/phive \
     && rm phive.phar.asc \
     && update-alternatives --install /usr/bin/php php /usr/bin/php7 100 \
-    && update-alternatives --install /usr/bin/php php /usr/bin/php8 10
+    && update-alternatives --install /usr/bin/php php /usr/bin/php8 10 \
+    && echo 'memory_limit = -1' > /etc/php7/conf.d/02_memlimit.ini \
+    && echo 'memory_limit = -1' > /etc/php8/conf.d/02_memlimit.ini
 
 
 # POWERSHELL installation


### PR DESCRIPTION
The default memory limit of `128M` is not enough to lint larger projects.

Since this is a development tool (running on trusted input, or in isolated environments) and not a production server its safe to disable this limit.

## Fixes:
```
PHP Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate xxxxx bytes)
```

## Proposed Changes:
1. Disable PHP memory limit

## Current Workaround:
Apply the changes by extending the Docker image with an new Dockerfile.
```Dockerfile
FROM megalinter/megalinter:latest

RUN echo 'memory_limit = -1' > /etc/php7/conf.d/02_memlimit.ini \
    && echo 'memory_limit = -1' > /etc/php8/conf.d/02_memlimit.ini
```

