### PR TITLE
Add `megalinter-reports` to JSCPD tempate ignore

### DIFF
--- a/TEMPLATES/.jscpd.json
+++ b/TEMPLATES/.jscpd.json
@@ -10,6 +10,7 @@
     "**/.rbenv/**",
     "**/.venv/**",
     "**/report/**",
+    "**/megalinter-reports/**",
     "**/*cache*/**",
     "**/*.json",
     "**/*.yaml",


### PR DESCRIPTION
Version 6 default report folder is `megalinter-reports`. I left `report` for backward compatibility.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
