### PR TITLE
add CLEAR_REPORT_DIRECTORY to schema

### DIFF
--- a/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
@@ -979,6 +979,13 @@
       "title": "BASH_SHFMT: Define or override a list of bash commands to run before the linter",
       "type": "array"
     },
+    "CLEAR_REPORT_FOLDER": {
+      "$id": "#/properties/CLEAR_REPORT_FOLDER",
+      "default": false,
+      "title": "Clear Report Folder",
+      "description": "Flag to clear files from report folder (usually megalinter-reports) before starting the linting process",
+      "type": "boolean"
+    },
     "CLOJURE_CLJ_KONDO_ARGUMENTS": {
       "$id": "#/properties/CLOJURE_CLJ_KONDO_ARGUMENTS",
       "description": "CLOJURE_CLJ_KONDO: User custom arguments to add in linter CLI call",


### PR DESCRIPTION
## Proposed Changes
1. Add new CLEAR_REPORT_DIRECTORY config var to the JSON schema
Extension of [Clear report directory](https://github.com/oxsecurity/megalinter/issues/1502) issue.

#1502 