### PR TITLE
update disable linters when running locally

### DIFF
--- a/docs/mega-linter-runner.md
+++ b/docs/mega-linter-runner.md
@@ -75,7 +75,7 @@ See [`.pre-commit-hooks.yaml`](../.pre-commit-hooks.yaml) for more details.
 mega-linter-runner [OPTIONS]
 ```
 
-The options are only related to mega-linter-runner. For MegaLinter options, please use a `.mega-linter.yml` [configuration file](#configuration). If settings are defined in both option flags and .mega-linter.yml, the priority is on option flags. 
+The options are only related to mega-linter-runner. For MegaLinter options, please use a `.mega-linter.yml` [configuration file](#configuration). Option flags take precedence over the configuration file.
 
 | Option                 | Description                                                                                                        | Default           |
 |------------------------|--------------------------------------------------------------------------------------------------------------------|-------------------|
@@ -100,6 +100,10 @@ mega-linter-runner
 
 ```shell
 mega-linter-runner -p myFolder --fix
+```
+
+```shell
+npx mega-linter-runner --flavor python -e "'DISABLE_LINTERS=PYTHON_BANDIT,PYTHON_PYLINT,PYTHON_MYPY'" -e 'SHOW_ELAPSED_TIME=true'
 ```
 
 

--- a/docs/mega-linter-runner.md
+++ b/docs/mega-linter-runner.md
@@ -15,7 +15,7 @@
 
 <!-- readme-header-end -->
 
-This package allows to run [MegaLinter](https://megalinter.github.io/) locally before running it in your CD/CI workflow, or simply to locally apply reformatting and fixes without having to install up to date linters for your files
+This package allows to run [MegaLinter](https://megalinter.github.io/) locally before running it in your CD/CI workflow, or simply to locally apply reformatting and fixes without having to install up to date linters for your files. You can still use use the `.mega-linter.yml` [configuration file](#configuration) to specify environment variables. The package can also find linting configuration files which are not held in the root project e.g. .github/linters.
 
 ![Screenshot](https://github.com/oxsecurity/megalinter/blob/main/docs/assets/images/ConsoleReporter.jpg?raw=true>)
 
@@ -41,10 +41,19 @@ npm install mega-linter-runner --save-dev
 
 You can run mega-linter-runner without installation by using `npx`
 
-Example:
+Examples:
+
+```shell
+# Environment variables specified in .mega-linter.yml configuration file
+npx mega-linter-runner
+```
 
 ```shell
 npx mega-linter-runner -r beta -e 'ENABLE=MARKDOWN,YAML' -e 'SHOW_ELAPSED_TIME=true'
+```
+
+```shell
+npx mega-linter-runner --flavor python -e "'DISABLE_LINTERS=PYTHON_BANDIT,PYTHON_PYLINT,PYTHON_MYPY,REPOSITORY_SEMGREP,SPELL_CSPELL'"
 ```
 
 ### Pre-commit hook
@@ -77,7 +86,7 @@ The options are only related to mega-linter-runner. For MegaLinter options, plea
 | `-p` <br/> `--path`    | Directory containing the files to lint                                                                             | current directory |
 | `--flavor`             | Set this parameter to use a [MegaLinter flavor](https://megalinter.github.io/flavors/)                             | `all`             |
 | `-d` <br/> `--image`   | You can override the used docker image, including if it is on another docker registry                              | <!-- -->          |
-| `-e` <br/> `--env`     | Environment variables for MegaLinter, following format **'ENV_VAR_NAME=VALUE'** <br/>Warning: Quotes are mandatory | <!-- -->          |
+| `-e` <br/> `--env`     | Environment variables for MegaLinter, following format **'ENV_VAR_NAME=VALUE'** <br/>Warning: Quotes are mandatory, you might also need double quotes around the single quotes  | <!-- -->          |
 | `--fix`                | Automatically apply formatting and fixes in your files                                                             | <!-- -->          |
 | `-r` <br/> `--release` | Allows to override MegaLinter version used                                                                         | `v5`              |
 | `-h` <br/> `--help`    | Show mega-linter-runner help                                                                                       | <!-- -->          |

--- a/docs/mega-linter-runner.md
+++ b/docs/mega-linter-runner.md
@@ -103,7 +103,7 @@ mega-linter-runner -p myFolder --fix
 ```
 
 ```shell
-npx mega-linter-runner --flavor python -e "'DISABLE_LINTERS=PYTHON_BANDIT,PYTHON_PYLINT,PYTHON_MYPY'" -e 'SHOW_ELAPSED_TIME=true'
+mega-linter-runner --flavor python -e "'DISABLE_LINTERS=PYTHON_BANDIT,PYTHON_PYLINT,PYTHON_MYPY'" -e 'SHOW_ELAPSED_TIME=true'
 ```
 
 

--- a/docs/mega-linter-runner.md
+++ b/docs/mega-linter-runner.md
@@ -49,7 +49,7 @@ npx mega-linter-runner
 ```
 
 ```shell
-npx mega-linter-runner --flavor python -e "'DISABLE_LINTERS=PYTHON_BANDIT,PYTHON_PYLINT,PYTHON_MYPY,REPOSITORY_SEMGREP,SPELL_CSPELL'"
+npx mega-linter-runner --flavor python -e "'DISABLE_LINTERS=PYTHON_BANDIT,PYTHON_PYLINT,PYTHON_MYPY'" -e 'SHOW_ELAPSED_TIME=true'
 ```
 
 ### Pre-commit hook

--- a/docs/mega-linter-runner.md
+++ b/docs/mega-linter-runner.md
@@ -15,7 +15,7 @@
 
 <!-- readme-header-end -->
 
-This package allows to run [MegaLinter](https://megalinter.github.io/) locally before running it in your CD/CI workflow, or simply to locally apply reformatting and fixes without having to install up to date linters for your files. You can still use use the `.mega-linter.yml` [configuration file](#configuration) to specify environment variables. The package can also find linting configuration files which are not held in the root project e.g. .github/linters.
+This package allows to run [MegaLinter](https://megalinter.github.io/) locally before running it in your CD/CI workflow, or simply to locally apply reformatting and fixes without having to install up to date linters for your files.
 
 ![Screenshot](https://github.com/oxsecurity/megalinter/blob/main/docs/assets/images/ConsoleReporter.jpg?raw=true>)
 
@@ -44,12 +44,8 @@ You can run mega-linter-runner without installation by using `npx`
 Examples:
 
 ```shell
-# Environment variables specified in .mega-linter.yml configuration file
+# Use default settings + .mega-linter.yml configuration file.
 npx mega-linter-runner
-```
-
-```shell
-npx mega-linter-runner -r beta -e 'ENABLE=MARKDOWN,YAML' -e 'SHOW_ELAPSED_TIME=true'
 ```
 
 ```shell
@@ -79,14 +75,14 @@ See [`.pre-commit-hooks.yaml`](../.pre-commit-hooks.yaml) for more details.
 mega-linter-runner [OPTIONS]
 ```
 
-The options are only related to mega-linter-runner. For MegaLinter options, please use a `.mega-linter.yml` [configuration file](#configuration)
+The options are only related to mega-linter-runner. For MegaLinter options, please use a `.mega-linter.yml` [configuration file](#configuration). If settings are defined in both option flags and .mega-linter.yml, the priority is on option flags. 
 
 | Option                 | Description                                                                                                        | Default           |
 |------------------------|--------------------------------------------------------------------------------------------------------------------|-------------------|
 | `-p` <br/> `--path`    | Directory containing the files to lint                                                                             | current directory |
 | `--flavor`             | Set this parameter to use a [MegaLinter flavor](https://megalinter.github.io/flavors/)                             | `all`             |
 | `-d` <br/> `--image`   | You can override the used docker image, including if it is on another docker registry                              | <!-- -->          |
-| `-e` <br/> `--env`     | Environment variables for MegaLinter, following format **'ENV_VAR_NAME=VALUE'** <br/>Warning: Quotes are mandatory, you might also need double quotes around the single quotes  | <!-- -->          |
+| `-e` <br/> `--env`     | Environment variables for MegaLinter, following format **'ENV_VAR_NAME=VALUE'** <br/>Warning: Quotes are mandatory; you will also need double quotes around the single quotes when setting lists | <!-- -->          |
 | `--fix`                | Automatically apply formatting and fixes in your files                                                             | <!-- -->          |
 | `-r` <br/> `--release` | Allows to override MegaLinter version used                                                                         | `v5`              |
 | `-h` <br/> `--help`    | Show mega-linter-runner help                                                                                       | <!-- -->          |
@@ -106,9 +102,6 @@ mega-linter-runner
 mega-linter-runner -p myFolder --fix
 ```
 
-```shell
-mega-linter-runner -r beta -e 'ENABLE=MARKDOWN,YAML' -e 'SHOW_ELAPSED_TIME=true'
-```
 
 ## Configuration
 


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #1659 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Documentation change to explain how to use the DISABLE_LINTERS when running locally

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
