### PR TITLE
Correct spelling of `removecontainer` argument.

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1013,7 +1013,6 @@
         "relaxng",
         "remarkrc",
         "remoting",
-        "removecontainer",
         "replicatedhq",
         "repos",
         "repositoryformatversion",

--- a/docs/mega-linter-runner.md
+++ b/docs/mega-linter-runner.md
@@ -84,7 +84,7 @@ The options are only related to mega-linter-runner. For MegaLinter options, plea
 | `-v` <br/> `--version` | Show mega-linter-runner version                                                                                    | <!-- -->          |
 | `-i` <br/> `--install` | Generate MegaLinter configuration files                                                                            | <!-- -->          |
 | `--containername`      | Specify MegaLinter container name                                                                                  | <!-- -->          |
-| `--removecontainer`    | Remove MegaLinter Docker container when done                                                                       | <!-- -->          |
+| `--remove-container`   | Remove MegaLinter Docker container when done                                                                       | <!-- -->          |
 
 _You can also use `npx mega-linter-runner` if you do not want to install the package_
 

--- a/mega-linter-runner/README.md
+++ b/mega-linter-runner/README.md
@@ -102,7 +102,7 @@ The options are only related to mega-linter-runner. For MegaLinter options, plea
 | `-v` <br/> `--version` | Show mega-linter-runner version                                                                                    | <!-- -->          |
 | `-i` <br/> `--install` | Generate MegaLinter configuration files                                                                            | <!-- -->          |
 | `--containername`      | Specify MegaLinter container name                                                                                  | <!-- -->          |
-| `--removecontainer`    | Remove MegaLinter Docker container when done                                                                       | <!-- -->          |
+| `--remove-container`   | Remove MegaLinter Docker container when done                                                                       | <!-- -->          |
 
 _You can also use `npx mega-linter-runner` if you do not want to install the package_
 

--- a/mega-linter-runner/lib/options.js
+++ b/mega-linter-runner/lib/options.js
@@ -122,7 +122,7 @@ module.exports = optionator({
       description: "Specify MegaLinter container name",
     },
     {
-      option: "removecontainer",
+      option: "remove-container",
       type: "Boolean",
       description: "Remove MegaLinter Docker container when done",
     },

--- a/mega-linter-runner/lib/runner.js
+++ b/mega-linter-runner/lib/runner.js
@@ -121,7 +121,7 @@ ERROR: Docker engine has not been found on your system.
     // Build docker run options
     const lintPath = path.resolve(options.path || ".");
     const commandArgs = ["run"];
-    if (options.removecontainer) {
+    if (options["remove-container"]) {
       commandArgs.push("--rm");
     }
     if (options.containername) {


### PR DESCRIPTION
Spell the new mega-linter-runner argument `removecontainer` for consistency with the package name, mega-linter-runner, and to spare users from needing to add `removecontainer` as a CSpell exception.

## Proposed Changes

1. Rename mega-linter-runner argument `removecontainer` to `remove-container`.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
