### PR TITLE
Surfacing warnings during successful runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Note: Can be used with `megalinter/megalinter@beta` in your GitHub Action mega-linter.yml file, or with `megalinter/megalinter:beta` docker image
 
+- Addition of warnings to reporters and logic changes to surface warnings even when there are no errors. Addition of cli_lint_warning_count & cli_lint_warning_regex variables to the JSON schema. [(#1541)](https://github.com/oxsecurity/megalinter/issues/1541)
 - Fixes about JSON Schema [(#1621)](https://github.com/oxsecurity/megalinter/issues/1621)
 - Add [checkmake](https://github.com/mrtazz/checkmake) to lint Makefile
 - Avoid cspell to lint all files. Lint only other linter files [(#1648)](https://github.com/oxsecurity/megalinter/issues/1648)

--- a/megalinter/Linter.py
+++ b/megalinter/Linter.py
@@ -111,6 +111,8 @@ class Linter:
         self.cli_lint_extra_args_after = []
         self.cli_lint_errors_count = None
         self.cli_lint_errors_regex = None
+        self.cli_lint_warnings_count = None
+        self.cli_lint_warnings_regex = None
         # Default arg name for configurations to use in linter version call
         self.cli_version_arg_name = "--version"
         self.cli_version_extra_args = []  # Extra arguments to send to cli everytime
@@ -332,6 +334,7 @@ class Linter:
             self.return_code = 0
             self.number_errors = 0
             self.total_number_errors = 0
+            self.total_number_warnings = 0
             self.number_fixed = 0
             self.files_lint_results = []
             self.start_perf = None
@@ -558,6 +561,9 @@ class Linter:
                 index = index + 1
                 return_code, stdout = self.process_linter(file)
                 file_errors_number = 0
+                file_warnings_number = 0
+                file_warnings_number = self.get_total_number_warnings(stdout)
+                self.total_number_warnings += file_warnings_number
                 if return_code > 0:
                     file_status = "error"
                     self.status = "warning" if self.disable_errors is True else "error"
@@ -565,23 +571,29 @@ class Linter:
                         self.return_code if self.disable_errors is True else 1
                     )
                     self.number_errors += 1
+                    # Calls external functions to count the number of warnings and errors
                     file_errors_number = self.get_total_number_errors(stdout)
+                    
                     self.total_number_errors += file_errors_number
                 self.update_files_lint_results(
-                    [file], return_code, file_status, stdout, file_errors_number
+                    [file], return_code, file_status, stdout, file_errors_number, file_warnings_number
                 )
         else:
             # Lint all workspace in one command
             return_code, stdout = self.process_linter()
             self.stdout = stdout
+            #Count warnings regardaless of return code
+            self.total_number_warnings += self.get_total_number_warnings(stdout)
             if return_code != 0:
                 self.status = "warning" if self.disable_errors is True else "error"
                 self.return_code = 0 if self.disable_errors is True else 1
                 self.number_errors += 1
                 self.total_number_errors += self.get_total_number_errors(stdout)
+            elif self.total_number_warnings > 0:
+                self.status = "warning"
             # Build result for list of files
             if self.cli_lint_mode == "list_of_files":
-                self.update_files_lint_results(self.files, None, None, None, None)
+                self.update_files_lint_results(self.files, None, None, None, None, None)
 
         # Set return code to 0 if failures in this linter must not make the MegaLinter run fail
         if self.return_code != 0:
@@ -622,7 +634,7 @@ class Linter:
         return variables_with_replacements
 
     def update_files_lint_results(
-        self, linted_files, return_code, file_status, stdout, file_errors_number
+        self, linted_files, return_code, file_status, stdout, file_errors_number, file_warnings_number
     ):
         if self.try_fix is True:
             updated_files = utils.list_updated_files(self.github_workspace)
@@ -646,6 +658,7 @@ class Linter:
                     "stdout": stdout,
                     "fixed": fixed,
                     "errors_number": file_errors_number,
+                    "warnings_number": file_warnings_number
                 }
             ]
 
@@ -993,6 +1006,7 @@ class Linter:
     # Find number of errors in linter stdout log
     def get_total_number_errors(self, stdout: str):
         total_errors = 0
+
         # Count using SARIF output file
         if self.output_sarif is True:
             try:
@@ -1043,17 +1057,17 @@ class Linter:
                     + stdout
                 )
                 return total_errors
-        # Get number with a single regex.
+        # Get number with a single regex. Used when linter prints out Found _ errors
         elif self.cli_lint_errors_count == "regex_number":
             reg = self.get_regex(self.cli_lint_errors_regex)
             m = re.search(reg, stdout)
             if m:
                 total_errors = int(m.group(1))
-        # Count the number of occurrences of a regex corresponding to an error in linter log
+        # Count the number of occurrences of a regex corresponding to an error in linter log (parses linter log)
         elif self.cli_lint_errors_count == "regex_count":
             reg = self.get_regex(self.cli_lint_errors_regex)
             total_errors = len(re.findall(reg, stdout))
-        # Sum of all numbers found in linter logs with a regex
+        # Sum of all numbers found in linter logs with a regex. Found when each file prints out total number of errors
         elif self.cli_lint_errors_count == "regex_sum":
             reg = self.get_regex(self.cli_lint_errors_regex)
             matches = re.findall(reg, stdout)
@@ -1071,10 +1085,47 @@ class Linter:
                 f"Unable to get number of errors with {self.cli_lint_errors_count} "
                 f"and {str(self.cli_lint_errors_regex)}"
             )
+        
+        #If no regex is defined, return 0 errors if there is a success or 1 error if there are any
         if self.status == "success":
             return 0
         else:
             return 1
+
+    # Find number of warnings in linter stdout log
+    def get_total_number_warnings(self, stdout: str):
+        total_warnings = 0
+
+        # Get number with a single regex.
+        if self.cli_lint_warnings_count == "regex_number":
+            reg = self.get_regex(self.cli_lint_warnings_regex)
+            m = re.search(reg, stdout)
+            if m:
+                total_warnings = int(m.group(1))
+        # Count the number of occurrences of a regex corresponding to an error in linter log (parses linter log)
+        elif self.cli_lint_warnings_count == "regex_count":
+            reg = self.get_regex(self.cli_lint_warnings_regex)
+            total_warnings = len(re.findall(reg, stdout))
+        # Sum of all numbers found in linter logs with a regex. Found when each file prints out total number of errors
+        elif self.cli_lint_warnings_count == "regex_sum":
+            reg = self.get_regex(self.cli_lint_warnings_regex)
+            matches = re.findall(reg, stdout)
+            total_warnings = sum(int(m) for m in matches)
+        # Count all lines of the linter log
+        elif self.cli_lint_warnings_count == "total_lines":
+            total_warnings = sum(
+                not line.isspace() and line != "" for line in stdout.splitlines()
+            )
+        # Return result if found, else default value according to status
+        if total_warnings > 0:
+            return total_warnings
+        if self.cli_lint_warnings_count is not None:
+            logging.warning(
+                f"Unable to get number of warnings with {self.cli_lint_warnings_count} "
+                f"and {str(self.cli_lint_warnings_regex)}"
+            )
+        
+        return 0
 
     # Build the CLI command to get linter version (can be overridden if --version is not the way to get the version)
     def build_version_command(self):

--- a/megalinter/descriptors/css.megalinter-descriptor.yml
+++ b/megalinter/descriptors/css.megalinter-descriptor.yml
@@ -21,6 +21,10 @@ linters:
     config_file_name: .stylelintrc.json
     cli_config_arg_name: "--config"
     cli_lint_fix_arg_name: "--fix"
+    cli_lint_errors_count: regex_number
+    cli_lint_errors_regex: "([0-9]+) errors"
+    cli_lint_warnings_count: regex_number
+    cli_lint_warnings_regex: "([0-9]+) warnings"
     examples:
       - "stylelint myfile.css"
       - "stylelint --config .stylelintrc.json myfile.css myfile2.css myfile3.css"

--- a/megalinter/descriptors/go.megalinter-descriptor.yml
+++ b/megalinter/descriptors/go.megalinter-descriptor.yml
@@ -18,6 +18,10 @@ linters:
     linter_rules_configuration_url: https://golangci-lint.run/usage/configuration/#config-file
     linter_rules_inline_disable_url: https://golangci-lint.run/usage/false-positives/#nolint
     config_file_name: .golangci.yml
+    cli_lint_errors_count: regex_count
+    cli_lint_errors_regex: "level=error"
+    cli_lint_warnings_count: regex_count
+    cli_lint_warnings_regex: "warning"
     cli_lint_extra_args:
       - "run"
     cli_version_arg_name: "version"

--- a/megalinter/descriptors/json.megalinter-descriptor.yml
+++ b/megalinter/descriptors/json.megalinter-descriptor.yml
@@ -103,6 +103,8 @@ linters:
       - "{{SARIF_OUTPUT_FILE}}"
     cli_lint_errors_count: regex_sum
     cli_lint_errors_regex: "✖ ([0-9]+) problem"
+    cli_lint_warnings_count: regex_number
+    cli_lint_warnings_regex: "([0-9]+) warnings"
     cli_executable_version: "npm"
     cli_version_arg_name: ""
     cli_version_extra_args: ["list", "eslint-plugin-jsonc", "--prefix", "/node-deps"]

--- a/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json
@@ -652,6 +652,33 @@
             "title": "Linting mode",
             "type": "string"
           },
+          "cli_lint_warnings_count": {
+            "$id": "#/properties/linters/items/properties/cli_lint_warnings_count",
+            "description": "Defines how to count warnings from log file. regex_number, regex_count, regex_sum, or total_lines",
+            "enum": [
+              "regex_number",
+              "regex_count",
+              "regex_sum",
+              "total_lines"
+            ],
+            "examples": [
+              "regex_number",
+              "regex_count",
+              "regex_sum",
+              "total_lines"
+            ],
+            "title": "Lint errors count mode",
+            "type": "string"
+          },
+          "cli_lint_warnings_regex": {
+            "$id": "#/properties/linters/items/properties/cli_lint_warnings_regex",
+            "description": "Regex allowing to extract the number of warnings from linter output logs",
+            "examples": [
+              "Issues found: (.*) in .* files"
+            ],
+            "title": "Lint warnings number regex",
+            "type": "string"
+          },
           "cli_sarif_args": {
             "$id": "#/properties/linters/items/properties/cli_sarif_args",
             "default": [],

--- a/megalinter/descriptors/sql.megalinter-descriptor.yml
+++ b/megalinter/descriptors/sql.megalinter-descriptor.yml
@@ -60,6 +60,10 @@ linters:
     linter_rules_inline_disable_url: https://github.com/tsqllint/tsqllint#disabling-rules-with-inline-comments
     config_file_name: ".tsqllintrc"
     cli_lint_mode: list_of_files
+    cli_lint_errors_count: regex_number
+    cli_lint_errors_regex: "([0-9]+) Errors"
+    cli_lint_warnings_count: regex_number
+    cli_lint_warnings_regex: "([0-9]+) Warnings"
     cli_config_arg_name: "--config"
     cli_help_arg_name: "--help"
     cli_version_arg_name: "--version"

--- a/megalinter/descriptors/yaml.megalinter-descriptor.yml
+++ b/megalinter/descriptors/yaml.megalinter-descriptor.yml
@@ -70,6 +70,10 @@ linters:
     linter_megalinter_ref_url: "no"
     config_file_name: ".yamllint.yml"
     cli_lint_mode: list_of_files
+    cli_lint_errors_count: regex_count
+    cli_lint_errors_regex: "error"
+    cli_lint_warnings_count: regex_count
+    cli_lint_warnings_regex: "warning"
     examples:
       - "yamllint myfile.yaml"
       - "yamllint -c .yamllint.yml myfile.yaml"

--- a/megalinter/reporters/ConsoleReporter.py
+++ b/megalinter/reporters/ConsoleReporter.py
@@ -59,7 +59,7 @@ class ConsoleReporter(Reporter):
         logging.info(log_section_end("megalinter-file-listing"))
 
     def produce_report(self):
-        table_header = ["Descriptor", "Linter", "Mode", "Files", "Fixed", "Errors"]
+        table_header = ["Descriptor", "Linter", "Mode", "Files", "Fixed", "Errors", "Warnings"]
         if self.master.show_elapsed_time is True:
             table_header += ["Elapsed time"]
         table_data = [table_header]
@@ -76,6 +76,9 @@ class ConsoleReporter(Reporter):
                     else "❌"
                 )
                 errors = str(linter.total_number_errors)
+                warnings = str(linter.total_number_warnings)
+                if warnings == "0":
+                    warnings = ""
                 if linter.cli_lint_mode == "project":
                     found = "n/a"
                     nb_fixed_cell = "yes" if nb_fixed_cell != "" else nb_fixed_cell
@@ -89,6 +92,7 @@ class ConsoleReporter(Reporter):
                     found,
                     nb_fixed_cell,
                     errors,
+                    warnings
                 ]
                 if self.master.show_elapsed_time is True:
                     table_line += [str(round(linter.elapsed_time_s, 2)) + "s"]

--- a/megalinter/reporters/GithubStatusReporter.py
+++ b/megalinter/reporters/GithubStatusReporter.py
@@ -41,7 +41,7 @@ class GithubStatusReporter(Reporter):
             run_id = config.get("GITHUB_RUN_ID")
             success_msg = "No errors were found in the linting process"
             error_not_blocking = "Errors were detected but are considered not blocking"
-            error_msg = f"Found {self.master.total_number_errors}, please check logs"
+            error_msg = f"Found {self.master.total_number_errors} errors, please check logs"
             url = f"{github_api_url}/repos/{github_repo}/statuses/{sha}"
             headers = {
                 "accept": "application/vnd.github.v3+json",


### PR DESCRIPTION
Fixes #1541.

Changed code so that the console shows a new tab called "warnings" which shows a list of warnings. Added the regex to .yaml files for both errors and warnings as a way to display the warnings
Even when there are no errors, warnings will now show in the console and be displayed
Developers can also add their own regex to each descriptor to count warnings

TODO: Add the warnings to additional reporters
<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. New schema additions, regex of warnings and warning count
2. Warning displayed on the console and other reporters in the future
3. .yaml file regex as yaml linter can very easily be counted

## Readiness Checklist
Run megalinter and there should now be a warning tab. Only .yaml files at the current moment support the counting of warnings. Other files will need additional regex to be written.
### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
