### PR TITLE
Add results item to SARIF reporter if missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-linter.yml file, or with `oxsecurity/megalinter:beta` docker image
 
+- Fix SARIF when a run is missing a results list ([#1725](https://github.com/oxsecurity/megalinter/issues/1725))
+
 - Add REPOSITORY_CHECKOV in all flavors
 
 - Linter versions upgrades

--- a/megalinter/reporters/SarifReporter.py
+++ b/megalinter/reporters/SarifReporter.py
@@ -214,7 +214,10 @@ class SarifReporter(Reporter):
                                     )
                                 result["locations"][id_location] = location
                         run["results"][id_result] = result
-
+                else:
+                    # make sure that there is a results entry so GitHub's SARIF validator doesn't cry
+                    run["results"] = []
+                    
                 # Update run in full list
                 linter_sarif_obj["runs"][id_run] = run
         return linter_sarif_obj


### PR DESCRIPTION
GitHub's SARIF validator doesn't like it when there is no `results` list associated with a run; therefore, it a `results` key doesn't exist, create one with an empty list.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #1725 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

If a run doesn't have a `results` list, add an empty one so that GitHub's SARIF validator doesn't throw an error resulting from a missing `results` list.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request  (_non-applicable_)

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change (_non-applicable_)
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
