### PR TITLE
Add checkbox for updating the changelog in the PR template

### DIFF
--- a/.github/pull_request-template.md
+++ b/.github/pull_request-template.md
@@ -17,6 +17,7 @@ Fixes #
 ## Readiness Checklist
 
 ### Author/Contributor
+- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
 - [ ] If documentation is needed for this change, has that been included in this pull request
 
 ### Reviewing Maintainer


### PR DESCRIPTION
It didn't occur to me that I should update the changelog when I created PR #1726 resulting in an additional exchange with @nvuillam that could have been avoided.  In other words, I used more of his time than was necessary.  So, to help preserve his time for more interesting, meaningful, and impactful activities, I created this PR.  Et voila!

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

It's just a new checkbox in a markdown template

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
