### PR TITLE
List of files as positional arguments for mega-linter-runner

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -580,6 +580,7 @@
         "filemode",
         "fileoverview",
         "fileset",
+        "filesonly",
         "fixrules",
         "fkirc",
         "fkotlin",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - New config variables:
   - **MEGALINTER_FILES_TO_LINT**: Comma-separated list of files to analyze. Using this variable will bypass other file listing methods ([#808](https://github.com/oxsecurity/megalinter/issues/808))
   - **SKIP_CLI_LINT_MODES**: Comma-separated list of cli_lint_modes. To use if you want to skip linters with some CLI lint modes (ex: `file,project`). Available values: `file`,`cli_lint_mode`,`project`.
+- mega-linter-runner:
+  - Allow `MEGALINTER_FILES_TO_LINT` to be sent as positional arguments
+  - New argument `--filesonly` that sends `SKIP_CLI_LINT_MODES=project`
+  - Example: `mega-linter-runner --flavor python --release beta --filesonly megalinter/config.py megalinter/flavor_factory.py megalinter/MegaLinter.py`
 
 - Linter versions upgrades
   - [checkov](https://www.checkov.io/) from 2.1.98 to **2.1.100** on 2022-08-07

--- a/mega-linter-runner/README.md
+++ b/mega-linter-runner/README.md
@@ -85,7 +85,7 @@ See [`.pre-commit-hooks.yaml`](../.pre-commit-hooks.yaml) for more details.
 ## Usage
 
 ```shell
-mega-linter-runner [OPTIONS]
+mega-linter-runner [OPTIONS] [FILES]
 ```
 
 The options are only related to mega-linter-runner. For MegaLinter options, please use a `.mega-linter.yml` [configuration file](#configuration)
@@ -118,6 +118,10 @@ mega-linter-runner -p myFolder --fix
 
 ```shell
 mega-linter-runner -r beta -e 'ENABLE=MARKDOWN,YAML' -e 'SHOW_ELAPSED_TIME=true'
+```
+
+```shell
+mega-linter-runner --flavor python --release beta --filesonly path/to/my/file1.py another/path/to/a/file.js and/another/file.py
 ```
 
 ## Configuration

--- a/mega-linter-runner/lib/options.js
+++ b/mega-linter-runner/lib/options.js
@@ -75,6 +75,11 @@ module.exports = optionator({
       description: "Apply formatters and fixes in linted sources",
     },
     {
+      option: "filesonly",
+      type: "Boolean",
+      description: "Do not run linters with project as CLI lint mode",
+    },
+    {
       option: "json",
       alias: "j",
       type: "Boolean",

--- a/mega-linter-runner/lib/runner.js
+++ b/mega-linter-runner/lib/runner.js
@@ -145,11 +145,14 @@ ERROR: Docker engine has not been found on your system.
     }
     // Files only
     if (options.filesonly === true) {
-      commandArgs.push(...["-e", "SKIP_CLI_LINT_MODES=project"]);      
+      commandArgs.push(...["-e", "SKIP_CLI_LINT_MODES=project"]);
     }
     // list of files
     if ((options._ || []).length > 0) {
-      commandArgs.push(...["-e"],`MEGALINTER_FILES_TO_LINT="${options._.join(",")}"`);
+      commandArgs.push(
+        ...["-e"],
+        `MEGALINTER_FILES_TO_LINT="${options._.join(",")}"`
+      );
     }
     commandArgs.push(dockerImage);
 

--- a/mega-linter-runner/lib/runner.js
+++ b/mega-linter-runner/lib/runner.js
@@ -143,6 +143,14 @@ ERROR: Docker engine has not been found on your system.
         commandArgs.push(...["-e", envVarEqualsValue]);
       }
     }
+    // Files only
+    if (options.filesonly === true) {
+      commandArgs.push(...["-e", "SKIP_CLI_LINT_MODES=project"]);      
+    }
+    // list of files
+    if ((options._ || []).length > 0) {
+      commandArgs.push(...["-e"],`MEGALINTER_FILES_TO_LINT="${options._.join(",")}"`);
+    }
     commandArgs.push(dockerImage);
 
     // Call docker run


### PR DESCRIPTION
- mega-linter-runner:
  - Allow `MEGALINTER_FILES_TO_LINT` to be sent as positional arguments
  - New argument `--filesonly` that sends `SKIP_CLI_LINT_MODES=project`
  - Example: `mega-linter-runner --flavor python --release beta --filesonly megalinter/config.py megalinter/flavor_factory.py megalinter/MegaLinter.py`

Fixes https://github.com/oxsecurity/megalinter/issues/808