### PR TITLE
Update pre-commit hooks from v5 to v6.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,66 +1,55 @@
-- id: megalinter
-  name: Run MegaLinter on files modified relative to DEFAULT_BRANCH
+- id: megalinter-incremental
+  name: Run MegaLinter (skipping linters that run in project mode)
   entry: npx --
   language: system
-  pass_filenames: false
   args:
     - mega-linter-runner
+    - --containername "megalinter-$(basename "$PWD")"
+    - --remove-container
     - --fix
     - --env
     - "'APPLY_FIXES=all'"
     - --env
-    - "'FAIL_IF_UPDATED_SOURCES=true'"
+    - "'CLEAR_REPORT_FOLDER=true'"
     - --env
     - "'LOG_LEVEL=warning'"
-    - --env
-    - "'VALIDATE_ALL_CODEBASE=false'"
-    - --env
-    - "'DISABLE_LINTERS=COPYPASTE_JSCPD'"
-  stages:
-    - commit
+    - --filesonly
   description: >
-    See https://oxsecurity.github.io/megalinter/latest/mega-linter-runner/#usage and
-    https://oxsecurity.github.io/megalinter/latest/configuration/ if you wish to override
-    the default arguments. mega-linter-runner is specified as an argument so
-    that you may override the version (e.g., mega-linter-runner@vx.y.z). Depends
-    on npx, which ships with npm 7+, and Docker. Unlike most pre-commit hooks,
-    MegaLinter itself computes the files to run on. Runs very slowly when the
-    pertinent Docker image isn't already cached (c.f.,
-    https://github.com/marketplace/actions/docker-cache/). If you encounter
-    permission errors, try running Docker in rootless mode (c.f.,
+    See https://oxsecurity.github.io/megalinter/latest/mega-linter-runner/#usage
+    and https://oxsecurity.github.io/megalinter/latest/configuration/ if you
+    wish to override the default arguments. mega-linter-runner is specified as
+    an argument so that you may override the version (e.g.,
+    mega-linter-runner@vx.y.z). Depends on npx, which ships with npm 7+, and
+    Docker. Runs very slowly when the pertinent Docker image isn't already
+    cached (c.f., https://github.com/marketplace/actions/docker-cache/). If you
+    encounter permission errors, try running Docker in rootless mode (c.f.,
     https://github.com/marketplace/actions/rootless-docker/). Linter results are
-    logged to the report directory, so you should make sure to list it in your
-    .gitignore and wipe it between runs. Skip jscpd since duplicate detection
-    fundamentally requires scanning the entire repository and hence can't be
-    performed incrementally.
+    logged to the megalinter-reports directory, so list it in your .gitignore.
+    Skip linters that run in project mode since they don't run incrementally.
 
-- id: megalinter-all
-  name: Run MegaLinter on all files
+- id: megalinter-full
+  name: Run MegaLinter
   entry: npx --
   language: system
-  pass_filenames: false
   args:
     - mega-linter-runner
+    - --containername "megalinter-all-$(basename "$PWD")"
+    - --remove-container
     - --fix
     - --env
     - "'APPLY_FIXES=all'"
     - --env
-    - "'FAIL_IF_UPDATED_SOURCES=true'"
+    - "'CLEAR_REPORT_FOLDER=true'"
     - --env
     - "'LOG_LEVEL=warning'"
-    - --env
-    - "'VALIDATE_ALL_CODEBASE=true'"
-  stages:
-    - push
   description: >
-    See https://oxsecurity.github.io/megalinter/latest/mega-linter-runner/#usage and
-    https://oxsecurity.github.io/megalinter/latest/configuration/ if you wish to override
-    the default arguments. mega-linter-runner is specified as an argument so
-    that you may override the version (e.g., mega-linter-runner@vx.y.z). Depends
-    on npx, which ships with npm 7+, and Docker. Runs very slowly when the
-    pertinent Docker image isn't already cached (c.f.,
-    https://github.com/marketplace/actions/docker-cache/). If you encounter
-    permission errors, try running Docker in rootless mode (c.f.,
+    See https://oxsecurity.github.io/megalinter/latest/mega-linter-runner/#usage
+    and https://oxsecurity.github.io/megalinter/latest/configuration/ if you
+    wish to override the default arguments. mega-linter-runner is specified as
+    an argument so that you may override the version (e.g.,
+    mega-linter-runner@vx.y.z). Depends on npx, which ships with npm 7+, and
+    Docker. Runs very slowly when the pertinent Docker image isn't already
+    cached (c.f., https://github.com/marketplace/actions/docker-cache/). If you
+    encounter permission errors, try running Docker in rootless mode (c.f.,
     https://github.com/marketplace/actions/rootless-docker/). Linter results are
-    logged to the report directory, so you should make sure to list it in your
-    .gitignore and wipe it between runs.
+    logged to the megalinter-reports directory, so list it in your .gitignore.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-linter.yml file, or with `oxsecurity/megalinter:beta` docker image
 
+- Update pre-commit hooks from v5 to v6 (#1755).
 - Linter versions upgrades
   - [eslint-plugin-jsonc](https://ota-meshi.github.io/eslint-plugin-jsonc/) from 2.3.1 to **2.4.0** on 2022-08-16
   - [checkov](https://www.checkov.io/) from 2.1.127 to **2.1.129** on 2022-08-16

--- a/docs/mega-linter-runner.md
+++ b/docs/mega-linter-runner.md
@@ -56,10 +56,14 @@ Sample `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/oxsecurity/megalinter
-    rev: v5.12.0 # Git tag specifying the hook, not mega-linter-runner, version
+    rev: v6.6.0 # Git tag specifying the hook, not mega-linter-runner, version
     hooks:
-      - id: megalinter # Faster, less thorough, runs pre-commit by default
-      - id: megalinter-all # Slower, more thorough, runs pre-push by default
+      - id: megalinter-incremental # Faster, less thorough
+        stages:
+          - commit
+      - id: megalinter-full # Slower, more thorough
+        stages:
+          - push
 ```
 
 See [`.pre-commit-hooks.yaml`](../.pre-commit-hooks.yaml) for more details.


### PR DESCRIPTION
Fixes #1755.

## Proposed Changes

Replace the v5 `megalinter` hook with a v6 `megalinter-incremental` hook that only runs on the modified files, skipping all linters that run in project mode. Replace the v5 `megalinter-all` hook with a v6 `megalinter-full` hook that runs only on the modified files when supported, but also runs linters that run in project mode. This brings MegaLinter's pre-commit hooks more in line with typical hooks, which run on the files passed by pre-commit rather than running git diff themselves.

Leverage new v6 features to automatically clean up the Docker container and `megalinter-reports` directory, and give a meaningful name to the Docker container rather than one randomly generated by Docker. Update documentation to reflect that the report directory was renamed `megalinter-reports` in v6.

Remove `FAIL_IF_UPDATED_SOURCES=true` since pre-commit hooks already fail when the hook modifies files, and this setting causes MegaLinter to fail whenever there are unstaged changes. Stop limiting the hooks to specific stages. The ability to run MegaLinter on specific files while still running all project linters is a significant performance improvement over running all linters on all files, so some users may wish to run the new `megalinter-full` hook pre-commit, not just pre-push. Conversely, some users may find the performance of `megalinter-full` prohibitive to run locally and prefer to only run `megalinter-incremental` pre-push.

## Readiness Checklist

### Author/Contributor
- [ x Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
