### PR TITLE
Fix: Match `files_sub_directory` as a prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Add Makefile linter within python flavor ([#1760](https://github.com/oxsecurity/megalinter/issues/1760))
 - Set DEFAULT_WORKSPACE as git safe directory per default [#1766](https://github.com/oxsecurity/megalinter/issues/1766)
 - Improve documentation for TAP_REPORTER
+- Fix: Properly match `files_sub_directory` as a prefix instead of partial string matching
 
 - Linter versions upgrades
   - [actionlint](https://rhysd.github.io/actionlint/) from 1.6.15 to **1.6.16**

--- a/megalinter/Linter.py
+++ b/megalinter/Linter.py
@@ -781,6 +781,7 @@ class Linter:
             file_contains_regex=self.file_contains_regex,
             files_sub_directory=self.files_sub_directory,
             lint_all_other_linters_files=self.lint_all_other_linters_files,
+            prefix=self.workspace,
         )
         self.files_number = len(self.files)
         logging.debug(

--- a/megalinter/utils.py
+++ b/megalinter/utils.py
@@ -72,6 +72,7 @@ def filter_files(
     file_contains_regex: Optional[Sequence[str]] = None,
     files_sub_directory: Optional[str] = None,
     lint_all_other_linters_files: bool = False,
+    prefix: Optional[str] = None,
 ) -> Sequence[str]:
     file_extensions = set(file_extensions)
     filter_regex_include_object = (
@@ -114,7 +115,7 @@ def filter_files(
         if filter_regex_exclude_object and filter_regex_exclude_object.search(file):
             continue
         # Skip if file is not in defined files_sub_directory
-        if files_sub_directory and files_sub_directory not in file:
+        if files_sub_directory and not os.path.normpath(file).startswith(os.path.normpath(os.path.join(prefix or "", files_sub_directory) + os.path.sep)):
             continue
 
         # Skip according to file extension (only if lint_all_other_linter_files is false)


### PR DESCRIPTION
## Proposed Changes

Properly match `files_sub_directory` as a prefix instead of partial string matching.

Before

- If directory named "files_sub_directory" exists then all files
  matching "files_sub_directory" are selected. For example if
  files_sub_directory is set to "dir" and dir exists under the workspace
  directory then "mode/direct/file.yml" and "new_directory/f.yml" will
  be selected

After

- If directory named "files_sub_directory" exists then all files
  which names start with "files_sub_directory" are selected. For example if
  files_sub_directory is set to "dir" (or "./dir" or "dir/" or "./dir/")
  and dir exists under the workspace directory then "dir/file.yml" will be
  selected but not "new_directory/f.yml" and not "some/dir/f.yml"

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->


<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
