### PR TITLE
Add DEFAULT_WORKSPACE path to git safe.directory by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-linter.yml file, or with `oxsecurity/megalinter:beta` docker image
 
+- Set DEFAULT_WORKSPACE as git safe directory per default [#1766](https://github.com/oxsecurity/megalinter/issues/1766)
 - Update pre-commit hooks from v5 to v6 ([#1755](https://github.com/oxsecurity/megalinter/issues/1755)).
 - Fix version in URL in logs produced by reporters
 - Improve documentation for TAP_REPORTER

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,14 @@ if [[ ${LOG_LEVEL} == "DEBUG" ]]; then
 fi
 
 # Manage newest git versions (related to CVE https://github.blog/2022-04-12-git-security-vulnerability-announced/)
+#
+if [[ "${WORKSPACE_AS_SAFE_DIR}" != 'false' && "${DEFAULT_WORKSPACE}" && -d "${DEFAULT_WORKSPACE}" ]] ; then
+  echo "Setting git safe.directory DEFAULT_WORKSPACE: ${DEFAULT_WORKSPACE} ..."
+  git config --global --add safe.directory "${DEFAULT_WORKSPACE}"
+else
+  echo "Skipped setting git safe.directory DEFAULT_WORKSPACE: ${DEFAULT_WORKSPACE} ..."
+fi
+
 if [ -z ${GITHUB_WORKSPACE+x} ]; then
   echo "Setting git safe.directory default: /github/workspace ..."
   git config --global --add safe.directory /github/workspace
@@ -17,6 +25,7 @@ else
   echo "Setting git safe.directory GITHUB_WORKSPACE: $GITHUB_WORKSPACE ..."
   git config --global --add safe.directory "$GITHUB_WORKSPACE"
 fi
+
 echo "Setting git safe.directory to /tmp/lint ..."
 git config --global --add safe.directory /tmp/lint
 


### PR DESCRIPTION
Fixes #1766 

Adds git safe.directory DEFAULT_WORKSPACE by default in entrypoint.sh.

## Proposed Changes

See discussion and motivation in [#1766 ](https://github.com/oxsecurity/megalinter/issues/1766).

Note: I made the option default, but left an small undocumented env variable to let anyone really wishing the old way configure it by setting WORKSPACE_AS_SAFE_DIR to "false". If you don't get any questions about this default behaviour over time, I would suggest to remove that flag. On the other hand,  If you do get questions for anyone wishing this, let's document WORKSPACE_AS_SAFE_DIR properly and add it to the documentation.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`

Signed-off-by: Josef Andersson <josef.andersson@gmail.com>