### PR TITLE
Add cli_lint_errors_count to java descriptor

### DIFF
--- a/megalinter/descriptors/java.megalinter-descriptor.yml
+++ b/megalinter/descriptors/java.megalinter-descriptor.yml
@@ -32,6 +32,7 @@ linters:
       - sarif
       - -o
       - "{{SARIF_OUTPUT_FILE}}"
+    cli_lint_errors_count: "regex_number"
     cli_lint_errors_regex: "Checkstyle ends with ([0-9]+) errors"
     cli_version_extra_args:
       - "-jar"


### PR DESCRIPTION
In order to parse the amount of errors Checkstyle finds, we need to tell the parser which type of message the linter responds with.
In case of checkstyle, it has a message like Checkstyle ends with ([0-9]+) errors which corresponds to `regex_number`. Otherwise megalinter will respond always with 1.
<!-- markdownlint-disable -->

Fixes #
Tries to fix an issue when the count of errors reported by checkstyle are not properly parsed.

## Proposed Changes

1. adds cli_lint_errors_count

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
