### PR TITLE
Fix broken link to documentation when using v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Use `list_of_files` Cli lint mode for checkstyle, to have unique SARIF output and improve performances
 - Reactivate snakefmt
 - Add SARIF output for ansible-lint
+- Fix broken link to documentation when using v6
 
 - Linter versions upgrades
   - [checkov](https://www.checkov.io/) from 2.1.183 to **2.1.184** on 2022-09-05

--- a/megalinter/constants.py
+++ b/megalinter/constants.py
@@ -5,7 +5,8 @@ ML_REPO_NAME = "megalinter"
 ML_REPO = f"{ML_REPO_OWNER}/{ML_REPO_NAME}"
 ML_REPO_URL = f"https://github.com/{ML_REPO_OWNER}/{ML_REPO_NAME}"
 ML_DOC_URL_BASE = "https://oxsecurity.github.io/megalinter/"
-ML_DOC_URL = ML_DOC_URL_BASE + config.get("BUILD_VERSION", "latest").replace("v", "")
+ML_VERSION = config.get("BUILD_VERSION", "latest").replace("v", "")
+ML_DOC_URL = ML_DOC_URL_BASE + (ML_VERSION if len(ML_VERSION) > 1 else "latest")
 ML_REPO_ISSUES_URL = f"https://github.com/{ML_REPO_OWNER}/{ML_REPO_NAME}/issues"
 ML_DOC_URL_DESCRIPTORS_ROOT = f"{ML_DOC_URL}/descriptors"
 


### PR DESCRIPTION
Fixes https://github.com/oxsecurity/megalinter/issues/1819