### PR TITLE
fix: correct cli arguments for terrascan

### DIFF
--- a/megalinter/linters/TerrascanLinter.py
+++ b/megalinter/linters/TerrascanLinter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-Use TfLint to lint terraform files
-https://github.com/terraform-linters/tflint
+Use Terrascan to lint terraform files
+https://github.com/tenable/terrascan
 """
 import logging
 
@@ -15,7 +15,7 @@ class TerrascanLinter(megalinter.Linter):
         # Build pre-command
         terrascan_init_command = "terrascan"
         if self.config_file is not None:
-            terrascan_init_command += f" --config {self.config_file}"
+            terrascan_init_command += f" --config-path {self.config_file}"
         logging.debug("terrascan before_lint_files: " + terrascan_init_command)
         # Add to pre-commands
         terrascan_pre_command = {


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

terrascan uses `--config-path` _(currently set to use `--config`)_

![image](https://user-images.githubusercontent.com/183195/189552731-b1d4f6be-56ba-48d1-b7aa-2c7044f138db.png)

