### PR TITLE
Fix a typo in documentation of bash-exec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-linter.yml file, or with `oxsecurity/megalinter:beta` docker image
 
+- Fix a typo in documentation of bash-exec linter ([#1892](https://github.com/oxsecurity/megalinter/pull/1892))
 - Add quotes to arm-ttk linter command ([#1879](https://github.com/oxsecurity/megalinter/issues/1879))
 
 - Linter versions upgrades

--- a/megalinter/descriptors/bash.megalinter-descriptor.yml
+++ b/megalinter/descriptors/bash.megalinter-descriptor.yml
@@ -38,7 +38,7 @@ linters:
               && chmod +x /usr/bin/bash-exec
     variables:
       - name: ERROR_ON_MISSING_EXEC_BIT
-        description: If set to `false`, the `bash-exec` linter will report a warning if a shell script is not executable. If set to `true`, the `bash-exec` linter will report an arror instead
+        description: If set to `false`, the `bash-exec` linter will report a warning if a shell script is not executable. If set to `true`, the `bash-exec` linter will report an error instead
         default_value: "false"
   # Shellcheck
   - class: ShellcheckLinter

--- a/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json
@@ -1218,7 +1218,7 @@
             "examples": [
               {
                 "default_value": "false",
-                "description": "If set to `false`, the `bash-exec` linter will report a warning if a shell script is not executable. If set to `true`, the `bash-exec` linter will report an arror instead",
+                "description": "If set to `false`, the `bash-exec` linter will report a warning if a shell script is not executable. If set to `true`, the `bash-exec` linter will report an error instead",
                 "name": "ERROR_ON_MISSING_EXEC_BIT"
               }
             ],


### PR DESCRIPTION
Follow-up for #1886.

## Proposed Changes

1. The corresponding documentation in the auto-generated docs/descriptors/bash_bash_exec.md was updated by mistake in 3d5e615775dbb7c3ab7b3500385808e43a8de8d0, so it was immediately overwritten. Update the source files
megalinter/descriptors/bash.megalinter-descriptor.yml and megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json instead this time.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
