### PR TITLE
Document `-f` Argument to mega-linter-runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-linter.yml file, or with `oxsecurity/megalinter:beta` docker image
 
+- Document the `-f` argument to mega-linter-runner ([#1895](https://github.com/oxsecurity/megalinter/issues/1895))
 - Fix a typo in documentation of bash-exec linter ([#1892](https://github.com/oxsecurity/megalinter/pull/1892))
 - Add quotes to arm-ttk linter command ([#1879](https://github.com/oxsecurity/megalinter/issues/1879))
 

--- a/mega-linter-runner/README.md
+++ b/mega-linter-runner/README.md
@@ -97,7 +97,7 @@ The options are only related to mega-linter-runner. For MegaLinter options, plea
 | Option                 | Description                                                                                                        | Default           |
 |------------------------|--------------------------------------------------------------------------------------------------------------------|-------------------|
 | `-p` <br/> `--path`    | Directory containing the files to lint                                                                             | current directory |
-| `--flavor`             | Set this parameter to use a [MegaLinter flavor](https://megalinter.github.io/flavors/)                             | `all`             |
+| `-f` <br/> `--flavor`  | Set this parameter to use a [MegaLinter flavor](https://megalinter.github.io/flavors/)                             | `all`             |
 | `-d` <br/> `--image`   | You can override the used docker image, including if it is on another docker registry                              | <!-- -->          |
 | `-e` <br/> `--env`     | Environment variables for MegaLinter, following format **'ENV_VAR_NAME=VALUE'** <br/>Warning: Quotes are mandatory | <!-- -->          |
 | `--fix`                | Automatically apply formatting and fixes in your files                                                             | <!-- -->          |

--- a/megalinter/MegaLinter.py
+++ b/megalinter/MegaLinter.py
@@ -563,7 +563,8 @@ class Megalinter:
         logging.debug(
             "All found files before filtering:" + utils.format_bullet_list(all_files)
         )
-        # Filter files according to fileExtensions, fileNames , filterRegexInclude and filterRegexExclude
+        # Filter files according to file_extensions, file_names_regex,
+        # filter_regex_include, and filter_regex_exclude
         if len(self.file_extensions) > 0:
             logging.info(
                 "- File extensions: " + ", ".join(sorted(self.file_extensions))

--- a/megalinter/MegaLinter.py
+++ b/megalinter/MegaLinter.py
@@ -565,11 +565,11 @@ class Megalinter:
         )
         # Filter files according to file_extensions, file_names_regex,
         # filter_regex_include, and filter_regex_exclude
-        if len(self.file_extensions) > 0:
+        if self.file_extensions:
             logging.info(
                 "- File extensions: " + ", ".join(sorted(self.file_extensions))
             )
-        if len(self.file_names_regex) > 0:
+        if self.file_names_regex:
             logging.info(
                 "- File names (regex): " + ", ".join(sorted(self.file_names_regex))
             )

--- a/megalinter/utils.py
+++ b/megalinter/utils.py
@@ -74,7 +74,7 @@ def filter_files(
     lint_all_other_linters_files: bool = False,
     prefix: Optional[str] = None,
 ) -> Sequence[str]:
-    file_extensions = set(file_extensions)
+    file_extensions = frozenset(file_extensions)
     filter_regex_include_object = (
         re.compile(filter_regex_include) if filter_regex_include else None
     )
@@ -92,7 +92,7 @@ def filter_files(
     # if each file is check against every ignored_files (it can contain all the files), it's a O(n²) filtering
     # to reduce the execution time and complexity ignored_files is split
     ignored_patterns = list(filter(lambda x: "*" in x, ignored_files or []))
-    ignored_fileset = set(ignored_files or [])
+    ignored_fileset = frozenset(ignored_files or [])
 
     # Filter all files to keep only the ones matching with the current linter
 


### PR DESCRIPTION
Fixes #1895.

## Proposed Changes

1. Document that `-f` argument to mega-linter-runner is the short form of `--flavor`.
2. Prefer `frozenset` to `set` in `megalinter/utils.py` when no mutations made.
3. Simplify some tests for empty collections in `megalinter/MegaLinter.py`.
4. Make minor corrections to a comment in `megalinter/MegaLinter.py`.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
