### PR TITLE
Set Devcontainer Python version to 3.10

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 		"dockerfile": "Dockerfile",
 		"context": "..",
 		"args": { 
-			"VARIANT": "3.9",
+			"VARIANT": "3.10",
 			"NODE_VERSION": "16"
 		}
 	},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Fix a typo in documentation of bash-exec linter ([#1892](https://github.com/oxsecurity/megalinter/pull/1892))
 - Add quotes to arm-ttk linter command ([#1879](https://github.com/oxsecurity/megalinter/issues/1879))
 - Improve support for devcontainers by using Python base image
+  - Fixed Python version in devcontainer from 3.9 -> 3.10
 
 - Linter versions upgrades
   - [cfn-lint](https://github.com/aws-cloudformation/cfn-lint) from 0.65.0 to **0.65.1** on 2022-09-20


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->
In the previous PR #1897 , the `.devcontainer.json` file was passing in Python 3.9 instead of 3.10, which is the version Megalinter is built on. This PR fixes the version error.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Update version in `.devcontainer.json` to 3.10

## Readiness Checklist

### Author/Contributor
- [X] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [X] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
