### PR TITLE
Correct casing of `removeContainer` in mega-linter-runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-linter.yml file, or with `oxsecurity/megalinter:beta` docker image
 
+- Correct removeContainer casing in runner ([#1917](https://github.com/oxsecurity/megalinter/issues/1917))
 - Linter versions upgrades
 <!-- linter-versions-end -->
 

--- a/mega-linter-runner/lib/runner.js
+++ b/mega-linter-runner/lib/runner.js
@@ -121,7 +121,7 @@ ERROR: Docker engine has not been found on your system.
     // Build docker run options
     const lintPath = path.resolve(options.path || ".");
     const commandArgs = ["run"];
-    if (options["remove-container"]) {
+    if (options["removeContainer"]) {
       commandArgs.push("--rm");
     }
     if (options.containername) {


### PR DESCRIPTION
Fixes #1917

optionator has the undocumented behavior of converting the casing of command line arguments (e.g., it converts `--remove-container` to `removeContainer`).

## Proposed Changes

1. Apply @dmitri-trofimov's suggestion from https://github.com/oxsecurity/megalinter/pull/1571#discussion_r979281210.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
