### PR TITLE
Fix Docker container names in pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,7 +5,7 @@
   require_serial: true
   args:
     - mega-linter-runner
-    - --container-name "megalinter-$(basename "$PWD")"
+    - --containername megalinter-incremental
     - --remove-container
     - --fix
     - --env
@@ -35,7 +35,7 @@
   require_serial: true
   args:
     - mega-linter-runner
-    - --container-name "megalinter-all-$(basename "$PWD")"
+    - --containername megalinter-full
     - --remove-container
     - --fix
     - --env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-linter.yml file, or with `oxsecurity/megalinter:beta` docker image
 
+- Fix invalid Docker container names in .pre-commit-hooks.yaml ([#1932](https://github.com/oxsecurity/megalinter/issues/1932))
 - Correct removeContainer casing in runner ([#1917](https://github.com/oxsecurity/megalinter/issues/1917))
 - Use -p argument for pyright custom config file path ([#1946](https://github.com/oxsecurity/megalinter/issues/1946))
 - Fix use of TERRAFORM_KICS_ARGUMENTS ([#1947](https://github.com/oxsecurity/megalinter/issues/1947))


### PR DESCRIPTION
Fixes oxsecurity/megalinter#1932
The previous Docker container names contained Bash syntax, but pre-commit interprets them as string literals, resulting in invalid Docker container names. Remove Bash syntax, and replace it with string literals.


