### PR TITLE
Add a more intuitive ´nostale´ label to stale bot exemptions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,12 +30,13 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity.\nIt will be closed in 14 days if no further activity occurs.\nThank you for your contributions.\n\nIf you think this issue should stay open, please remove the `O: stale 🤖` label or comment on the issue."
           stale-pr-message: "This pull request has been automatically marked as stale because it has not had recent activity.\nIt will be closed in 14 days if no further activity occurs.\nThank you for your contributions.\n\nIf you think this pull request should stay open, please remove the `O: stale 🤖` label or comment on the pull request."
+          close-issue-reason: not_planned
           days-before-stale: 30
           days-before-close: 14
           stale-issue-label: "O: stale 🤖"
-          exempt-issue-labels: "O: backlog 🤖"
+          exempt-issue-labels: "O: backlog 🤖,nostale"
           stale-pr-label: "O: stale 🤖"
-          exempt-pr-labels: "O: backlog 🤖"
+          exempt-pr-labels: "O: backlog 🤖,nostale"
           labels-to-remove-when-unstale: "O: stale 🤖"
           remove-issue-stale-when-updated: true
           remove-pr-stale-when-updated: true


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->


<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

The current stale bot has a uncommon label (and with an emoji) to prevent an issue of being stale. Furthermore, it isn’t found in the project’s labels, so it can’t be added with the mobile app to an existing issue or PR.

This PR also touches the close-issue-reason as it is part of the new configuration since v6 with the default reason as not_planned (I know, it touches another thing). Its to keep trace of the options used.

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
