### PR TITLE
Run Docker container as current user

### DIFF
--- a/.automation/build.py
+++ b/.automation/build.py
@@ -251,8 +251,9 @@ branding:
             file.write(action_yml)
             logging.info(f"Updated {flavor_action_yml}")
     extra_lines = [
-        "COPY entrypoint.sh /entrypoint.sh",
+        "COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh",
         "RUN chmod +x entrypoint.sh",
+        "USER 1000",
         'ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]',
     ]
     build_dockerfile(

--- a/.github/workflows/test-mega-linter-runner.yml
+++ b/.github/workflows/test-mega-linter-runner.yml
@@ -40,5 +40,11 @@ jobs:
           node-version: "12"
       - name: Install dependencies
         run: cd mega-linter-runner && yarn install --frozen-lockfile && npm link
-      - name: Run tests
-        run: cd mega-linter-runner && npm run test
+      - name: Run CLI tests
+        run: cd mega-linter-runner && npm run test:cli
+      - name: Run module tests
+        if: always()
+        run: cd mega-linter-runner && npm run test:module
+      - name: Run upgrade tests
+        if: always()
+        run: cd mega-linter-runner && npm run test:upgrade

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Upgrade create-pull-request and create-or-update-comment GitHub Actions
   - Increase auto-update-linters GitHub Action timeout
   - Upgrade base Docker image to python:3.11.3-alpine3.17
+  - Make Docker image rootless, and run it as user 1000 rather than root by
+    @Kurt-von-Laven in [#1975](https://github.com/oxsecurity/megalinter/issues/1975).
 
 - Documentation
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -668,7 +668,7 @@ ENV KICS_QUERIES_PATH=/opt/kics/assets/queries KICS_LIBRARIES_PATH=/opt/kics/ass
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -677,8 +677,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #
@@ -717,7 +717,8 @@ LABEL com.github.actions.name="MegaLinter" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #EXTRA_DOCKERFILE_LINES__START
-COPY entrypoint.sh /entrypoint.sh
+COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
+USER 1000
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 #EXTRA_DOCKERFILE_LINES__END

--- a/flavors/ci_light/Dockerfile
+++ b/flavors/ci_light/Dockerfile
@@ -209,7 +209,7 @@ RUN wget -q -O - https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/m
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -218,8 +218,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #
@@ -258,7 +258,8 @@ LABEL com.github.actions.name="MegaLinter" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #EXTRA_DOCKERFILE_LINES__START
-COPY entrypoint.sh /entrypoint.sh
+COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
+USER 1000
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 #EXTRA_DOCKERFILE_LINES__END

--- a/flavors/cupcake/Dockerfile
+++ b/flavors/cupcake/Dockerfile
@@ -450,7 +450,7 @@ ENV KICS_QUERIES_PATH=/opt/kics/assets/queries KICS_LIBRARIES_PATH=/opt/kics/ass
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -459,8 +459,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #
@@ -499,7 +499,8 @@ LABEL com.github.actions.name="MegaLinter" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #EXTRA_DOCKERFILE_LINES__START
-COPY entrypoint.sh /entrypoint.sh
+COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
+USER 1000
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 #EXTRA_DOCKERFILE_LINES__END

--- a/flavors/documentation/Dockerfile
+++ b/flavors/documentation/Dockerfile
@@ -296,7 +296,7 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -305,8 +305,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #
@@ -345,7 +345,8 @@ LABEL com.github.actions.name="MegaLinter" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #EXTRA_DOCKERFILE_LINES__START
-COPY entrypoint.sh /entrypoint.sh
+COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
+USER 1000
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 #EXTRA_DOCKERFILE_LINES__END

--- a/flavors/dotnet/Dockerfile
+++ b/flavors/dotnet/Dockerfile
@@ -391,7 +391,7 @@ RUN curl --retry 5 --retry-delay 5 -sLO "${ARM_TTK_URI}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -400,8 +400,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #
@@ -440,7 +440,8 @@ LABEL com.github.actions.name="MegaLinter" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #EXTRA_DOCKERFILE_LINES__START
-COPY entrypoint.sh /entrypoint.sh
+COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
+USER 1000
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 #EXTRA_DOCKERFILE_LINES__END

--- a/flavors/go/Dockerfile
+++ b/flavors/go/Dockerfile
@@ -311,7 +311,7 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -320,8 +320,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #
@@ -360,7 +360,8 @@ LABEL com.github.actions.name="MegaLinter" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #EXTRA_DOCKERFILE_LINES__START
-COPY entrypoint.sh /entrypoint.sh
+COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
+USER 1000
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 #EXTRA_DOCKERFILE_LINES__END

--- a/flavors/java/Dockerfile
+++ b/flavors/java/Dockerfile
@@ -324,7 +324,7 @@ RUN wget --quiet https://github.com/pmd/pmd/releases/download/pmd_releases%2F${P
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -333,8 +333,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #
@@ -373,7 +373,8 @@ LABEL com.github.actions.name="MegaLinter" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #EXTRA_DOCKERFILE_LINES__START
-COPY entrypoint.sh /entrypoint.sh
+COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
+USER 1000
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 #EXTRA_DOCKERFILE_LINES__END

--- a/flavors/javascript/Dockerfile
+++ b/flavors/javascript/Dockerfile
@@ -312,7 +312,7 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -321,8 +321,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #
@@ -361,7 +361,8 @@ LABEL com.github.actions.name="MegaLinter" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #EXTRA_DOCKERFILE_LINES__START
-COPY entrypoint.sh /entrypoint.sh
+COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
+USER 1000
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 #EXTRA_DOCKERFILE_LINES__END

--- a/flavors/php/Dockerfile
+++ b/flavors/php/Dockerfile
@@ -340,7 +340,7 @@ RUN composer global require --ignore-platform-reqs overtrue/phplint ^5.3 \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -349,8 +349,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #
@@ -389,7 +389,8 @@ LABEL com.github.actions.name="MegaLinter" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #EXTRA_DOCKERFILE_LINES__START
-COPY entrypoint.sh /entrypoint.sh
+COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
+USER 1000
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 #EXTRA_DOCKERFILE_LINES__END

--- a/flavors/python/Dockerfile
+++ b/flavors/python/Dockerfile
@@ -307,7 +307,7 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -316,8 +316,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #
@@ -356,7 +356,8 @@ LABEL com.github.actions.name="MegaLinter" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #EXTRA_DOCKERFILE_LINES__START
-COPY entrypoint.sh /entrypoint.sh
+COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
+USER 1000
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 #EXTRA_DOCKERFILE_LINES__END

--- a/flavors/ruby/Dockerfile
+++ b/flavors/ruby/Dockerfile
@@ -297,7 +297,7 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -306,8 +306,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #
@@ -346,7 +346,8 @@ LABEL com.github.actions.name="MegaLinter" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #EXTRA_DOCKERFILE_LINES__START
-COPY entrypoint.sh /entrypoint.sh
+COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
+USER 1000
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 #EXTRA_DOCKERFILE_LINES__END

--- a/flavors/rust/Dockerfile
+++ b/flavors/rust/Dockerfile
@@ -291,7 +291,7 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -300,8 +300,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #
@@ -340,7 +340,8 @@ LABEL com.github.actions.name="MegaLinter" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #EXTRA_DOCKERFILE_LINES__START
-COPY entrypoint.sh /entrypoint.sh
+COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
+USER 1000
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 #EXTRA_DOCKERFILE_LINES__END

--- a/flavors/salesforce/Dockerfile
+++ b/flavors/salesforce/Dockerfile
@@ -318,7 +318,7 @@ RUN echo y|sfdx plugins:install sfdx-hardis \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -327,8 +327,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #
@@ -367,7 +367,8 @@ LABEL com.github.actions.name="MegaLinter" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #EXTRA_DOCKERFILE_LINES__START
-COPY entrypoint.sh /entrypoint.sh
+COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
+USER 1000
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 #EXTRA_DOCKERFILE_LINES__END

--- a/flavors/security/Dockerfile
+++ b/flavors/security/Dockerfile
@@ -253,7 +253,7 @@ ENV KICS_QUERIES_PATH=/opt/kics/assets/queries KICS_LIBRARIES_PATH=/opt/kics/ass
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -262,8 +262,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #
@@ -302,7 +302,8 @@ LABEL com.github.actions.name="MegaLinter" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #EXTRA_DOCKERFILE_LINES__START
-COPY entrypoint.sh /entrypoint.sh
+COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
+USER 1000
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 #EXTRA_DOCKERFILE_LINES__END

--- a/flavors/swift/Dockerfile
+++ b/flavors/swift/Dockerfile
@@ -294,7 +294,7 @@ RUN rc-update add docker boot && rc-service docker start || true \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -303,8 +303,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #
@@ -343,7 +343,8 @@ LABEL com.github.actions.name="MegaLinter" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #EXTRA_DOCKERFILE_LINES__START
-COPY entrypoint.sh /entrypoint.sh
+COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
+USER 1000
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 #EXTRA_DOCKERFILE_LINES__END

--- a/flavors/terraform/Dockerfile
+++ b/flavors/terraform/Dockerfile
@@ -320,7 +320,7 @@ ENV KICS_QUERIES_PATH=/opt/kics/assets/queries KICS_LIBRARIES_PATH=/opt/kics/ass
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -329,8 +329,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #
@@ -369,7 +369,8 @@ LABEL com.github.actions.name="MegaLinter" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #EXTRA_DOCKERFILE_LINES__START
-COPY entrypoint.sh /entrypoint.sh
+COPY --chown=1000:1000 entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
+USER 1000
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 #EXTRA_DOCKERFILE_LINES__END

--- a/linters/action_actionlint/Dockerfile
+++ b/linters/action_actionlint/Dockerfile
@@ -139,7 +139,7 @@ COPY --link --from=shellcheck /bin/shellcheck /usr/bin/shellcheck
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -148,8 +148,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/ansible_ansible_lint/Dockerfile
+++ b/linters/ansible_ansible_lint/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/arm_arm_ttk/Dockerfile
+++ b/linters/arm_arm_ttk/Dockerfile
@@ -155,7 +155,7 @@ RUN curl --retry 5 --retry-delay 5 -sLO "${ARM_TTK_URI}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -164,8 +164,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/bash_exec/Dockerfile
+++ b/linters/bash_exec/Dockerfile
@@ -132,7 +132,7 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -141,8 +141,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/bash_shellcheck/Dockerfile
+++ b/linters/bash_shellcheck/Dockerfile
@@ -134,7 +134,7 @@ COPY --link --from=shellcheck /bin/shellcheck /usr/bin/shellcheck
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -143,8 +143,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/bash_shfmt/Dockerfile
+++ b/linters/bash_shfmt/Dockerfile
@@ -130,7 +130,7 @@ COPY --link --from=shfmt /bin/shfmt /usr/bin/
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -139,8 +139,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/bicep_bicep_linter/Dockerfile
+++ b/linters/bicep_bicep_linter/Dockerfile
@@ -135,7 +135,7 @@ RUN curl --retry 5 --retry-delay 5 -sLo ${BICEP_EXE} "${BICEP_URI}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -144,8 +144,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/c_cpplint/Dockerfile
+++ b/linters/c_cpplint/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/clojure_clj_kondo/Dockerfile
+++ b/linters/clojure_clj_kondo/Dockerfile
@@ -133,7 +133,7 @@ RUN curl -sLO https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/scrip
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -142,8 +142,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/cloudformation_cfn_lint/Dockerfile
+++ b/linters/cloudformation_cfn_lint/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/coffee_coffeelint/Dockerfile
+++ b/linters/coffee_coffeelint/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/copypaste_jscpd/Dockerfile
+++ b/linters/copypaste_jscpd/Dockerfile
@@ -151,7 +151,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -160,8 +160,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/cpp_cpplint/Dockerfile
+++ b/linters/cpp_cpplint/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/csharp_csharpier/Dockerfile
+++ b/linters/csharp_csharpier/Dockerfile
@@ -145,7 +145,7 @@ RUN /usr/share/dotnet/dotnet tool install -g csharpier
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -154,8 +154,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/csharp_dotnet_format/Dockerfile
+++ b/linters/csharp_dotnet_format/Dockerfile
@@ -142,7 +142,7 @@ ENV PATH="${PATH}:/root/.dotnet/tools:/usr/share/dotnet"
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -151,8 +151,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/css_scss_lint/Dockerfile
+++ b/linters/css_scss_lint/Dockerfile
@@ -134,7 +134,7 @@ RUN echo 'gem: --no-document' >> ~/.gemrc && \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -143,8 +143,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/css_stylelint/Dockerfile
+++ b/linters/css_stylelint/Dockerfile
@@ -153,7 +153,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -162,8 +162,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/dart_dartanalyzer/Dockerfile
+++ b/linters/dart_dartanalyzer/Dockerfile
@@ -138,7 +138,7 @@ RUN wget --tries=50 -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sge
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -147,8 +147,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/dockerfile_hadolint/Dockerfile
+++ b/linters/dockerfile_hadolint/Dockerfile
@@ -130,7 +130,7 @@ COPY --link --from=hadolint /bin/hadolint /usr/bin/hadolint
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -139,8 +139,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/editorconfig_editorconfig_checker/Dockerfile
+++ b/linters/editorconfig_editorconfig_checker/Dockerfile
@@ -130,7 +130,7 @@ COPY --link --from=editorconfig-checker /usr/bin/ec /usr/bin/editorconfig-checke
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -139,8 +139,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/env_dotenv_linter/Dockerfile
+++ b/linters/env_dotenv_linter/Dockerfile
@@ -130,7 +130,7 @@ RUN wget -q -O - https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/m
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -139,8 +139,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/gherkin_gherkin_lint/Dockerfile
+++ b/linters/gherkin_gherkin_lint/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/go_golangci_lint/Dockerfile
+++ b/linters/go_golangci_lint/Dockerfile
@@ -133,7 +133,7 @@ RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -142,8 +142,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/go_revive/Dockerfile
+++ b/linters/go_revive/Dockerfile
@@ -135,7 +135,7 @@ COPY --link --from=revive /usr/bin/revive /usr/bin/revive
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -144,8 +144,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/graphql_graphql_schema_linter/Dockerfile
+++ b/linters/graphql_graphql_schema_linter/Dockerfile
@@ -151,7 +151,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -160,8 +160,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/groovy_npm_groovy_lint/Dockerfile
+++ b/linters/groovy_npm_groovy_lint/Dockerfile
@@ -151,7 +151,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -160,8 +160,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/html_djlint/Dockerfile
+++ b/linters/html_djlint/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/html_htmlhint/Dockerfile
+++ b/linters/html_htmlhint/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/java_checkstyle/Dockerfile
+++ b/linters/java_checkstyle/Dockerfile
@@ -144,7 +144,7 @@ RUN --mount=type=secret,id=GITHUB_TOKEN CHECKSTYLE_LATEST=$(curl -s \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -153,8 +153,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/java_pmd/Dockerfile
+++ b/linters/java_pmd/Dockerfile
@@ -140,7 +140,7 @@ RUN wget --quiet https://github.com/pmd/pmd/releases/download/pmd_releases%2F${P
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -149,8 +149,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/javascript_es/Dockerfile
+++ b/linters/javascript_es/Dockerfile
@@ -162,7 +162,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -171,8 +171,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/javascript_prettier/Dockerfile
+++ b/linters/javascript_prettier/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/javascript_standard/Dockerfile
+++ b/linters/javascript_standard/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/json_eslint_plugin_jsonc/Dockerfile
+++ b/linters/json_eslint_plugin_jsonc/Dockerfile
@@ -152,7 +152,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -161,8 +161,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/json_jsonlint/Dockerfile
+++ b/linters/json_jsonlint/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/json_npm_package_json_lint/Dockerfile
+++ b/linters/json_npm_package_json_lint/Dockerfile
@@ -151,7 +151,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -160,8 +160,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/json_prettier/Dockerfile
+++ b/linters/json_prettier/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/json_v8r/Dockerfile
+++ b/linters/json_v8r/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/jsx_eslint/Dockerfile
+++ b/linters/jsx_eslint/Dockerfile
@@ -153,7 +153,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -162,8 +162,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/kotlin_ktlint/Dockerfile
+++ b/linters/kotlin_ktlint/Dockerfile
@@ -134,7 +134,7 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -143,8 +143,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/kubernetes_helm/Dockerfile
+++ b/linters/kubernetes_helm/Dockerfile
@@ -129,7 +129,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -138,8 +138,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/kubernetes_kubeconform/Dockerfile
+++ b/linters/kubernetes_kubeconform/Dockerfile
@@ -138,7 +138,7 @@ RUN ML_THIRD_PARTY_DIR="/third-party/kubeconform" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -147,8 +147,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/kubernetes_kubeval/Dockerfile
+++ b/linters/kubernetes_kubeval/Dockerfile
@@ -137,7 +137,7 @@ RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -146,8 +146,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/latex_chktex/Dockerfile
+++ b/linters/latex_chktex/Dockerfile
@@ -131,7 +131,7 @@ RUN cd ~ && touch .chktexrc && cd /
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/lua_luacheck/Dockerfile
+++ b/linters/lua_luacheck/Dockerfile
@@ -145,7 +145,7 @@ RUN wget --tries=5 https://www.lua.org/ftp/lua-5.3.5.tar.gz -O - -q | tar -xzf -
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -154,8 +154,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/makefile_checkmake/Dockerfile
+++ b/linters/makefile_checkmake/Dockerfile
@@ -130,7 +130,7 @@ COPY --link --from=checkmake /checkmake /usr/bin/checkmake
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -139,8 +139,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/markdown_markdown_link_check/Dockerfile
+++ b/linters/markdown_markdown_link_check/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/markdown_markdown_table_formatter/Dockerfile
+++ b/linters/markdown_markdown_table_formatter/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/markdown_markdownlint/Dockerfile
+++ b/linters/markdown_markdownlint/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/markdown_remark_lint/Dockerfile
+++ b/linters/markdown_remark_lint/Dockerfile
@@ -151,7 +151,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -160,8 +160,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/openapi_spectral/Dockerfile
+++ b/linters/openapi_spectral/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/perl_perlcritic/Dockerfile
+++ b/linters/perl_perlcritic/Dockerfile
@@ -132,7 +132,7 @@ RUN curl --retry 5 --retry-delay 5 -sL https://cpanmin.us/ | perl - -nq --no-wge
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -141,8 +141,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/php_phpcs/Dockerfile
+++ b/linters/php_phpcs/Dockerfile
@@ -161,7 +161,7 @@ RUN --mount=type=secret,id=GITHUB_TOKEN GITHUB_AUTH_TOKEN="$(cat /run/secrets/GI
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -170,8 +170,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/php_phplint/Dockerfile
+++ b/linters/php_phplint/Dockerfile
@@ -162,7 +162,7 @@ RUN composer global require --ignore-platform-reqs overtrue/phplint ^5.3 \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -171,8 +171,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/php_phpstan/Dockerfile
+++ b/linters/php_phpstan/Dockerfile
@@ -161,7 +161,7 @@ RUN chmod +x /usr/bin/phpstan
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -170,8 +170,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/php_psalm/Dockerfile
+++ b/linters/php_psalm/Dockerfile
@@ -161,7 +161,7 @@ RUN --mount=type=secret,id=GITHUB_TOKEN GITHUB_AUTH_TOKEN="$(cat /run/secrets/GI
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -170,8 +170,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/powershell_powershell/Dockerfile
+++ b/linters/powershell_powershell/Dockerfile
@@ -148,7 +148,7 @@ RUN pwsh -c 'Install-Module -Name PSScriptAnalyzer -RequiredVersion ${PSSA_VERSI
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -157,8 +157,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/powershell_powershell_formatter/Dockerfile
+++ b/linters/powershell_powershell_formatter/Dockerfile
@@ -148,7 +148,7 @@ RUN pwsh -c 'Install-Module -Name PSScriptAnalyzer -RequiredVersion ${PSSA_VERSI
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -157,8 +157,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/protobuf_protolint/Dockerfile
+++ b/linters/protobuf_protolint/Dockerfile
@@ -130,7 +130,7 @@ COPY --link --from=protolint /usr/local/bin/protolint /usr/bin/
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -139,8 +139,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/puppet_puppet_lint/Dockerfile
+++ b/linters/puppet_puppet_lint/Dockerfile
@@ -134,7 +134,7 @@ RUN echo 'gem: --no-document' >> ~/.gemrc && \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -143,8 +143,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/python_bandit/Dockerfile
+++ b/linters/python_bandit/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/python_black/Dockerfile
+++ b/linters/python_black/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/python_flake8/Dockerfile
+++ b/linters/python_flake8/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/python_isort/Dockerfile
+++ b/linters/python_isort/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/python_mypy/Dockerfile
+++ b/linters/python_mypy/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/python_pylint/Dockerfile
+++ b/linters/python_pylint/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/python_pyright/Dockerfile
+++ b/linters/python_pyright/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/python_ruff/Dockerfile
+++ b/linters/python_ruff/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/r_lintr/Dockerfile
+++ b/linters/r_lintr/Dockerfile
@@ -144,7 +144,7 @@ RUN mkdir -p /home/r-library \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -153,8 +153,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/raku_raku/Dockerfile
+++ b/linters/raku_raku/Dockerfile
@@ -137,7 +137,7 @@ ENV PATH="~/.raku/bin:/opt/rakudo-pkg/bin:/opt/rakudo-pkg/share/perl6/site/bin:$
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -146,8 +146,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/repository_checkov/Dockerfile
+++ b/linters/repository_checkov/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/repository_devskim/Dockerfile
+++ b/linters/repository_devskim/Dockerfile
@@ -143,7 +143,7 @@ RUN dotnet tool install --global Microsoft.CST.DevSkim.CLI --version 0.7.104
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -152,8 +152,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/repository_dustilock/Dockerfile
+++ b/linters/repository_dustilock/Dockerfile
@@ -132,7 +132,7 @@ COPY --link --from=dustilock /usr/bin/dustilock /usr/bin/dustilock
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -141,8 +141,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/repository_git_diff/Dockerfile
+++ b/linters/repository_git_diff/Dockerfile
@@ -128,7 +128,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -137,8 +137,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/repository_gitleaks/Dockerfile
+++ b/linters/repository_gitleaks/Dockerfile
@@ -130,7 +130,7 @@ COPY --link --from=gitleaks /usr/bin/gitleaks /usr/bin/
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -139,8 +139,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/repository_goodcheck/Dockerfile
+++ b/linters/repository_goodcheck/Dockerfile
@@ -134,7 +134,7 @@ RUN echo 'gem: --no-document' >> ~/.gemrc && \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -143,8 +143,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/repository_secretlint/Dockerfile
+++ b/linters/repository_secretlint/Dockerfile
@@ -152,7 +152,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -161,8 +161,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/repository_semgrep/Dockerfile
+++ b/linters/repository_semgrep/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/repository_syft/Dockerfile
+++ b/linters/repository_syft/Dockerfile
@@ -130,7 +130,7 @@ RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | 
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -139,8 +139,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/repository_trivy/Dockerfile
+++ b/linters/repository_trivy/Dockerfile
@@ -131,7 +131,7 @@ RUN wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/rst_rst_lint/Dockerfile
+++ b/linters/rst_rst_lint/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/rst_rstcheck/Dockerfile
+++ b/linters/rst_rstcheck/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/rst_rstfmt/Dockerfile
+++ b/linters/rst_rstfmt/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/ruby_rubocop/Dockerfile
+++ b/linters/ruby_rubocop/Dockerfile
@@ -139,7 +139,7 @@ RUN echo 'gem: --no-document' >> ~/.gemrc && \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -148,8 +148,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/rust_clippy/Dockerfile
+++ b/linters/rust_clippy/Dockerfile
@@ -132,7 +132,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -141,8 +141,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/salesforce_sfdx_scanner_apex/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_apex/Dockerfile
@@ -163,7 +163,7 @@ RUN echo y|sfdx plugins:install sfdx-hardis \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -172,8 +172,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/salesforce_sfdx_scanner_aura/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_aura/Dockerfile
@@ -163,7 +163,7 @@ RUN echo y|sfdx plugins:install sfdx-hardis \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -172,8 +172,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/salesforce_sfdx_scanner_lwc/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_lwc/Dockerfile
@@ -163,7 +163,7 @@ RUN echo y|sfdx plugins:install sfdx-hardis \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -172,8 +172,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/scala_scalafix/Dockerfile
+++ b/linters/scala_scalafix/Dockerfile
@@ -135,7 +135,7 @@ RUN curl --retry-all-errors --retry 10 -fLo coursier https://git.io/coursier-cli
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -144,8 +144,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/snakemake_lint/Dockerfile
+++ b/linters/snakemake_lint/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/snakemake_snakefmt/Dockerfile
+++ b/linters/snakemake_snakefmt/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/spell_cspell/Dockerfile
+++ b/linters/spell_cspell/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/spell_misspell/Dockerfile
+++ b/linters/spell_misspell/Dockerfile
@@ -136,7 +136,7 @@ RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -145,8 +145,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/spell_proselint/Dockerfile
+++ b/linters/spell_proselint/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/sql_sql_lint/Dockerfile
+++ b/linters/sql_sql_lint/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/sql_sqlfluff/Dockerfile
+++ b/linters/sql_sqlfluff/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/sql_tsqllint/Dockerfile
+++ b/linters/sql_tsqllint/Dockerfile
@@ -143,7 +143,7 @@ RUN dotnet tool install --global TSQLLint
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -152,8 +152,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/swift_swiftlint/Dockerfile
+++ b/linters/swift_swiftlint/Dockerfile
@@ -130,7 +130,7 @@ RUN rc-update add docker boot && rc-service docker start || true
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -139,8 +139,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/tekton_tekton_lint/Dockerfile
+++ b/linters/tekton_tekton_lint/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/terraform_checkov/Dockerfile
+++ b/linters/terraform_checkov/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/terraform_kics/Dockerfile
+++ b/linters/terraform_kics/Dockerfile
@@ -134,7 +134,7 @@ ENV KICS_QUERIES_PATH=/opt/kics/assets/queries KICS_LIBRARIES_PATH=/opt/kics/ass
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -143,8 +143,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/terraform_terraform_fmt/Dockerfile
+++ b/linters/terraform_terraform_fmt/Dockerfile
@@ -130,7 +130,7 @@ COPY --link --from=terragrunt /bin/terraform /usr/bin/
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -139,8 +139,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/terraform_terragrunt/Dockerfile
+++ b/linters/terraform_terragrunt/Dockerfile
@@ -130,7 +130,7 @@ COPY --link --from=terragrunt /usr/local/bin/terragrunt /usr/bin/
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -139,8 +139,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/terraform_terrascan/Dockerfile
+++ b/linters/terraform_terrascan/Dockerfile
@@ -130,7 +130,7 @@ COPY --link --from=terrascan /go/bin/terrascan /usr/bin/
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -139,8 +139,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/terraform_tflint/Dockerfile
+++ b/linters/terraform_tflint/Dockerfile
@@ -130,7 +130,7 @@ COPY --link --from=tflint /usr/local/bin/tflint /usr/bin/
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -139,8 +139,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/tsx_eslint/Dockerfile
+++ b/linters/tsx_eslint/Dockerfile
@@ -162,7 +162,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -171,8 +171,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/typescript_es/Dockerfile
+++ b/linters/typescript_es/Dockerfile
@@ -165,7 +165,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -174,8 +174,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/typescript_prettier/Dockerfile
+++ b/linters/typescript_prettier/Dockerfile
@@ -151,7 +151,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -160,8 +160,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/typescript_standard/Dockerfile
+++ b/linters/typescript_standard/Dockerfile
@@ -153,7 +153,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -162,8 +162,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/vbdotnet_dotnet_format/Dockerfile
+++ b/linters/vbdotnet_dotnet_format/Dockerfile
@@ -142,7 +142,7 @@ ENV PATH="${PATH}:/root/.dotnet/tools:/usr/share/dotnet"
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -151,8 +151,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/xml_xmllint/Dockerfile
+++ b/linters/xml_xmllint/Dockerfile
@@ -132,7 +132,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -141,8 +141,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/yaml_prettier/Dockerfile
+++ b/linters/yaml_prettier/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/yaml_v8r/Dockerfile
+++ b/linters/yaml_v8r/Dockerfile
@@ -150,7 +150,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -159,8 +159,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/linters/yaml_yamllint/Dockerfile
+++ b/linters/yaml_yamllint/Dockerfile
@@ -131,7 +131,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 ################################
 # Installs python dependencies #
 ################################
-COPY megalinter /megalinter
+COPY --chown=1000:1000 megalinter /megalinter
 RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
     && PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py clean --all \
     && rm -rf /var/cache/apk/* \
@@ -140,8 +140,8 @@ RUN PYTHONDONTWRITEBYTECODE=1 python /megalinter/setup.py install \
 #######################################
 # Copy scripts and rules to container #
 #######################################
-COPY megalinter/descriptors /megalinter-descriptors
-COPY TEMPLATES /action/lib/.automation
+COPY --chown=1000:1000 megalinter/descriptors /megalinter-descriptors
+COPY --chown=1000:1000 TEMPLATES /action/lib/.automation
 
 ###########################
 # Get the build arguments #

--- a/mega-linter-runner/lib/runner.js
+++ b/mega-linter-runner/lib/runner.js
@@ -132,6 +132,8 @@ ERROR: Docker engine has not been found on your system.
     if (options["containerName"]) {
       commandArgs.push(...["--name", options["containerName"]]);
     }
+    commandArgs.push(...["--user", `1000:1000`]);
+    commandArgs.push(...["--tmpfs", "/tmp:rw,exec"]);
     commandArgs.push(...["-v", "/var/run/docker.sock:/var/run/docker.sock:rw"]);
     commandArgs.push(...["-v", `${lintPath}:/tmp/lint:rw`]);
     if (options.fix === true) {

--- a/mega-linter-runner/package.json
+++ b/mega-linter-runner/package.json
@@ -15,7 +15,10 @@
     "mega-linter-runner": "lib/index.js"
   },
   "scripts": {
-    "test": "mocha \"test/**/*.test.js\""
+    "test": "mocha \"test/**/*.test.js\"",
+    "test:cli": "mocha test/megalinter-cli.test.js",
+    "test:module": "mocha test/megalinter-module.test.js",
+    "test:upgrade": "mocha test/megalinter-upgrade.test.js"
   },
   "keywords": [
     "mega-linter",

--- a/mega-linter-runner/test/megalinter-module.test.js
+++ b/mega-linter-runner/test/megalinter-module.test.js
@@ -48,7 +48,7 @@ Disabled until find a way to run with default options
       path: "./..",
       release,
       nodockerpull,
-      env: ["ENABLE=YAML"],
+      env: ["ENABLE=YAML", "LOG_LEVEL=DEBUG"],
     };
     const res = await new MegaLinterRunner().run(options);
     assert(res.status === 0, `status is 0 (${res.status} returned)`);


### PR DESCRIPTION
Fixes #1975.

Previously, mega-linter-runner ran the MegaLinter Docker image as root. Users whose files became owned by root as a consequence of this behavior will need to `chown` them to be owned by the appropriate user. This change only affects POSIX platforms, because `process.getuid` and `process.getgid` are only available there.

## Proposed Changes

1. Instruct the MegaLinter Docker container to inherit the UID and GID of the mega-linter-runner process.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
