### PR TITLE
Deploy additional Docker images to GitHub Container Registry

### DIFF
--- a/.github/linters/.cspell.json
+++ b/.github/linters/.cspell.json
@@ -1080,6 +1080,7 @@
         "regexpp",
         "rego",
         "regsub",
+        "reimann",
         "reindent",
         "relaxng",
         "remarkrc",

--- a/.github/workflows/deploy-ALPHA-flavors.yml
+++ b/.github/workflows/deploy-ALPHA-flavors.yml
@@ -78,9 +78,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      #####################
-      # Run Deploy script #
-      #####################
+      ###################################
+      # Run Deploy script for Dockerhub #
+      ###################################
       - name: Deploy latest image to DockerHub
         env:
           # Set the Env Vars
@@ -91,6 +91,23 @@ jobs:
           DOCKERFILE_PATH: flavors/${{ matrix.flavor }}/Dockerfile
           DOCKER_BUILD_PLATFORMS: linux/amd64
           REGISTRY: Docker
+          SQUASH: "true"
+        shell: bash
+        run: .automation/upload-docker.sh
+
+      ###################################################
+      # Run Deploy script for GitHub Container Registry #
+      ###################################################
+      - name: Deploy latest image to GitHub Container Registry
+        env:
+          # Set the Env Vars
+          GCR_USERNAME: ${{ secrets.GCR_USERNAME }}
+          GCR_TOKEN: ${{ secrets.GCR_PASSWORD }}
+          IMAGE_REPO: oxsecurity/megalinter-${{ matrix.flavor }}
+          IMAGE_VERSION: alpha
+          DOCKERFILE_PATH: flavors/${{ matrix.flavor }}/Dockerfile
+          DOCKER_BUILD_PLATFORMS: linux/amd64
+          REGISTRY: GCR
           SQUASH: "true"
         shell: bash
         run: .automation/upload-docker.sh

--- a/.github/workflows/deploy-BETA-flavors.yml
+++ b/.github/workflows/deploy-BETA-flavors.yml
@@ -82,9 +82,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      #####################
-      # Run Deploy script #
-      #####################
+      ###################################
+      # Run Deploy script for Dockerhub #
+      ###################################
       - name: Deploy beta image to DockerHub
         env:
           # Set the Env Vars
@@ -95,6 +95,22 @@ jobs:
           DOCKERFILE_PATH: flavors/${{ matrix.flavor }}/Dockerfile
           DOCKER_BUILD_PLATFORMS: linux/amd64
           REGISTRY: Docker
+        shell: bash
+        run: .automation/upload-docker.sh
+
+      ###################################################
+      # Run Deploy script for GitHub Container Registry #
+      ###################################################
+      - name: Deploy beta image to GitHub Container Registry
+        env:
+          # Set the Env Vars
+          GCR_USERNAME: ${{ secrets.GCR_USERNAME }}
+          GCR_TOKEN: ${{ secrets.GCR_PASSWORD }}
+          IMAGE_REPO: oxsecurity/megalinter-${{ matrix.flavor }}
+          IMAGE_VERSION: beta
+          DOCKERFILE_PATH: flavors/${{ matrix.flavor }}/Dockerfile
+          DOCKER_BUILD_PLATFORMS: linux/amd64
+          REGISTRY: GCR
         shell: bash
         run: .automation/upload-docker.sh
 

--- a/.github/workflows/deploy-BETA-linters.yml
+++ b/.github/workflows/deploy-BETA-linters.yml
@@ -109,9 +109,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      #####################
-      # Run Deploy script #
-      #####################
+      ###################################
+      # Run Deploy script for Dockerhub #
+      ###################################
       - name: Deploy Beta image to DockerHub
         env:
           # Set the Env Vars
@@ -135,6 +135,36 @@ jobs:
           DOCKERFILE_PATH: linters/${{ matrix.linter }}/Dockerfile
           DOCKER_BUILD_PLATFORMS: linux/amd64
           REGISTRY: Docker
+          ALWAYS_BUILD: force
+        shell: bash
+        run: .automation/upload-docker.sh
+
+      ###################################################
+      # Run Deploy script for GitHub Container Registry #
+      ###################################################
+      - name: Deploy Beta image to GitHub Container Registry
+        env:
+          # Set the Env Vars
+          GCR_USERNAME: ${{ secrets.GCR_USERNAME }}
+          GCR_TOKEN: ${{ secrets.GCR_PASSWORD }}
+          IMAGE_REPO: oxsecurity/megalinter-only-${{ matrix.linter }}
+          IMAGE_VERSION: beta
+          DOCKERFILE_PATH: linters/${{ matrix.linter }}/Dockerfile
+          DOCKER_BUILD_PLATFORMS: linux/amd64
+          REGISTRY: GCR
+        shell: bash
+        run: .automation/upload-docker.sh
+
+      - name: Deploy ${{ needs.prepare.outputs.unique_docker_image_name }} image to GitHub Container Registry
+        env:
+          # Set the Env Vars
+          GCR_USERNAME: ${{ secrets.GCR_USERNAME }}
+          GCR_TOKEN: ${{ secrets.GCR_PASSWORD }}
+          IMAGE_REPO: oxsecurity/megalinter-only-${{ matrix.linter }}
+          IMAGE_VERSION: "${{ needs.prepare.outputs.unique_docker_image_name }}"
+          DOCKERFILE_PATH: linters/${{ matrix.linter }}/Dockerfile
+          DOCKER_BUILD_PLATFORMS: linux/amd64
+          REGISTRY: GCR
           ALWAYS_BUILD: force
         shell: bash
         run: .automation/upload-docker.sh

--- a/.github/workflows/deploy-RELEASE-flavors.yml
+++ b/.github/workflows/deploy-RELEASE-flavors.yml
@@ -87,6 +87,22 @@ jobs:
         shell: bash
         run: .automation/upload-docker.sh
 
+      ###################################################
+      # Run Deploy script for GitHub Container Registry #
+      ###################################################
+      - name: Deploy Release image to GitHub Container Registry
+        env:
+          # Set the Env Vars
+          GCR_USERNAME: ${{ secrets.GCR_USERNAME }}
+          GCR_TOKEN: ${{ secrets.GCR_PASSWORD }}
+          IMAGE_REPO: oxsecurity/megalinter-${{ matrix.flavor }}
+          IMAGE_VERSION: ${{ github.event.release.tag_name }}
+          DOCKERFILE_PATH: flavors/${{ matrix.flavor }}/Dockerfile
+          DOCKER_BUILD_PLATFORMS: linux/amd64
+          REGISTRY: GCR
+        shell: bash
+        run: .automation/upload-docker.sh
+
       # Free disk space
       - name: Free Disk space
         shell: bash
@@ -108,4 +124,3 @@ jobs:
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
           timeout: 10m0s
-

--- a/.github/workflows/deploy-RELEASE-linters.yml
+++ b/.github/workflows/deploy-RELEASE-linters.yml
@@ -85,9 +85,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      #####################
-      # Run Deploy script #
-      #####################
+      ###################################
+      # Run Deploy script for Dockerhub #
+      ###################################
       - name: Deploy ${{ github.event.release.tag_name }} image to DockerHub
         env:
           # Set the Env Vars
@@ -98,6 +98,23 @@ jobs:
           DOCKERFILE_PATH: linters/${{ matrix.linter }}/Dockerfile
           DOCKER_BUILD_PLATFORMS: linux/amd64
           REGISTRY: Docker
+          ALWAYS_BUILD: force
+        shell: bash
+        run: .automation/upload-docker.sh
+
+      ###################################################
+      # Run Deploy script for GitHub Container Registry #
+      ###################################################
+      - name: Deploy ${{ github.event.release.tag_name }} image to GitHub Container Registry
+        env:
+          # Set the Env Vars
+          GCR_USERNAME: ${{ secrets.GCR_USERNAME }}
+          GCR_TOKEN: ${{ secrets.GCR_PASSWORD }}
+          IMAGE_REPO: oxsecurity/megalinter-only-${{ matrix.linter }}
+          IMAGE_VERSION: "${{ github.event.release.tag_name }}"
+          DOCKERFILE_PATH: linters/${{ matrix.linter }}/Dockerfile
+          DOCKER_BUILD_PLATFORMS: linux/amd64
+          REGISTRY: GCR
           ALWAYS_BUILD: force
         shell: bash
         run: .automation/upload-docker.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-linter.yml file, or with `oxsecurity/megalinter:beta` docker image
 
+- Core
+  - Deploy additional Docker images to GitHub Container Registry, by @lars-reimann in [#2117](https://github.com/oxsecurity/megalinter/pull/2117)
+
 - Fixes
   - Change name of config file for powershell formatter to avoid collision with powershell linter config
 


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes partially #1472

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Deploy additional Docker images to GitHub Container Registry. This would later allow [action.yml](https://github.com/oxsecurity/megalinter/blob/main/action.yml) to pull the MegaLinter image from GitHub instead of Docker Hub, which _should_ speed up the pull phase of the action.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
