### PR TITLE
Remove def.ws prefix from aggregate sarif report

### DIFF
--- a/megalinter/reporters/SarifReporter.py
+++ b/megalinter/reporters/SarifReporter.py
@@ -221,11 +221,22 @@ class SarifReporter(Reporter):
                 # Update run in full list
                 linter_sarif_obj["runs"][id_run] = run
         return linter_sarif_obj
+    
+    # If DEFAULT_WORKSPACE is set, don't add that to the SARIF-report prefix
+    def fix_default_workspace_prefix(self, artifactLocation):
+        default_workspace = config.get("DEFAULT_WORKSPACE", "")
+        if default_workspace:
+            if artifactLocation["uri"].startswith(default_workspace):
+                artifactLocation["uri"] = artifactLocation["uri"].replace(default_workspace,"",1)
+        return artifactLocation["uri"]
 
     # Replace startLine and endLine in region or contextRegion
     def fix_sarif_physical_location(self, physical_location):
+        
         for location_key in physical_location.keys():
             location_item = physical_location[location_key]
+            if "uri" in location_item and location_key == "artifactLocation":
+                location_item["uri"] = self.fix_default_workspace_prefix(location_item)
             if "startLine" in location_item and location_item["startLine"] == 0:
                 location_item["startLine"] = 1
             if "endLine" in location_item and location_item["endLine"] == 0:


### PR DESCRIPTION




<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #https://github.com/oxsecurity/megalinter/issues/2006
(partially, see discussion there)

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

This will replace the default workspace prefix
from when creating the aggregate sarif report output. (def. megalinter-reports.sarif).

In other words, the artifact uri will be

/root/path/of/source/code

instead of as of now:

DEFAULT_WORKSPACE/root/path/of/source/code.

## Proposed Changes

As the DEFAULT_WORKSPACE might only exist during
runtime lints, it needs to be removed to offer a deterministic uri, for the reports.

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`

Signed-off-by: Josef Andersson <josef.andersson@gmail.com>