### PR TITLE
Fix HTML email not rendering correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Add Makefile linters to documentation flavor
 - Fixes
   - CSpell file name linting does not use (custom) CSpell configuration ([#2058](https://github.com/oxsecurity/megalinter/issues/2058))
+  - HTML email not rendering correctly ([#2120](https://github.com/oxsecurity/megalinter/issues/2120)). Set `REPORTERS_MARKDOWN_TYPE` to `simple` to avoid external images in PR/MR markdown comments.
 
 - Linter versions upgrades
   - [cspell](https://github.com/streetsidesoftware/cspell/tree/master/packages/cspell) from 6.14.3 to **6.15.0** on 2022-11-26

--- a/docs/reporters/AzureCommentReporter.md
+++ b/docs/reporters/AzureCommentReporter.md
@@ -43,3 +43,4 @@ Example:
 |-----------------------------------|------------------------------------------------------------------------------------|---------------|
 | AZURE_COMMENT_REPORTER            | Activates/deactivates reporter                                                     | true          |
 | AZURE_COMMENT_REPORTER_LINKS_TYPE | Set to `build` if you want comments linking to target Build and not artifacts page | `artifacts`   |
+| REPORTERS_MARKDOWN_TYPE           | Set to `simple` to avoid external images in generated markdown                     | `advanced`    |

--- a/docs/reporters/GitHubCommentReporter.md
+++ b/docs/reporters/GitHubCommentReporter.md
@@ -17,3 +17,4 @@ Click on hyperlinks to access detailed logs
 | GITHUB_API_URL          | URL where the github API can be reached<br/>Must be overridden if using GitHub Enterprise | `https://api.github.com` |
 | GITHUB_SERVER_URL       | URL of the GitHub instance<br/>Must be overridden if using GitHub Enterprise              | `https://github.com`     |
 | CI_ACTION_RUN_URL       | URL of the CI job visualization page url (if using Github but not GitHub Actions)         | <!--  -->                |
+| REPORTERS_MARKDOWN_TYPE | Set to `simple` to avoid external images in generated markdown                            | `advanced`               |

--- a/docs/reporters/GitlabCommentReporter.md
+++ b/docs/reporters/GitlabCommentReporter.md
@@ -24,6 +24,7 @@ Click on hyperlinks to access detailed logs (click on **Download** in **Artifact
 | GITLAB_ACCESS_TOKEN_MEGALINTER | Must contain a Gitlab private access token defined with api access                                     | <!-- -->                 |
 | GITLAB_CUSTOM_CERTIFICATE      | SSL certificate value to connect to Gitlab                                                             | <!-- -->                 |
 | GITLAB_CERTIFICATE_PATH        | Path to SSL certificate to connect to Gitlab (if SSL cert has been manually defined with PRE_COMMANDS) | <!-- -->                 |
+| REPORTERS_MARKDOWN_TYPE        | Set to `simple` to avoid external images in generated markdown                                         | `advanced`               |
 
 ## Special Thanks
 

--- a/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
@@ -9456,6 +9456,17 @@
       "title": "Output folder",
       "type": "string"
     },
+    "REPORTERS_MARKDOWN_TYPE" : {
+      "$id": "#/properties/REPORTERS_MARKDOWN_TYPE",
+      "default": "advanced",
+      "description": "Define simple if you do not to have external images in PR/MR comments",
+      "enum": [
+        "simple",
+        "advanced"
+      ],
+      "title": "Reporters Markdown type",
+      "type": "string"
+    },
     "REPOSITORY_CHECKOV_ARGUMENTS": {
       "$id": "#/properties/REPOSITORY_CHECKOV_ARGUMENTS",
       "description": "REPOSITORY_CHECKOV: User custom arguments to add in linter CLI call",

--- a/megalinter/reporters/GitlabCommentReporter.py
+++ b/megalinter/reporters/GitlabCommentReporter.py
@@ -131,7 +131,7 @@ class GitlabCommentReporter(Reporter):
             # Check if there is already a MegaLinter comment
             for comment in existing_comments:
                 if (
-                    "See errors details in [**artifact MegaLinter reports** on"
+                    "See errors details in [artifact MegaLinter reports on"
                     in comment.body
                 ):
                     existing_comment = comment

--- a/megalinter/utils_reporter.py
+++ b/megalinter/utils_reporter.py
@@ -41,7 +41,7 @@ def build_markdown_summary(reporter_self, action_run_url):
                 found = "yes"
                 nb_fixed_cell = "yes" if nb_fixed_cell != "" else nb_fixed_cell
                 errors_cell = (
-                    log_link(f"**{linter.total_number_errors}**", action_run_url)
+                    log_link(f"{linter.total_number_errors}", action_run_url)
                     if linter.number_errors > 0
                     else "no"
                 )
@@ -49,7 +49,7 @@ def build_markdown_summary(reporter_self, action_run_url):
             else:
                 found = str(len(linter.files))
                 errors_cell = (
-                    log_link(f"**{linter.total_number_errors}**", action_run_url)
+                    log_link(f"{linter.total_number_errors}", action_run_url)
                     if linter.number_errors > 0
                     else linter.number_errors
                 )
@@ -78,7 +78,7 @@ def build_markdown_summary(reporter_self, action_run_url):
     status_with_href = (
         status
         + " "
-        + log_link(f"**{reporter_self.master.status.upper()}**", action_run_url)
+        + log_link(f"{reporter_self.master.status.upper()}", action_run_url)
     )
     p_r_msg = (
         f"## [\U0001f999 MegaLinter]({ML_DOC_URL}) status: {status_with_href}"
@@ -88,7 +88,7 @@ def build_markdown_summary(reporter_self, action_run_url):
     p_r_msg += table_content + os.linesep
     if action_run_url != "":
         p_r_msg += (
-            "See errors details in [**artifact MegaLinter reports** on "
+            "See errors details in [artifact MegaLinter reports on "
             f"CI Job page]({action_run_url})" + os.linesep
         )
     else:
@@ -116,7 +116,7 @@ def build_markdown_summary(reporter_self, action_run_url):
                 f"&title={urllib.parse.quote('Request new MegaLinter flavor')}"
                 f"&body={urllib.parse.quote(body)}"
             )
-            p_r_msg += f"- [**Click here to request the new flavor**]({new_flavor_url})"
+            p_r_msg += f"- [Click here to request the new flavor]({new_flavor_url})"
         else:
             p_r_msg += (
                 os.linesep
@@ -130,17 +130,24 @@ def build_markdown_summary(reporter_self, action_run_url):
                     f"{ML_REPO}/flavors/{suggestion['flavor']}@{action_version}"
                 )
                 p_r_msg += (
-                    f"- [**{action_path}**]({ML_DOC_URL}/flavors/{suggestion['flavor']}/)"
+                    f"- [{action_path}]({ML_DOC_URL}/flavors/{suggestion['flavor']}/)"
                     f" ({suggestion['linters_number']} linters)" + os.linesep
                 )
         p_r_msg += os.linesep
     # Link to ox
-    p_r_msg += (
-        os.linesep
-        + "_MegaLinter is graciously provided by [![OX Security]"
-        + "(https://www.ox.security/wp-content/uploads/2022/06/"
-        + "logo.svg?ref=megalinter_comment)](https://www.ox.security/?ref=megalinter)_"
-    )
+    if config.get("REPORTERS_MARKDOWN_TYPE", "advanced") == "simple":
+        p_r_msg += (
+            os.linesep
+            + "MegaLinter is graciously provided by [OX Security]"
+            + "(https://www.ox.security/?ref=megalinter)"
+        )
+    else:
+        p_r_msg += (
+            os.linesep
+            + "_MegaLinter is graciously provided by [![OX Security]"
+            + "(https://www.ox.security/wp-content/uploads/2022/06/"
+            + "logo.svg?ref=megalinter_comment)](https://www.ox.security/?ref=megalinter)_"
+        )
     logging.debug("\n" + p_r_msg)
     return p_r_msg
 


### PR DESCRIPTION
Fixes https://github.com/oxsecurity/megalinter/issues/2120
 Set `REPORTERS_MARKDOWN_TYPE` to `simple` to avoid external images in PR/MR markdown comments.