### PR TITLE
Change reporter text for better UX

### DIFF
--- a/docs/reporters/TextReporter.md
+++ b/docs/reporters/TextReporter.md
@@ -19,7 +19,7 @@ Posts a pack of text logs , zipped as a GitHub Action artifact
 
 ### Get Artifacts on GitLab CI
 
-- Access GitLabel CI job page
+- Access GitLab CI job page
 
 ![Screenshot](../assets/images/TextReporter_gitlab_1.jpg)
 

--- a/megalinter/reporters/GitlabCommentReporter.py
+++ b/megalinter/reporters/GitlabCommentReporter.py
@@ -131,8 +131,8 @@ class GitlabCommentReporter(Reporter):
             # Check if there is already a MegaLinter comment
             for comment in existing_comments:
                 if (
-                    "See errors details in [artifact MegaLinter reports on"
-                    in comment.body
+                    "See detailed report in [MegaLinter reports" in comment.body
+                    or "See detailed report in MegaLinter reports" in comment.body
                 ):
                     existing_comment = comment
 

--- a/megalinter/utils_reporter.py
+++ b/megalinter/utils_reporter.py
@@ -88,11 +88,11 @@ def build_markdown_summary(reporter_self, action_run_url):
     p_r_msg += table_content + os.linesep
     if action_run_url != "":
         p_r_msg += (
-            "See errors details in [artifact MegaLinter reports on "
-            f"CI Job page]({action_run_url})" + os.linesep
+            "See detailed report in [MegaLinter reports"
+            f"]({action_run_url})" + os.linesep
         )
     else:
-        p_r_msg += "See errors details in MegaLinter reports" + os.linesep
+        p_r_msg += "See detailed report in MegaLinter reports" + os.linesep
     if reporter_self.master.validate_all_code_base is False:
         p_r_msg += (
             "_Set `VALIDATE_ALL_CODEBASE: true` in mega-linter.yml to validate "


### PR DESCRIPTION
To prevent users seeing 'See errors details in' text even when their run is not in an error state, lets change this to 'See detailed report in'.

Also removing the 'artifact' text in the message as there are use cases where artifacts are not published and the link takes the user to the build (and not artifacts) page.
