### PR TITLE
Removed hyperlinks to broken links

### DIFF
--- a/docs/descriptors/spell_misspell.md
+++ b/docs/descriptors/spell_misspell.md
@@ -17,10 +17,10 @@ misspell detects and corrects commonly misspelled english words
 
 ## Configuration in MegaLinter
 
-- Enable misspell by adding `SPELL_MISSPELL` in [ENABLE_LINTERS variable](https://megalinter.io/beta/configuration/#activation-and-deactivation)
-- Disable misspell by adding `SPELL_MISSPELL` in [DISABLE_LINTERS variable](https://megalinter.io/beta/configuration/#activation-and-deactivation)
+- Enable misspell by adding `SPELL_MISSPELL` in ENABLE_LINTERS variable
+- Disable misspell by adding `SPELL_MISSPELL` in DISABLE_LINTERS variable
 
-- Enable **auto-fixes** by adding `SPELL_MISSPELL` in [APPLY_FIXES variable](https://megalinter.io/beta/configuration/#apply-fixes)
+- Enable **auto-fixes** by adding `SPELL_MISSPELL` in APPLY_FIXES variable
 
 | Variable                                   | Description                                                                                                                                                                                                         | Default value      |
 |--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #
Link to broken URLs
<!-- markdownlint-restore -->

<!-- Describe what the changes are -->
In the "Configuration in MegaLinter" section, there are references to the following broken links, which have been removed in this commit:
- https://megalinter.io/latest/6.16.0/configuration/#activation-and-deactivation
- https://megalinter.io/latest/6.16.0/configuration/#apply-fixes

## Proposed Changes

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
