### PR TITLE
Pass extra args for friendlier CSpell UX (#2271)

### DIFF
--- a/.github/linters/.cspell.json
+++ b/.github/linters/.cspell.json
@@ -778,6 +778,7 @@
         "kxdddddddoc",
         "lacheck",
         "langserver",
+        "Laven",
         "leavevmode",
         "leveldb",
         "levn",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Fixes
   - Change name of config file for powershell formatter to avoid collision with powershell linter config
   - Enhance find SARIF json in stdout output
+  - Pass --show-context, --show-suggestions, and --no-must-find-files to CSpell for friendlier UX
+    by @Kurt-von-Laven in [#2271](https://github.com/oxsecurity/megalinter/issues/2271).
 
 - Documentation
   - Configure jsonschema documentation formatting (see [Descriptor schema](https://megalinter.io/latest/json-schemas/descriptor.html), [Configuration schema](https://megalinter.io/latest/json-schemas/configuration.html)), by @echoix in [#2270](https://github.com/oxsecurity/megalinter/pull/2270)

--- a/megalinter/linters/CSpellLinter.py
+++ b/megalinter/linters/CSpellLinter.py
@@ -19,6 +19,11 @@ class CSpellLinter(Linter):
         super().__init__(params, linter_config)
 
     def build_lint_command(self, file=None) -> list:
+        self.cli_lint_extra_args += [
+            "--show-context",
+            "--show-suggestions",
+            "--no-must-find-files",
+        ]
         # Create temp file with files segments
         if (
             self.cli_lint_mode == "list_of_files"


### PR DESCRIPTION
Fixes #2271.

Pass `--show-context` to show the text surrounding a misspelling, `--show-suggestions` to show best guesses of the correct spelling, and `--no-must-find-files` to suppress errors when there are no files to spell check. This prevents CSpell from complaining when MegaLinter is run incrementally but no spell-checked files were modified.

## Proposed Changes

1. Append `--show-context`, `--show-suggestions`, and `--no-must-find-files` to `cli_lint_extra_args`.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
