### PR TITLE
Only Run npm-package-json-lint When `package.json` is Present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Change name of config file for powershell formatter to avoid collision with powershell linter config
   - Enhance find SARIF json in stdout output
   - Pass --show-context, --show-suggestions, and --no-must-find-files to CSpell for friendlier UX
-    by @Kurt-von-Laven in [#2271](https://github.com/oxsecurity/megalinter/issues/2271).
+    by @Kurt-von-Laven in [#2275](https://github.com/oxsecurity/megalinter/pull/2275).
 
 - Documentation
   - Configure jsonschema documentation formatting (see [Descriptor schema](https://megalinter.io/latest/json-schemas/descriptor.html), [Configuration schema](https://megalinter.io/latest/json-schemas/configuration.html)), by @echoix in [#2270](https://github.com/oxsecurity/megalinter/pull/2270)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Enhance find SARIF json in stdout output
   - Pass --show-context, --show-suggestions, and --no-must-find-files to CSpell for friendlier UX
     by @Kurt-von-Laven in [#2275](https://github.com/oxsecurity/megalinter/pull/2275).
+  - Only run npm-package-json-lint when package.json is present by @Kurt-von-Laven in
+    [#2280](https://github.com/oxsecurity/megalinter/pull/2280).
 
 - Documentation
   - Configure jsonschema documentation formatting (see [Descriptor schema](https://megalinter.io/latest/json-schemas/descriptor.html), [Configuration schema](https://megalinter.io/latest/json-schemas/configuration.html)), by @echoix in [#2270](https://github.com/oxsecurity/megalinter/pull/2270)

--- a/megalinter/descriptors/json.megalinter-descriptor.yml
+++ b/megalinter/descriptors/json.megalinter-descriptor.yml
@@ -233,6 +233,8 @@ linters:
       - salesforce
     file_names_regex:
       - "package\\.json"
+    active_only_if_file_found:
+      - "package.json"
     cli_lint_mode: project
     cli_executable: npmPkgJsonLint
     cli_config_arg_name: --configFile

--- a/megalinter/flavor_factory.py
+++ b/megalinter/flavor_factory.py
@@ -95,7 +95,7 @@ def check_active_linters_match_flavor(active_linters):
     missing_linters_str = ",".join(missing_linters)
     logging.warning(
         f"MegaLinter flavor [{flavor}] does not contain linters {missing_linters_str}.\n"
-        "As they are not available in this docker image, they will not be processed\n"
+        "As they are not available in this Docker image, they will not be processed\n"
         "To solve this problem, please either: \n"
         f"- use default flavor {ML_REPO}\n"
         "- add ignored linters in DISABLE or DISABLE_LINTERS variables in your .mega-linter.yml config file "

--- a/megalinter/flavor_factory.py
+++ b/megalinter/flavor_factory.py
@@ -89,27 +89,26 @@ def check_active_linters_match_flavor(active_linters):
             if not active_linter.name.startswith("REPOSITORY"):
                 missing_linters.append(active_linter.name)
 
-    # Manage cases where linters are missing in flavor
-    if len(missing_linters) > 0:
-        missing_linters_str = ",".join(missing_linters)
-        logging.warning(
-            f"MegaLinter flavor [{flavor}] does not contain linters {missing_linters_str}.\n"
-            "As they are not available in this docker image, they will not be processed\n"
-            "To solve this problem, please either: \n"
-            f"- use default flavor {ML_REPO}\n"
-            "- add ignored linters in DISABLE or DISABLE_LINTERS variables in your .mega-linter.yml config file "
-            "located in your root directory\n"
-            "- ignore this message by setting config variable FLAVOR_SUGGESTIONS to false"
+    if not missing_linters:
+        return True
+
+    missing_linters_str = ",".join(missing_linters)
+    logging.warning(
+        f"MegaLinter flavor [{flavor}] does not contain linters {missing_linters_str}.\n"
+        "As they are not available in this docker image, they will not be processed\n"
+        "To solve this problem, please either: \n"
+        f"- use default flavor {ML_REPO}\n"
+        "- add ignored linters in DISABLE or DISABLE_LINTERS variables in your .mega-linter.yml config file "
+        "located in your root directory\n"
+        "- ignore this message by setting config variable FLAVOR_SUGGESTIONS to false"
+    )
+    # Stop the process if user wanted so in case of missing linters
+    if config.get("FAIL_IF_MISSING_LINTER_IN_FLAVOR", "") == "true":
+        logging.error(
+            'Missing linter and FAIL_IF_MISSING_LINTER_IN_FLAVOR has been set to "true": Stop run'
         )
-        # Stop the process if user wanted so in case of missing linters
-        if config.get("FAIL_IF_MISSING_LINTER_IN_FLAVOR", "") == "true":
-            logging.error(
-                'Missing linter and FAIL_IF_MISSING_LINTER_IN_FLAVOR has been set to "true": Stop run'
-            )
-            sys.exit(84)
-        return False
-    # All good !
-    return True
+        sys.exit(84)
+    return False
 
 
 # Compare active linters with available flavors to make suggestions to improve CI performances

--- a/megalinter/flavor_factory.py
+++ b/megalinter/flavor_factory.py
@@ -84,7 +84,7 @@ def check_active_linters_match_flavor(active_linters):
     missing_linters = []
     for active_linter in active_linters:
         if active_linter.name not in flavor_linters:
-            missing_linters += [active_linter.name]
+            missing_linters.append(active_linter.name)
             active_linter.is_active = False
     # Manage cases where linters are missing in flavor
     if len(missing_linters) > 0:


### PR DESCRIPTION
Fixes #2279.

## Proposed Changes

1. Only run npm-package-json-lint when `package.json` is present.
2. Don't include REPOSITORY linters in warning about missing linters.
3. Make minor syntactic simplifications in directly related code.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
