### PR TITLE
docs: fix syft logo

### DIFF
--- a/docs/descriptors/repository_syft.md
+++ b/docs/descriptors/repository_syft.md
@@ -7,7 +7,7 @@ description: How to use syft (configure, ignore files, ignore errors, help & ver
 
 <div align="center">
   <a href="https://github.com/anchore/syft#readme" target="blank" title="Visit linter Web Site">
-    <img src="https://raw.githubusercontent.com/returntocorp/semgrep/develop/semgrep.svg" alt="syft" height="150px" class="megalinter-banner">
+    <img src="https://user-images.githubusercontent.com/5199289/136844524-1527b09f-c5cb-4aa9-be54-5aa92a6086c1.png" alt="syft" height="150px" class="megalinter-banner">
   </a>
 </div>
 


### PR DESCRIPTION
Instead of the syft logo, the Semgrep logo was displayed.

Logo reference taken from https://github.com/anchore/syft/blob/641bccc79bd98af48dcb450af9b217d68b1d5662/README.md

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
