### PR TITLE
Tag some automatically updated files as generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@
 
 .automation/generated/flavor-stats.json linguist-generated=true
 .automation/generated/linter-helps.json linguist-generated=true
+docs/descriptors/python_black.md linguist-generated=true
+docs/descriptors/repository_checkov.md linguist-generated=true
+docs/descriptors/terraform_checkov.md linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 * text=auto eol=lf
 *.{cmd,[cC][mM][dD]} text eol=crlf
 *.{bat,[bB][aA][tT]} text eol=crlf
+
+.automation/generated/flavor-stats.json linguist-generated=true
+.automation/generated/linter-helps.json linguist-generated=true


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Some committed helper files are automatically generated and are often updated. 
These files are a good candidate to be tagged as generated files in the `.gitattributes` file.
As described in the docs here, https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github, adding `linguist-generated=true` to a pattern (files in our case), hides changes by default in diffs (collapsed like large diffs), and are ignored in the repo's language statistics.

For now, I added only two files.

-  [`.automation/generated/flavor-stats.json`](https://github.com/oxsecurity/megalinter/blob/main/.automation/generated/flavors-stats.json)
-  [`.automation/generated/linter-helps.json`](https://github.com/oxsecurity/megalinter/blob/main/.automation/generated/linter-helps.json)

I'd like some input on at least the inclusion of the [`linter-helps.json`](https://github.com/oxsecurity/megalinter/blob/main/.automation/generated/linter-helps.json) file. On one side, seeing in the diff is quite verbose for nothing since some python linters use a non-deterministic set to store the options, so the order is always different at each invocation. It is redundant with the content that we will see underneath for the doc pages. But on the other side, it may help to see a little faster if a linter has its options changed if we happen to look at it: if the diff is not collapsed as a large diff, it would be at the top of the diff view.

For other files, especially the [linter-versions.json](https://github.com/oxsecurity/megalinter/blob/main/.automation/generated/linter-versions.json), I think it is useful to have a quick view of what changes are concerned in the PR.
For [megalinter-users.json](https://github.com/oxsecurity/megalinter/blob/main/.automation/generated/megalinter-users.json), it wasn't updated in a week, but before was updated more often before that. This is another file that is simply storing data.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Add some files in to the `.gitattributes` file with a tag `linguist-generated=true`


## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
