### PR TITLE
Remove unneeded go install requirement for shfmt

### DIFF
--- a/flavors/ci_light/Dockerfile
+++ b/flavors/ci_light/Dockerfile
@@ -50,7 +50,6 @@ RUN apk add --update --no-cache \
                 make \
                 musl-dev \
                 openssh \
-                go \
                 nodejs \
                 npm \
                 yarn \

--- a/megalinter/descriptors/bash.megalinter-descriptor.yml
+++ b/megalinter/descriptors/bash.megalinter-descriptor.yml
@@ -122,8 +122,6 @@ linters:
       - "shfmt -d myfile.sh"
       - "shfmt -w myfile.sh" # Fix
     install:
-      apk:
-        - go
       dockerfile:
         - FROM mvdan/shfmt:latest-alpine as shfmt
         - COPY --from=shfmt /bin/shfmt /usr/bin/


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #2315 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Remove go in the apk install of the bash descriptor for linter shfmt. It is already installed from a copied file of a Docker image


## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
