### PR TITLE
Fix pre-commit CLI parameter syntax & sort parameters

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,10 +5,7 @@
   require_serial: true
   args:
     - mega-linter-runner
-    - --containername
-    - "megalinter-incremental"
-    - --remove-container
-    - --fix
+    - --containername=megalinter-incremental
     - --env
     - "'APPLY_FIXES=all'"
     - --env
@@ -16,6 +13,8 @@
     - --env
     - "'LOG_LEVEL=warning'"
     - --filesonly
+    - --fix
+    - --remove-container
   description: >
     See https://megalinter.io/latest/mega-linter-runner/#usage
     and https://megalinter.io/latest/configuration/ if you
@@ -36,15 +35,15 @@
   require_serial: true
   args:
     - mega-linter-runner
-    - --containername megalinter-full
-    - --remove-container
-    - --fix
+    - --containername=megalinter-full
     - --env
     - "'APPLY_FIXES=all'"
     - --env
     - "'CLEAR_REPORT_FOLDER=true'"
     - --env
     - "'LOG_LEVEL=warning'"
+    - --fix
+    - --remove-container
   description: >
     See https://megalinter.io/latest/mega-linter-runner/#usage
     and https://megalinter.io/latest/configuration/ if you

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Core
   - Upgrade base docker image from python:3.10.4-alpine3.16 to python:3.11.1-alpine3.17
 
+- Fixes
+  - Fix pre-commit hook’s command line parameter and argument passing syntax, by @sanmai-NL in <https://github.com/oxsecurity/megalinter/pull/2327>
+
 - Linter versions upgrades
   - [golangci-lint](https://golangci-lint.run/) from 1.51.0 to **1.51.1** on 2023-02-06
   - [cspell](https://github.com/streetsidesoftware/cspell/tree/master/packages/cspell) from 6.21.0 to **6.22.0** on 2023-02-06


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

As is, optionator rejects the command line parameter and argument syntax.

```
Run MegaLinter...........................................................Failed
- hook id: megalinter-full
- exit code: 1

/Users/user/.npm/_npx/614e542633a698fb/node_modules/optionator/lib/index.js:316
          throw new Error("Value for '" + prop + "' of type '" + getOption(prop).type + "' required.");
                ^

Error: Value for 'container-name' of type 'String' required.
...
```

## Proposed Changes

1. Fix pre-commit parameter syntax.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [X] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`