### PR TITLE
Use latest trivy version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -564,7 +564,7 @@ RUN dotnet tool install --global Microsoft.CST.DevSkim.CLI \
     && curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin \
 
 # trivy installation
-    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1 \
+    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
 
 # sfdx-scanner-apex installation
     && sfdx plugins:install @salesforce/sfdx-scanner \

--- a/flavors/ci_light/Dockerfile
+++ b/flavors/ci_light/Dockerfile
@@ -199,7 +199,7 @@ RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
 # Managed with COPY --from=gitleaks /usr/bin/gitleaks /usr/bin/
 
 # trivy installation
-    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1
+    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
 
 
 #OTHER__END

--- a/flavors/cupcake/Dockerfile
+++ b/flavors/cupcake/Dockerfile
@@ -378,7 +378,7 @@ RUN go install github.com/rhysd/actionlint/cmd/actionlint@latest && go clean --c
 # Managed with COPY --from=gitleaks /usr/bin/gitleaks /usr/bin/
 
 # trivy installation
-    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1 \
+    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
 
 # misspell installation
     && ML_THIRD_PARTY_DIR="/third-party/misspell" \

--- a/flavors/documentation/Dockerfile
+++ b/flavors/documentation/Dockerfile
@@ -265,7 +265,7 @@ RUN go install github.com/rhysd/actionlint/cmd/actionlint@latest && go clean --c
 # Managed with COPY --from=gitleaks /usr/bin/gitleaks /usr/bin/
 
 # trivy installation
-    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1 \
+    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
 
 # misspell installation
     && ML_THIRD_PARTY_DIR="/third-party/misspell" \

--- a/flavors/dotnet/Dockerfile
+++ b/flavors/dotnet/Dockerfile
@@ -345,7 +345,7 @@ RUN curl --retry 5 --retry-delay 5 -sLO "${ARM_TTK_URI}" \
 # Managed with COPY --from=gitleaks /usr/bin/gitleaks /usr/bin/
 
 # trivy installation
-    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1 \
+    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
 
 # misspell installation
     && ML_THIRD_PARTY_DIR="/third-party/misspell" \

--- a/flavors/go/Dockerfile
+++ b/flavors/go/Dockerfile
@@ -272,7 +272,7 @@ RUN go install github.com/rhysd/actionlint/cmd/actionlint@latest && go clean --c
 # Managed with COPY --from=gitleaks /usr/bin/gitleaks /usr/bin/
 
 # trivy installation
-    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1 \
+    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
 
 # misspell installation
     && ML_THIRD_PARTY_DIR="/third-party/misspell" \

--- a/flavors/java/Dockerfile
+++ b/flavors/java/Dockerfile
@@ -289,7 +289,7 @@ RUN go install github.com/rhysd/actionlint/cmd/actionlint@latest && go clean --c
 # Managed with COPY --from=gitleaks /usr/bin/gitleaks /usr/bin/
 
 # trivy installation
-    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1 \
+    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
 
 # misspell installation
     && ML_THIRD_PARTY_DIR="/third-party/misspell" \

--- a/flavors/javascript/Dockerfile
+++ b/flavors/javascript/Dockerfile
@@ -282,7 +282,7 @@ RUN go install github.com/rhysd/actionlint/cmd/actionlint@latest && go clean --c
 # Managed with COPY --from=gitleaks /usr/bin/gitleaks /usr/bin/
 
 # trivy installation
-    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1 \
+    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
 
 # misspell installation
     && ML_THIRD_PARTY_DIR="/third-party/misspell" \

--- a/flavors/php/Dockerfile
+++ b/flavors/php/Dockerfile
@@ -301,7 +301,7 @@ RUN go install github.com/rhysd/actionlint/cmd/actionlint@latest && go clean --c
 # Managed with COPY --from=gitleaks /usr/bin/gitleaks /usr/bin/
 
 # trivy installation
-    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1 \
+    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
 
 # misspell installation
     && ML_THIRD_PARTY_DIR="/third-party/misspell" \

--- a/flavors/python/Dockerfile
+++ b/flavors/python/Dockerfile
@@ -275,7 +275,7 @@ RUN go install github.com/rhysd/actionlint/cmd/actionlint@latest && go clean --c
 # Managed with COPY --from=gitleaks /usr/bin/gitleaks /usr/bin/
 
 # trivy installation
-    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1 \
+    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
 
 # misspell installation
     && ML_THIRD_PARTY_DIR="/third-party/misspell" \

--- a/flavors/ruby/Dockerfile
+++ b/flavors/ruby/Dockerfile
@@ -265,7 +265,7 @@ RUN go install github.com/rhysd/actionlint/cmd/actionlint@latest && go clean --c
 # Managed with COPY --from=gitleaks /usr/bin/gitleaks /usr/bin/
 
 # trivy installation
-    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1 \
+    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
 
 # misspell installation
     && ML_THIRD_PARTY_DIR="/third-party/misspell" \

--- a/flavors/rust/Dockerfile
+++ b/flavors/rust/Dockerfile
@@ -260,7 +260,7 @@ RUN go install github.com/rhysd/actionlint/cmd/actionlint@latest && go clean --c
 # Managed with COPY --from=gitleaks /usr/bin/gitleaks /usr/bin/
 
 # trivy installation
-    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1 \
+    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
 
 # misspell installation
     && ML_THIRD_PARTY_DIR="/third-party/misspell" \

--- a/flavors/salesforce/Dockerfile
+++ b/flavors/salesforce/Dockerfile
@@ -271,7 +271,7 @@ RUN go install github.com/rhysd/actionlint/cmd/actionlint@latest && go clean --c
 # Managed with COPY --from=gitleaks /usr/bin/gitleaks /usr/bin/
 
 # trivy installation
-    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1 \
+    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
 
 # sfdx-scanner-apex installation
     && sfdx plugins:install @salesforce/sfdx-scanner \

--- a/flavors/security/Dockerfile
+++ b/flavors/security/Dockerfile
@@ -233,7 +233,7 @@ RUN dotnet tool install --global Microsoft.CST.DevSkim.CLI \
     && curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin \
 
 # trivy installation
-    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1 \
+    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
 
 # tflint installation
 # Managed with COPY --from=tflint /usr/local/bin/tflint /usr/bin/

--- a/flavors/swift/Dockerfile
+++ b/flavors/swift/Dockerfile
@@ -263,7 +263,7 @@ RUN go install github.com/rhysd/actionlint/cmd/actionlint@latest && go clean --c
 # Managed with COPY --from=gitleaks /usr/bin/gitleaks /usr/bin/
 
 # trivy installation
-    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1 \
+    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
 
 # misspell installation
     && ML_THIRD_PARTY_DIR="/third-party/misspell" \

--- a/flavors/terraform/Dockerfile
+++ b/flavors/terraform/Dockerfile
@@ -270,7 +270,7 @@ RUN go install github.com/rhysd/actionlint/cmd/actionlint@latest && go clean --c
 # Managed with COPY --from=gitleaks /usr/bin/gitleaks /usr/bin/
 
 # trivy installation
-    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1 \
+    && wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
 
 # misspell installation
     && ML_THIRD_PARTY_DIR="/third-party/misspell" \

--- a/linters/repository_trivy/Dockerfile
+++ b/linters/repository_trivy/Dockerfile
@@ -122,7 +122,7 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 #############################################################################################
 #OTHER__START
 # trivy installation
-RUN wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1
+RUN wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
 
 
 #OTHER__END

--- a/megalinter/descriptors/repository.megalinter-descriptor.yml
+++ b/megalinter/descriptors/repository.megalinter-descriptor.yml
@@ -384,11 +384,10 @@ linters:
     test_folder: trivy
     examples:
       - "trivy fs --scanners vuln,config ."
-    downgraded_version: true
     install:
       dockerfile:
         - |
-          RUN wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1
+          RUN wget --tries=5 -q -O - https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
     ide:
       vscode:
         - name: VSCode Trivy


### PR DESCRIPTION
I didn't know that we could remove the version and use default "latest" directly, so in this PR I modify it