### PR TITLE
Use latest pyright version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,7 +145,7 @@ RUN PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir --upgrade pip virtuale
     && mkdir -p "/venvs/isort" && cd "/venvs/isort" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir isort black && deactivate && cd ./../.. \
     && mkdir -p "/venvs/bandit" && cd "/venvs/bandit" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir bandit bandit_sarif_formatter && deactivate && cd ./../.. \
     && mkdir -p "/venvs/mypy" && cd "/venvs/mypy" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir mypy && deactivate && cd ./../.. \
-    && mkdir -p "/venvs/pyright" && cd "/venvs/pyright" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir pyright==1.1.270 && deactivate && cd ./../.. \
+    && mkdir -p "/venvs/pyright" && cd "/venvs/pyright" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir pyright && deactivate && cd ./../.. \
     && mkdir -p "/venvs/checkov" && cd "/venvs/checkov" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir packaging checkov && deactivate && cd ./../.. \
     && mkdir -p "/venvs/semgrep" && cd "/venvs/semgrep" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir semgrep && deactivate && cd ./../.. \
     && mkdir -p "/venvs/rst-lint" && cd "/venvs/rst-lint" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir restructuredtext_lint && deactivate && cd ./../.. \

--- a/docs/descriptors/python_pyright.md
+++ b/docs/descriptors/python_pyright.md
@@ -124,4 +124,4 @@ Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`
 ### Installation on mega-linter Docker image
 
 - PIP packages (Python):
-  - [pyright==1.1.270](https://pypi.org/project/pyright/1.1.270)
+  - [pyright](https://pypi.org/project/pyright)

--- a/flavors/cupcake/Dockerfile
+++ b/flavors/cupcake/Dockerfile
@@ -115,7 +115,7 @@ RUN PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir --upgrade pip virtuale
     && mkdir -p "/venvs/flake8" && cd "/venvs/flake8" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir flake8 && deactivate && cd ./../.. \
     && mkdir -p "/venvs/isort" && cd "/venvs/isort" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir isort black && deactivate && cd ./../.. \
     && mkdir -p "/venvs/mypy" && cd "/venvs/mypy" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir mypy && deactivate && cd ./../.. \
-    && mkdir -p "/venvs/pyright" && cd "/venvs/pyright" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir pyright==1.1.270 && deactivate && cd ./../.. \
+    && mkdir -p "/venvs/pyright" && cd "/venvs/pyright" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir pyright && deactivate && cd ./../.. \
     && mkdir -p "/venvs/checkov" && cd "/venvs/checkov" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir packaging checkov && deactivate && cd ./../.. \
     && mkdir -p "/venvs/semgrep" && cd "/venvs/semgrep" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir semgrep && deactivate && cd ./../.. \
     && mkdir -p "/venvs/rst-lint" && cd "/venvs/rst-lint" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir restructuredtext_lint && deactivate && cd ./../.. \

--- a/flavors/python/Dockerfile
+++ b/flavors/python/Dockerfile
@@ -96,7 +96,7 @@ RUN PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir --upgrade pip virtuale
     && mkdir -p "/venvs/isort" && cd "/venvs/isort" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir isort black && deactivate && cd ./../.. \
     && mkdir -p "/venvs/bandit" && cd "/venvs/bandit" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir bandit bandit_sarif_formatter && deactivate && cd ./../.. \
     && mkdir -p "/venvs/mypy" && cd "/venvs/mypy" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir mypy && deactivate && cd ./../.. \
-    && mkdir -p "/venvs/pyright" && cd "/venvs/pyright" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir pyright==1.1.270 && deactivate && cd ./../.. \
+    && mkdir -p "/venvs/pyright" && cd "/venvs/pyright" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir pyright && deactivate && cd ./../.. \
     && mkdir -p "/venvs/checkov" && cd "/venvs/checkov" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir packaging checkov && deactivate && cd ./../.. \
     && mkdir -p "/venvs/semgrep" && cd "/venvs/semgrep" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir semgrep && deactivate && cd ./../.. \
     && mkdir -p "/venvs/rst-lint" && cd "/venvs/rst-lint" && virtualenv . && source bin/activate && PYTHONDONTWRITEBYTECODE=1 pip3 install --no-cache-dir restructuredtext_lint && deactivate && cd ./../.. \

--- a/megalinter/Linter.py
+++ b/megalinter/Linter.py
@@ -1242,3 +1242,9 @@ class Linter:
     # noinspection PyMethodMayBeStatic
     def complete_text_reporter_report(self, _reporter_self):
         return []
+    
+    def pre_test(self):
+        pass
+    
+    def post_test(self):
+        pass

--- a/megalinter/Linter.py
+++ b/megalinter/Linter.py
@@ -1242,9 +1242,9 @@ class Linter:
     # noinspection PyMethodMayBeStatic
     def complete_text_reporter_report(self, _reporter_self):
         return []
-    
+
     def pre_test(self):
         pass
-    
+
     def post_test(self):
         pass

--- a/megalinter/descriptors/python.megalinter-descriptor.yml
+++ b/megalinter/descriptors/python.megalinter-descriptor.yml
@@ -317,10 +317,9 @@ linters:
     examples:
       - "pyright myfile.py myfile2.py"
       - "pyright myfile.py"
-    downgraded_version: true
     install:
       pip:
-        - pyright==1.1.270
+        - pyright
     ide:
       emacs:
         - name: LSP-pyright

--- a/megalinter/descriptors/python.megalinter-descriptor.yml
+++ b/megalinter/descriptors/python.megalinter-descriptor.yml
@@ -295,7 +295,8 @@ linters:
   #     pip:
   #       - pytype
   # PyRight
-  - linter_name: pyright
+  - class: PyrightLinter
+    linter_name: pyright
     name: PYTHON_PYRIGHT
     linter_text: |
       Optional static typing checks for python, by Microsoft

--- a/megalinter/linters/PyrightLinter.py
+++ b/megalinter/linters/PyrightLinter.py
@@ -5,21 +5,26 @@ https://raku.org/
 """
 import os
 
-from megalinter import Linter
-from megalinter import utils
+from megalinter import Linter, utils
 
 
 class PyrightLinter(Linter):
     def pre_test(self):
         # The file must be in the root of the repository so we create it temporarily for the test.
-        # By default pyright ignores files starting with "." so we override this behavior 
+        # By default pyright ignores files starting with "." so we override this behavior
         # to work with the .automation folder
-        with open(os.path.join(utils.REPO_HOME_DEFAULT, "pyproject.toml"), "w", encoding="utf-8") as f:
-            f.write("""[tool.pyright]
+        with open(
+            os.path.join(utils.REPO_HOME_DEFAULT, "pyproject.toml"),
+            "w",
+            encoding="utf-8",
+        ) as f:
+            f.write(
+                """[tool.pyright]
 exclude = [
     "**/node_modules",
     "**/__pycache__"
-]""")
+]"""
+            )
 
     def post_test(self):
         os.remove(os.path.join(utils.REPO_HOME_DEFAULT, "pyproject.toml"))

--- a/megalinter/linters/PyrightLinter.py
+++ b/megalinter/linters/PyrightLinter.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""
+Use Raku to lint raku files
+https://raku.org/
+"""
+import os
+
+from megalinter import Linter
+from megalinter import utils
+
+
+class PyrightLinter(Linter):
+    def pre_test(self):
+        # The file must be in the root of the repository so we create it temporarily for the test.
+        # By default pyright ignores files starting with "." so we override this behavior 
+        # to work with the .automation folder
+        with open(os.path.join(utils.REPO_HOME_DEFAULT, "pyproject.toml"), "w", encoding="utf-8") as f:
+            f.write("""[tool.pyright]
+exclude = [
+    "**/node_modules",
+    "**/__pycache__"
+]""")
+
+    def post_test(self):
+        os.remove(os.path.join(utils.REPO_HOME_DEFAULT, "pyproject.toml"))

--- a/megalinter/linters/PyrightLinter.py
+++ b/megalinter/linters/PyrightLinter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-Use Raku to lint raku files
-https://raku.org/
+Use Pyright to lint py files
+https://github.com/Microsoft/pyright/
 """
 import os
 

--- a/megalinter/linters/PyrightLinter.py
+++ b/megalinter/linters/PyrightLinter.py
@@ -5,7 +5,7 @@ https://github.com/Microsoft/pyright/
 """
 import os
 
-from megalinter import Linter, utils
+from megalinter import Linter
 
 
 class PyrightLinter(Linter):
@@ -14,7 +14,7 @@ class PyrightLinter(Linter):
         # By default pyright ignores files starting with "." so we override this behavior
         # to work with the .automation folder
         with open(
-            os.path.join(utils.REPO_HOME_DEFAULT, "pyproject.toml"),
+            os.path.join(os.getcwd(), "pyproject.toml"),
             "w",
             encoding="utf-8",
         ) as f:
@@ -27,4 +27,4 @@ exclude = [
             )
 
     def post_test(self):
-        os.remove(os.path.join(utils.REPO_HOME_DEFAULT, "pyproject.toml"))
+        os.remove(os.path.join(os.getcwd(), "pyproject.toml"))

--- a/megalinter/tests/test_megalinter/LinterTestRoot.py
+++ b/megalinter/tests/test_megalinter/LinterTestRoot.py
@@ -17,24 +17,42 @@ class LinterTestRoot:
 
     def test_success(self):
         utilstest.linter_test_setup()
-        utilstest.test_linter_success(self.get_linter_instance(), self)
+        linter = self.get_linter_instance()
+        linter.pre_test()
+        utilstest.test_linter_success(linter, self)
+        linter.post_test()
 
     def test_failure(self):
         utilstest.linter_test_setup()
-        utilstest.test_linter_failure(self.get_linter_instance(), self)
+        linter = self.get_linter_instance()
+        linter.pre_test()
+        utilstest.test_linter_failure(linter, self)
+        linter.post_test()
 
     def test_get_linter_version(self):
         utilstest.linter_test_setup()
-        utilstest.test_get_linter_version(self.get_linter_instance(), self)
+        linter = self.get_linter_instance()
+        linter.pre_test()
+        utilstest.test_get_linter_version(linter, self)
+        linter.post_test()
 
     def test_get_linter_help(self):
         utilstest.linter_test_setup()
-        utilstest.test_get_linter_help(self.get_linter_instance(), self)
+        linter = self.get_linter_instance()
+        linter.pre_test()
+        utilstest.test_get_linter_help(linter, self)
+        linter.post_test()
 
     def test_report_tap(self):
         utilstest.linter_test_setup({"report_type": "tap"})
-        utilstest.test_linter_report_tap(self.get_linter_instance(), self)
+        linter = self.get_linter_instance()
+        linter.pre_test()
+        utilstest.test_linter_report_tap(linter, self)
+        linter.post_test()
 
     def test_report_sarif(self):
         utilstest.linter_test_setup({"report_type": "SARIF"})
+        linter = self.get_linter_instance()
+        linter.pre_test()
         utilstest.test_linter_report_sarif(self.get_linter_instance(), self)
+        linter.post_test()


### PR DESCRIPTION
@nvuillam this case will not be so easy because in a certain version they added some excludes by default and it will give us problems with the `.automation` (Because it starts with a dot) folder when running the tests.

https://github.com/microsoft/pyright/blob/main/packages/pyright-internal/src/analyzer/service.ts#L661

https://github.com/microsoft/pyright/commit/618f54edc047ce08b7d39a2edc867d55382b6071

As you see there, it excludes by default `**/.*` so it ignores the `.automation` folder.

I asked if this was the case and was told that the only way is to create a file that includes an entry in `excludes`:

https://github.com/microsoft/pyright/issues/4597#issuecomment-1423244633

The problem is that the `pyproject.toml` file has to be in the working directory where the command is executed, which I understand will be the root of the repository...

https://github.com/microsoft/pyright/blob/cca7588f76c9142fdbcba1bb0c22c30a9d317594/packages/pyright-internal/src/analyzer/service.ts#L646

In the `.github` folder I see that there is one but it would not be useful because the command is not executed from there.

In that file we have to add an exclude:

https://github.com/microsoft/pyright/blob/main/docs/configuration.md#sample-pyprojecttoml-file

The content should be this (removing `**/.*`):

```toml
[tool.pyright]
exclude = [
    "**/node_modules",
    "**/__pycache__"
]
```

**How do we solve this problem?**