### PR TITLE
Added rubocop-rake RubyGem for linting Rake files with RuboCop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Test: create a testing architecture for format/autofix linters, by @bdovaz in [#2294](https://github.com/oxsecurity/megalinter/pull/2294)
   - Test: create or adapt input files for format/autofix tests, by @bdovaz in [#2294](https://github.com/oxsecurity/megalinter/pull/2294)
   - Test: created specific test folders for linters that need them because they cannot share them, by @bdovaz in [#2294](https://github.com/oxsecurity/megalinter/pull/2294)
+  - Added rubocop-rake RubyGem for linting Rake files with RuboCop
 
 - Fixes
   - Correctly generate class names and test class files for each linter when the linter descriptor defines the attribute "name", by @bdovaz in [#2294](https://github.com/oxsecurity/megalinter/pull/2294)

--- a/Dockerfile
+++ b/Dockerfile
@@ -256,6 +256,7 @@ RUN echo 'gem: --no-document' >> ~/.gemrc && \
           rubocop-github \
           rubocop-performance \
           rubocop-rails \
+          rubocop-rake \
           rubocop-rspec
 #GEM__END
 

--- a/docs/descriptors/ruby_rubocop.md
+++ b/docs/descriptors/ruby_rubocop.md
@@ -279,4 +279,5 @@ Profiling Options:
   - [rubocop-github](https://rubygems.org/gems/rubocop-github)
   - [rubocop-performance](https://rubygems.org/gems/rubocop-performance)
   - [rubocop-rails](https://rubygems.org/gems/rubocop-rails)
+  - [rubocop-rake](https://rubygems.org/gems/rubocop-rake)
   - [rubocop-rspec](https://rubygems.org/gems/rubocop-rspec)

--- a/flavors/cupcake/Dockerfile
+++ b/flavors/cupcake/Dockerfile
@@ -218,6 +218,7 @@ RUN echo 'gem: --no-document' >> ~/.gemrc && \
           rubocop-github \
           rubocop-performance \
           rubocop-rails \
+          rubocop-rake \
           rubocop-rspec
 #GEM__END
 

--- a/flavors/ruby/Dockerfile
+++ b/flavors/ruby/Dockerfile
@@ -172,6 +172,7 @@ RUN echo 'gem: --no-document' >> ~/.gemrc && \
           rubocop-github \
           rubocop-performance \
           rubocop-rails \
+          rubocop-rake \
           rubocop-rspec
 #GEM__END
 

--- a/linters/ruby_rubocop/Dockerfile
+++ b/linters/ruby_rubocop/Dockerfile
@@ -104,6 +104,7 @@ RUN echo 'gem: --no-document' >> ~/.gemrc && \
           rubocop-github \
           rubocop-performance \
           rubocop-rails \
+          rubocop-rake \
           rubocop-rspec
 #GEM__END
 

--- a/megalinter/descriptors/ruby.megalinter-descriptor.yml
+++ b/megalinter/descriptors/ruby.megalinter-descriptor.yml
@@ -27,6 +27,7 @@ linters:
         - rubocop-github
         - rubocop-performance
         - rubocop-rails
+        - rubocop-rake
         - rubocop-rspec
     ide:
       atom:


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

I have added the rubocop-rake RuboCop plugin so that projects that use it to lint Rake files can use Megalinter.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Added `rubocop-rake` to the list of gems installed with RuboCop.
2. Updated the corresponding documentation listing the bundled gems.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
