### PR TITLE
Fixup changes/no changes exit codes for build-command

### DIFF
--- a/.github/workflows/build-command.yml
+++ b/.github/workflows/build-command.yml
@@ -62,7 +62,6 @@ jobs:
           cache: pip # optional
       - run: pip install -r requirements.dev.txt
       - name: Create comment starting build.sh
-        if: steps.check-changes.outputs.has-changes != '1'
         uses: peter-evans/create-or-update-comment@v2
         with:
           ## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
@@ -76,14 +75,13 @@ jobs:
         run: ./build.sh
       - name: Check if changes were made
         id: check-changes
-        run: |
-          git diff --quiet && git diff --staged --quiet
-          HAS_CHANGES=$?
-          echo "has-changes=$HAS_CHANGES" >> $GITHUB_OUTPUT
-          echo "$HAS_CHANGES"
-      # Commit changes to the PR branch
+        run: git diff --exit-code
+        # https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---exit-code
+        # Make the program exit with codes similar to diff(1). That is, it exits with 1 if there were differences and 0 means no differences.
+        # 0 is success (no difference), non-zero (like 1) is failure (differences)
+        continue-on-error: true
       - name: Commit changes to the PR branch
-        if: steps.check-changes.outputs.has-changes == '1'
+        if: steps.check-changes.outputs.outcome == "failure"
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
@@ -99,7 +97,7 @@ jobs:
           issue-number: ${{ github.event.inputs.issue-number }}
           reaction-type: hooray
       - name: Create final comment updated files
-        if: steps.check-changes.outputs.has-changes == '1'
+        if: steps.check-changes.outputs.outcome == "failure"
         uses: peter-evans/create-or-update-comment@v2
         with:
           ## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
@@ -110,7 +108,7 @@ jobs:
           body: |
             > Build command workflow completed updating files.
       - name: Create final comment no updated files
-        if: steps.check-changes.outputs.has-changes != '1'
+        if: steps.check-changes.outputs.outcome == "success"
         uses: peter-evans/create-or-update-comment@v2
         with:
           ## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]

--- a/.github/workflows/build-command.yml
+++ b/.github/workflows/build-command.yml
@@ -1,23 +1,23 @@
 name: build-command
 on:
   workflow_dispatch:
-    # checkov:skip=CKV_GHA_7:We are only triggering these workflows by users with write access manually, it is expected. 
-    # Error was: 
-    # The build output cannot be affected by user parameters other than the build entry point and the top-level source location. 
-    # GitHub Actions workflow_dispatch inputs MUST be empty. 
+    # checkov:skip=CKV_GHA_7:We are only triggering these workflows by users with write access manually, it is expected.
+    # Error was:
+    # The build output cannot be affected by user parameters other than the build entry point and the top-level source location.
+    # GitHub Actions workflow_dispatch inputs MUST be empty.
     inputs:
       repository:
-        description: 'The repository from which the slash command was dispatched'
+        description: "The repository from which the slash command was dispatched"
         required: true
       comment-id:
-        description: 'The comment-id of the slash command'
+        description: "The comment-id of the slash command"
         required: true
       issue-number:
-       description: 'The issue number in which the slash command was made'
-       required: true
+        description: "The issue number in which the slash command was made"
+        required: true
       actor:
-       description: 'The user who executed the slash command'
-       required: true
+        description: "The user who executed the slash command"
+        required: true
   repository_dispatch:
     types: [build-command]
 jobs:

--- a/.github/workflows/build-command.yml
+++ b/.github/workflows/build-command.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-python@v4.5.0
         with:
           # Version range or exact version of Python or PyPy to use, using SemVer's version range syntax. Reads from .python-version if unset.
-          python-version: 3.11.1 # optional
+          python-version: 3.11.2 # optional
           # Used to specify a package manager for caching in the default directory. Supported values: pip, pipenv, poetry.
           cache: pip # optional
       - run: pip install -r requirements.dev.txt
@@ -73,20 +73,10 @@ jobs:
             > Running script `./build.sh`
       - name: Run build script
         run: ./build.sh
-      - name: Check if changes were made
-        id: check-changes
-        run: git diff --exit-code
-        # https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---exit-code
-        # Make the program exit with codes similar to diff(1). That is, it exits with 1 if there were differences and 0 means no differences.
-        # 0 is success (no difference), non-zero (like 1) is failure (differences)
-        continue-on-error: true
-      - name: Commit changes to the PR branch
-        if: steps.check-changes.outputs.outcome == "failure"
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git diff --quiet && git diff --staged --quiet || (git commit -am "[build-command] Update generated files")
-          git push
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        id: auto-commit-action
+        with:
+          commit_message: "[build-command] Update generated files"
       - name: Add reaction
         uses: peter-evans/create-or-update-comment@v2
         with:
@@ -97,7 +87,7 @@ jobs:
           issue-number: ${{ github.event.inputs.issue-number }}
           reaction-type: hooray
       - name: Create final comment updated files
-        if: steps.check-changes.outputs.outcome == "failure"
+        if: steps.auto-commit-action.outputs.changes_detected == 'true'
         uses: peter-evans/create-or-update-comment@v2
         with:
           ## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
@@ -108,7 +98,7 @@ jobs:
           body: |
             > Build command workflow completed updating files.
       - name: Create final comment no updated files
-        if: steps.check-changes.outputs.outcome == "success"
+        if: steps.auto-commit-action.outputs.changes_detected == 'false'
         uses: peter-evans/create-or-update-comment@v2
         with:
           ## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]

--- a/.github/workflows/deploy-DEV-linters.yml
+++ b/.github/workflows/deploy-DEV-linters.yml
@@ -20,12 +20,18 @@ on:
       - .github/CONTRIBUTING.md
       - CHANGELOG.md
       - README.md
+      - .github/workflows/slash-command-dispatch.yml
+      - .github/workflows/help-command.yml
+      - .github/workflows/build-command.yml
   pull_request:
     branches-ignore: []
     paths-ignore:
       - .github/CONTRIBUTING.md
       - CHANGELOG.md
       - README.md
+      - .github/workflows/slash-command-dispatch.yml
+      - .github/workflows/help-command.yml
+      - .github/workflows/build-command.yml
 
 ###############
 # Set the Job #

--- a/.github/workflows/deploy-DEV.yml
+++ b/.github/workflows/deploy-DEV.yml
@@ -25,12 +25,18 @@ on:
       - .github/CONTRIBUTING.md
       - CHANGELOG.md
       - README.md
+      - .github/workflows/slash-command-dispatch.yml
+      - .github/workflows/help-command.yml
+      - .github/workflows/build-command.yml
   pull_request:
     branches-ignore: []
     paths-ignore:
       - .github/CONTRIBUTING.md
       - CHANGELOG.md
       - README.md
+      - .github/workflows/slash-command-dispatch.yml
+      - .github/workflows/help-command.yml
+      - .github/workflows/build-command.yml
 
 ###############
 # Set the Job #

--- a/.github/workflows/test-mega-linter-runner.yml
+++ b/.github/workflows/test-mega-linter-runner.yml
@@ -6,11 +6,17 @@ on:
       - .github/CONTRIBUTING.md
       - CHANGELOG.md
       - README.md
+      - .github/workflows/slash-command-dispatch.yml
+      - .github/workflows/help-command.yml
+      - .github/workflows/build-command.yml
   pull_request:
     paths-ignore:
       - .github/CONTRIBUTING.md
       - CHANGELOG.md
       - README.md
+      - .github/workflows/slash-command-dispatch.yml
+      - .github/workflows/help-command.yml
+      - .github/workflows/build-command.yml
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Use docker/build-push-action to build docker images and akhilerm/tag-push-action to release by retagging and pushing beta images instead of rebuilding them
   - Authenticate to GitHub API during docker build to avoid reaching limits
   - Remove apk go package install in images where possible to decrease image sizes, by @echoix in <https://github.com/oxsecurity/megalinter/pull/2318>
-  - Create a slash PR bot to run `./build.sh` command manually on PRs, by @echoix in <https://github.com/oxsecurity/megalinter/pull/2353>
+  - Create a slash PR bot to run `./build.sh` command manually on PRs, by @echoix in [#2353](https://github.com/oxsecurity/megalinter/pull/2353) and [#2381](https://github.com/oxsecurity/megalinter/pull/2381)
 
 - Fixes
   - Replace deprecated spectral package, by @bdovaz in by @bdovaz in <https://github.com/oxsecurity/megalinter/pull/2340>


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Seems like the handling of the exit codes to determine if changes are to be committed didn't work well once used in an action. ~~Going simpler in bash, using only `git diff` with `--exit-code` in order to show the diff, but have the exit code. Then the exit code is handled by the outcome (using continue-on-error) to use the `success` or `failure` outcome of a step.~~

~~https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context ~~
~~https://docs.github.com/en/actions/creating-actions/setting-exit-codes-for-actions#about-exit-codes~~
~~https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---exit-code~~
~~vs https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---quiet~~

**_Edit_**:
 Since this approach didn't end up going smoothly, I changed the approach and used the https://github.com/stefanzweifel/git-auto-commit-action to commit and set an output if there were changes. With this, it works as expected.


<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Be able to commit changes with the build command (without the step being always skipped) -> using https://github.com/stefanzweifel/git-auto-commit-action
2. Disable workflow runs for slash command dispatcher and its commands on PR/pushes where possible: these files can't change the flavors by themselves
3. ...

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
