### PR TITLE
feat: add option to skip def_ws prefix in sarif reports

### DIFF
--- a/docs/reporters/SarifReporter.md
+++ b/docs/reporters/SarifReporter.md
@@ -2,6 +2,7 @@
 title: SARIF Reporter for MegaLinter
 description: Generates SAST results in SARIF format within a file named mega-linter-report.sarif, located in report folder
 ---
+
 # SARIF Reporter (beta)
 
 Generates a full execution log in SARIF format within a file named **mega-linter-report.sarif** , located in report folder.
@@ -30,8 +31,9 @@ with:
 
 ## Configuration
 
-| Variable                 | Description                                                                                            | Default value              |
-|--------------------------|--------------------------------------------------------------------------------------------------------|----------------------------|
-| SARIF_REPORTER           | Activates/deactivates reporter                                                                         | `false`                    |
-| SARIF_REPORTER_FILE_NAME | File name for SARIF report output file                                                                 | `mega-linter-report.sarif` |
-| SARIF_REPORTER_LINTERS   | List of linter keys that will output SARIF (if not set, all SARIF compliant linters will output SARIF) | `[]`                       |
+| Variable                                | Description                                                                                                | Default value              |
+|-----------------------------------------|------------------------------------------------------------------------------------------------------------|----------------------------|
+| SARIF_REPORTER                          | Activates/deactivates reporter                                                                             | `false`                    |
+| SARIF_REPORTER_NORMALIZE_LINTERS_OUTPUT | Remove DEFAULT_WORKSPACE prefix in SARIF-files, i.e. 'DEFAULT_WORKSPACE/src/main' would be 'src/main' etc. | `true`                     |
+| SARIF_REPORTER_FILE_NAME                | File name for SARIF report output file                                                                     | `mega-linter-report.sarif` |
+| SARIF_REPORTER_LINTERS                  | List of linter keys that will output SARIF (if not set, all SARIF compliant linters will output SARIF)     | `[]`                       |

--- a/megalinter/Linter.py
+++ b/megalinter/Linter.py
@@ -32,7 +32,7 @@ import urllib.request
 from time import perf_counter
 
 import yaml
-from megalinter import config, pre_post_factory, utils, utils_reporter
+from megalinter import config, pre_post_factory, utils, utils_sarif, utils_reporter
 from megalinter.constants import DEFAULT_DOCKER_WORKSPACE_DIR
 
 
@@ -108,7 +108,8 @@ class Linter:
         self.sarif_default_output_file = None
         self.no_config_if_fix = False
         self.cli_lint_extra_args = []  # Extra arguments to send to cli everytime
-        self.cli_lint_fix_arg_name = None  # Name of the cli argument to send in case of APPLY_FIXES required by user
+        # Name of the cli argument to send in case of APPLY_FIXES required by user
+        self.cli_lint_fix_arg_name = None
         self.cli_lint_fix_remove_args = (
             []
         )  # Arguments to remove in case fix argument is sent
@@ -177,7 +178,8 @@ class Linter:
         )
         if self.output_sarif is True:
             # Disable SARIF if linter not in specified linter list
-            sarif_enabled_linters = config.get_list("SARIF_REPORTER_LINTERS", None)
+            sarif_enabled_linters = config.get_list(
+                "SARIF_REPORTER_LINTERS", None)
             if (
                 sarif_enabled_linters is not None
                 and self.name not in sarif_enabled_linters
@@ -216,7 +218,8 @@ class Linter:
                 self.apply_fixes = False
             # APPLY_FIXES is "all"
             elif param_apply_fixes == "all" or (
-                isinstance(param_apply_fixes, bool) and param_apply_fixes is True
+                isinstance(param_apply_fixes,
+                           bool) and param_apply_fixes is True
             ):
                 self.apply_fixes = True
             # APPLY_FIXES is a comma-separated list in a single string
@@ -390,7 +393,8 @@ class Linter:
             self.is_active = True
         # check activation rules
         if self.is_active is True and len(self.activation_rules) > 0:
-            self.is_active = utils.check_activation_rules(self.activation_rules, self)
+            self.is_active = utils.check_activation_rules(
+                self.activation_rules, self)
 
     # Manage configuration variables
     def load_config_vars(self, params):
@@ -399,22 +403,26 @@ class Linter:
         if config.exists(self.name + "_CONFIG_FILE"):
             self.config_file_name = config.get(self.name + "_CONFIG_FILE")
         elif config.exists(self.descriptor_id + "_CONFIG_FILE"):
-            self.config_file_name = config.get(self.descriptor_id + "_CONFIG_FILE")
+            self.config_file_name = config.get(
+                self.descriptor_id + "_CONFIG_FILE")
         elif config.exists(self.name + "_FILE_NAME"):
             self.config_file_name = config.get(self.name + "_FILE_NAME")
         elif config.exists(self.descriptor_id + "_FILE_NAME"):
-            self.config_file_name = config.get(self.descriptor_id + "_FILE_NAME")
+            self.config_file_name = config.get(
+                self.descriptor_id + "_FILE_NAME")
         # Ignore file name: try first NAME + _FILE_NAME, then LANGUAGE + _FILE_NAME
         if self.cli_lint_ignore_arg_name is not None:
             if config.exists(self.name + "_IGNORE_FILE"):
                 self.ignore_file_name = config.get(self.name + "_IGNORE_FILE")
             elif config.exists(self.descriptor_id + "_IGNORE_FILE"):
-                self.ignore_file_name = config.get(self.descriptor_id + "_IGNORE_FILE")
+                self.ignore_file_name = config.get(
+                    self.descriptor_id + "_IGNORE_FILE")
         # Linter rules path: try first NAME + _RULE_PATH, then LANGUAGE + _RULE_PATH
         if config.exists(self.name + "_RULES_PATH"):
             self.linter_rules_path = config.get(self.name + "_RULES_PATH")
         elif config.exists(self.descriptor_id + "_RULES_PATH"):
-            self.linter_rules_path = config.get(self.descriptor_id + "_RULES_PATH")
+            self.linter_rules_path = config.get(
+                self.descriptor_id + "_RULES_PATH")
         # Linter config file:
         # 0: LINTER_DEFAULT set in user config: let the linter find it, do not reference it in cli arguments
         # 1: http rules path: fetch remove file and copy it locally (then delete it after linting)
@@ -582,14 +590,16 @@ class Linter:
 
         # Include regex :try first NAME + _FILTER_REGEX_INCLUDE, then LANGUAGE + _FILTER_REGEX_INCLUDE
         if config.exists(self.name + "_FILTER_REGEX_INCLUDE"):
-            self.filter_regex_include = config.get(self.name + "_FILTER_REGEX_INCLUDE")
+            self.filter_regex_include = config.get(
+                self.name + "_FILTER_REGEX_INCLUDE")
         elif config.exists(self.descriptor_id + "_FILTER_REGEX_INCLUDE"):
             self.filter_regex_include = config.get(
                 self.descriptor_id + "_FILTER_REGEX_INCLUDE"
             )
         # User arguments from config
         if config.get(self.name + "_ARGUMENTS", "") != "":
-            self.cli_lint_user_args = config.get_list_args(self.name + "_ARGUMENTS")
+            self.cli_lint_user_args = config.get_list_args(
+                self.name + "_ARGUMENTS")
 
         # Get PRE_COMMANDS overridden by user
         if config.get(self.name + "_PRE_COMMANDS", "") != "":
@@ -618,7 +628,8 @@ class Linter:
             self.disable_errors = True
         # Exclude regex: try first NAME + _FILTER_REGEX_EXCLUDE, then LANGUAGE + _FILTER_REGEX_EXCLUDE
         if config.exists(self.name + "_FILTER_REGEX_EXCLUDE"):
-            self.filter_regex_exclude = config.get(self.name + "_FILTER_REGEX_EXCLUDE")
+            self.filter_regex_exclude = config.get(
+                self.name + "_FILTER_REGEX_EXCLUDE")
         elif config.exists(self.descriptor_id + "_FILTER_REGEX_EXCLUDE"):
             self.filter_regex_exclude = config.get(
                 self.descriptor_id + "_FILTER_REGEX_EXCLUDE"
@@ -671,10 +682,12 @@ class Linter:
                 self.status = "warning" if self.disable_errors is True else "error"
                 self.return_code = 0 if self.disable_errors is True else 1
                 self.number_errors += 1
-                self.total_number_errors += self.get_total_number_errors(stdout)
+                self.total_number_errors += self.get_total_number_errors(
+                    stdout)
             # Build result for list of files
             if self.cli_lint_mode == "list_of_files":
-                self.update_files_lint_results(self.files, None, None, None, None)
+                self.update_files_lint_results(
+                    self.files, None, None, None, None)
 
         # Set return code to 0 if failures in this linter must not make the MegaLinter run fail
         if self.return_code != 0:
@@ -709,7 +722,8 @@ class Linter:
         variables_with_replacements = []
         for txt in variables:
             if "{{SARIF_OUTPUT_FILE}}" in txt:
-                txt = txt.replace("{{SARIF_OUTPUT_FILE}}", self.sarif_output_file)
+                txt = txt.replace("{{SARIF_OUTPUT_FILE}}",
+                                  self.sarif_output_file)
             elif "{{REPORT_FOLDER}}" in txt:
                 txt = txt.replace("{{REPORT_FOLDER}}", self.report_folder)
             elif "{{WORKSPACE}}" in txt:
@@ -748,7 +762,8 @@ class Linter:
 
     # List all reporters, then instantiate each of them
     def load_reporters(self):
-        reporter_init_params = {"master": self, "report_folder": self.report_folder}
+        reporter_init_params = {"master": self,
+                                "report_folder": self.report_folder}
         self.reporters = utils.list_active_reporters_for_scope(
             "linter", reporter_init_params
         )
@@ -874,9 +889,19 @@ class Linter:
                 if os.path.isfile(self.sarif_default_output_file)
                 else os.path.join(self.workspace, self.sarif_default_output_file)
             )
-            shutil.move(linter_sarif_report, self.sarif_output_file)
-            sarif_confirmed = True
-            logging.debug(f"Moved {linter_sarif_report} to {self.sarif_output_file}")
+
+            # Check that a sarif report really exists before moving it etc)
+            if os.path.isfile(linter_sarif_report):
+                shutil.move(linter_sarif_report, self.sarif_output_file)
+                sarif_confirmed = True
+                logging.debug(
+                    f"Moved {linter_sarif_report} to {self.sarif_output_file}"
+                )
+            else:
+                logging.debug(
+                    f"Could not find {linter_sarif_report} (linter sarif output error?)"
+                )
+                sarif_confirmed = False
         # Manage case when SARIF output is in stdout (and not generated by the linter)
         elif (
             self.can_output_sarif is True
@@ -899,10 +924,15 @@ class Linter:
             and os.path.isfile(self.sarif_output_file)
         ):
             sarif_confirmed = True
+
+        if sarif_confirmed is True:
+            utils_sarif.normalize_sarif_files(self)
+
         # Convert SARIF into human readable text for Console & Text reporters
         if sarif_confirmed is True and self.master.sarif_to_human is True:
             with open(self.sarif_output_file, "r", encoding="utf-8") as file:
-                self.stdout_human = utils_reporter.convert_sarif_to_human(file.read())
+                self.stdout_human = utils_reporter.convert_sarif_to_human(
+                    file.read())
 
     # Returns linter version (can be overridden in special cases, like version has special format)
     def get_linter_version(self):
@@ -933,9 +963,11 @@ class Linter:
             )
             return_code = process.returncode
             output = utils.decode_utf8(process.stdout)
-            logging.debug("Linter version result: " + str(return_code) + " " + output)
+            logging.debug("Linter version result: " +
+                          str(return_code) + " " + output)
         except FileNotFoundError:
-            logging.warning("Unable to call command [" + " ".join(command) + "]")
+            logging.warning(
+                "Unable to call command [" + " ".join(command) + "]")
             return_code = 666
             output = "ERROR"
 
@@ -944,7 +976,8 @@ class Linter:
                 "Unable to get version for linter [" + self.linter_name + "]"
             )
             logging.warning(
-                " ".join(command) + f" returned output: ({str(return_code)}) " + output
+                " ".join(command) +
+                f" returned output: ({str(return_code)}) " + output
             )
             return "ERROR"
         else:
@@ -972,16 +1005,20 @@ class Linter:
                 )
                 return_code = process.returncode
                 output += utils.decode_utf8(process.stdout)
-                logging.debug("Linter help result: " + str(return_code) + " " + output)
+                logging.debug("Linter help result: " +
+                              str(return_code) + " " + output)
             except FileNotFoundError:
-                logging.warning("Unable to call command [" + " ".join(command) + "]")
+                logging.warning(
+                    "Unable to call command [" + " ".join(command) + "]")
                 return_code = 666
                 output += "ERROR"
                 break
 
         if return_code != self.help_command_return_code or output.strip() == "":
-            logging.warning("Unable to get help for linter [" + self.linter_name + "]")
-            logging.warning(f"{str(command)} returned output: ({return_code}) {output}")
+            logging.warning(
+                "Unable to get help for linter [" + self.linter_name + "]")
+            logging.warning(
+                f"{str(command)} returned output: ({return_code}) {output}")
             return "ERROR"
         else:
             return output
@@ -1119,9 +1156,11 @@ class Linter:
                     self.workspace, DEFAULT_DOCKER_WORKSPACE_DIR
                 )
             if self.cli_lint_ignore_arg_name.endswith("="):
-                ignore_args += [self.cli_lint_ignore_arg_name + self.final_ignore_file]
+                ignore_args += [self.cli_lint_ignore_arg_name +
+                                self.final_ignore_file]
             elif self.cli_lint_ignore_arg_name != "":
-                ignore_args += [self.cli_lint_ignore_arg_name, self.final_ignore_file]
+                ignore_args += [self.cli_lint_ignore_arg_name,
+                                self.final_ignore_file]
         return ignore_args
 
     # Manage SARIF arguments

--- a/megalinter/reporters/SarifReporter.py
+++ b/megalinter/reporters/SarifReporter.py
@@ -5,10 +5,9 @@ Produce SARIF report
 import json
 import logging
 import os
-import random
 from json.decoder import JSONDecodeError
 
-from megalinter import Linter, Reporter, config, utils
+from megalinter import Reporter, config, utils
 from megalinter.constants import (
     DEFAULT_SARIF_REPORT_FILE_NAME,
     DEFAULT_SARIF_SCHEMA_URI,
@@ -16,7 +15,6 @@ from megalinter.constants import (
     ML_DOC_URL,
 )
 from megalinter.utils import normalize_log_string
-from megalinter.utils_reporter import get_linter_doc_url
 
 
 class SarifReporter(Reporter):
@@ -89,8 +87,6 @@ class SarifReporter(Reporter):
                         )
                         logging.error(str(e))
                 if load_ok is True:
-                    # fix sarif file
-                    linter_sarif_obj = self.fix_sarif(linter_sarif_obj, linter)
                     # append to global megalinter sarif run
                     sarif_obj["runs"] += linter_sarif_obj["runs"]
                     # Delete linter SARIF file if LOG_FILE=none
@@ -129,121 +125,3 @@ class SarifReporter(Reporter):
                 except:  # noqa: E722
                     pass
         return obj
-
-    # Some SARIF linter output contain errors (like references to line 0)
-    # We must correct them so SARIF is valid
-    def fix_sarif(self, linter_sarif_obj, linter: Linter):
-        # browse runs
-        if "runs" in linter_sarif_obj:
-            for id_run, run in enumerate(linter_sarif_obj["runs"]):
-                # Add MegaLinter info
-                run_properties = run["properties"] if "properties" in run else {}
-                run_properties["megalinter"] = {
-                    "linterKey": linter.name,
-                    "docUrl": get_linter_doc_url(linter),
-                    "linterVersion": linter.get_linter_version(),
-                }
-                run["properties"] = run_properties
-
-                # Update linter name in case there are duplicates
-                if (
-                    "tool" in run
-                    and "driver" in run["tool"]
-                    and "name" in run["tool"]["driver"]
-                    and linter.master.megalinter_flavor
-                    != "none"  # single linter image case
-                ):
-                    run["tool"]["driver"]["name"] = (
-                        run["tool"]["driver"]["name"]
-                        + " (MegaLinter "
-                        + linter.name
-                        + ")"
-                    )
-
-                # fix missing informationUri
-                if (
-                    "tool" in run
-                    and "driver" in run["tool"]
-                    and "informationUri" not in run["tool"]["driver"]
-                ):
-                    run["tool"]["driver"]["informationUri"] = get_linter_doc_url(linter)
-
-                # fix missing version
-                if (
-                    "tool" in run
-                    and "driver" in run["tool"]
-                    and "version" not in run["tool"]["driver"]
-                ):
-                    run["tool"]["driver"]["version"] = linter.get_linter_version()
-
-                # fix duplicate rules property
-                if (
-                    "tool" in run
-                    and "driver" in run["tool"]
-                    and "rules" in run["tool"]["driver"]
-                ):
-                    rules = run["tool"]["driver"]["rules"]
-                    rules_updated: list = []
-                    for rule in rules:
-                        # If duplicate id, update duplicate items ids with a random value
-                        if "id" in rule and any(
-                            "id" in rule_item and rule_item["id"] == rule["id"]
-                            for rule_item in rules_updated
-                        ):
-                            rule["id"] = (
-                                rule["id"]
-                                + "_DUPLICATE_"
-                                + str(random.randint(1, 99999))
-                            )
-                        rules_updated += [rule]
-                    run["tool"]["driver"]["rules"] = rules_updated
-
-                # fix results property
-                if "results" in run:
-                    # browse run results
-                    for id_result, result in enumerate(run["results"]):
-                        if "locations" in result:
-                            # browse result locations
-                            for id_location, location in enumerate(result["locations"]):
-                                if "physicalLocation" in location:
-                                    location[
-                                        "physicalLocation"
-                                    ] = self.fix_sarif_physical_location(
-                                        location["physicalLocation"]
-                                    )
-                                result["locations"][id_location] = location
-                        run["results"][id_result] = result
-                else:
-                    # make sure that there is a results entry so GitHub's SARIF validator doesn't cry
-                    run["results"] = []
-
-                # Update run in full list
-                linter_sarif_obj["runs"][id_run] = run
-        return linter_sarif_obj
-
-    # If DEFAULT_WORKSPACE is set, don't add that to the SARIF-report prefix
-    def fix_default_workspace_prefix(self, artifactLocation):
-        default_workspace = config.get("DEFAULT_WORKSPACE", "")
-        if default_workspace:
-            if artifactLocation["uri"].startswith(default_workspace):
-                artifactLocation["uri"] = artifactLocation["uri"].replace(
-                    default_workspace, "", 1
-                )
-        return artifactLocation["uri"]
-
-    # Replace startLine and endLine in region or contextRegion
-    def fix_sarif_physical_location(self, physical_location):
-        for location_key in physical_location.keys():
-            location_item = physical_location[location_key]
-            if "uri" in location_item and location_key == "artifactLocation":
-                location_item["uri"] = self.fix_default_workspace_prefix(location_item)
-            if "startLine" in location_item and location_item["startLine"] == 0:
-                location_item["startLine"] = 1
-            if "endLine" in location_item and location_item["endLine"] == 0:
-                location_item["endLine"] = 1
-            if "startColumn" in location_item and location_item["startColumn"] == 0:
-                location_item["startColumn"] = 1
-            if "endColumn" in location_item and location_item["endColumn"] == 0:
-                location_item["endColumn"] = 1
-            physical_location[location_key] = location_item
-        return physical_location

--- a/megalinter/utils_sarif.py
+++ b/megalinter/utils_sarif.py
@@ -1,0 +1,196 @@
+import random
+import os
+import json
+import logging
+import re
+from tempfile import mkstemp
+from shutil import move
+from os import fdopen
+
+from json.decoder import JSONDecodeError
+from megalinter import config
+from megalinter.utils_reporter import get_linter_doc_url
+
+
+def normalize_sarif_files(linter):
+    if (
+        linter.sarif_output_file is not None
+        and os.path.isfile(linter.sarif_output_file)
+        and os.path.getsize(linter.sarif_output_file) > 0
+    ):
+        # Read SARIF output file
+
+        load_ok = False
+        with open(linter.sarif_output_file, "r", encoding="utf-8") as linter_sarif_file:
+            # parse sarif file
+            try:
+                linter_sarif_obj = json.load(linter_sarif_file)
+                load_ok = True
+            except JSONDecodeError as e:
+                # JSON decoding error
+                logging.error(
+                    f"[SARIF reporter] ERROR: Unable to decode {linter.name} "
+                    f"SARIF file {linter.sarif_output_file}"
+                )
+                logging.error(str(e))
+                logging.debug(f"SARIF File content:\n{linter_sarif_file.read()}")
+            except Exception as e:  # noqa: E722
+                # Other error
+                logging.error(
+                    f"[SARIF reporter] ERROR: Unknown error with {linter.name} "
+                    f"SARIF file {linter.sarif_output_file}"
+                )
+                logging.error(str(e))
+        if load_ok is True:
+            linter_sarif_obj = fix_sarif(linter_sarif_obj, linter)
+
+            result_json = json.dumps(linter_sarif_obj, sort_keys=True, indent=2)
+
+            with open(linter.sarif_output_file, "w", encoding="utf-8") as sarif_file:
+                sarif_file.write(result_json)
+                logging.info(
+                    f"[SARIF Reporter] Generated {linter.name} report: {linter.sarif_output_file}"
+                )
+
+            # In case SARIF is active, and default workspace is set, clear that from sarif files
+            default_workspace = config.get("DEFAULT_WORKSPACE")
+            if (
+                config.get("SARIF_REPORTER_NORMALIZE_LINTERS_OUTPUT", True) == "true"
+                and default_workspace
+            ):
+                clear_default_workspace_prefix(
+                    linter.sarif_output_file, default_workspace
+                )
+
+
+def clear_default_workspace_prefix(file_path, default_workspace):
+    def_ws_pattern = r'(?P<def_ws_context>\s+"uri"\:\s")' + default_workspace + "/"
+    def_ws_pattern2 = (
+        r'(?P<def_ws_context>\s+"uri"\:\s"file://)' + default_workspace + "/"
+    )
+    def_ws_pattern3 = r'(?P<def_ws_context>\s+")' + default_workspace + "/"
+
+    patterns = [def_ws_pattern, def_ws_pattern2, def_ws_pattern3]
+
+    # Create temp file
+    fh, abs_path = mkstemp()
+    with fdopen(fh, "w") as new_file:
+        with open(file_path) as old_file:
+            for line in old_file:
+                new_line = line
+                matched = False
+                for p in patterns:
+                    match = re.match(p, line)
+
+                    if match:
+                        matched = True
+                        replaced = re.sub(p, match.group("def_ws_context"), line)
+                        new_file.write(replaced)
+
+                if not matched:
+                    new_file.write(new_line)
+    move(abs_path, file_path)
+
+
+# Some SARIF linter output contain errors (like references to line 0)
+# We must correct them so SARIF is valid
+def fix_sarif(linter_sarif_obj, linter):
+    # browse runs
+    if "runs" in linter_sarif_obj:
+        for id_run, run in enumerate(linter_sarif_obj["runs"]):
+            # Add MegaLinter info
+            run_properties = run["properties"] if "properties" in run else {}
+            run_properties["megalinter"] = {
+                "linterKey": linter.name,
+                "docUrl": get_linter_doc_url(linter),
+                "linterVersion": linter.get_linter_version(),
+            }
+            run["properties"] = run_properties
+
+            # Update linter name in case there are duplicates
+            if (
+                "tool" in run
+                and "driver" in run["tool"]
+                and "name" in run["tool"]["driver"]
+                and linter.master.megalinter_flavor
+                != "none"  # single linter image case
+            ):
+                run["tool"]["driver"]["name"] = (
+                    run["tool"]["driver"]["name"] + " (MegaLinter " + linter.name + ")"
+                )
+
+            # fix missing informationUri
+            if (
+                "tool" in run
+                and "driver" in run["tool"]
+                and "informationUri" not in run["tool"]["driver"]
+            ):
+                run["tool"]["driver"]["informationUri"] = get_linter_doc_url(linter)
+
+            # fix missing version
+            if (
+                "tool" in run
+                and "driver" in run["tool"]
+                and "version" not in run["tool"]["driver"]
+            ):
+                run["tool"]["driver"]["version"] = linter.get_linter_version()
+
+            # fix duplicate rules property
+            if (
+                "tool" in run
+                and "driver" in run["tool"]
+                and "rules" in run["tool"]["driver"]
+            ):
+                rules = run["tool"]["driver"]["rules"]
+                rules_updated: list = []
+                for rule in rules:
+                    # If duplicate id, update duplicate items ids with a random value
+                    if "id" in rule and any(
+                        "id" in rule_item and rule_item["id"] == rule["id"]
+                        for rule_item in rules_updated
+                    ):
+                        rule["id"] = (
+                            rule["id"] + "_DUPLICATE_" + str(random.randint(1, 99999))
+                        )
+                    rules_updated += [rule]
+                run["tool"]["driver"]["rules"] = rules_updated
+
+            # fix results property
+            if "results" in run:
+                # browse run results
+                for id_result, result in enumerate(run["results"]):
+                    if "locations" in result:
+                        # browse result locations
+                        for id_location, location in enumerate(result["locations"]):
+                            if "physicalLocation" in location:
+                                location[
+                                    "physicalLocation"
+                                ] = fix_sarif_physical_location(
+                                    location["physicalLocation"]
+                                )
+                            result["locations"][id_location] = location
+
+                    run["results"][id_result] = result
+            else:
+                # make sure that there is a results entry so GitHub's SARIF validator doesn't cry
+                run["results"] = []
+
+            # Update run in full list
+            linter_sarif_obj["runs"][id_run] = run
+    return linter_sarif_obj
+
+
+# Replace startLine and endLine in region or contextRegion
+def fix_sarif_physical_location(physical_location):
+    for location_key in physical_location.keys():
+        location_item = physical_location[location_key]
+        if "startLine" in location_item and location_item["startLine"] == 0:
+            location_item["startLine"] = 1
+        if "endLine" in location_item and location_item["endLine"] == 0:
+            location_item["endLine"] = 1
+        if "startColumn" in location_item and location_item["startColumn"] == 0:
+            location_item["startColumn"] = 1
+        if "endColumn" in location_item and location_item["endColumn"] == 0:
+            location_item["endColumn"] = 1
+        physical_location[location_key] = location_item
+    return physical_location


### PR DESCRIPTION
Fixes #2006 
 
This PR is a suggestion for solving the use case
of needing to remove the DEFAULT_WORKSPACE from
the out put in the generated SARIF output.
(https://github.com/oxsecurity/megalinter/issues/2006).

It moves the SARIF logic to an earlier phase, to be handled before the aggregate SARIF generation.
It replaces the prefix if the flag
SARIF_REPORTER_NORMALIZE_LINTERS_OUTPUT: true is set (default: true)
(see clear_default_workspace_prefix(...

Implementation is done by line parsing and replacing, as a node traversal solution quickly would grew due to
the many places in the sarif out put the uri can be found (metris, relatedLocations, and so on), and the code is much simpler this way to maintain.

Improvements and suggestions:
- Could json dumps() and resulting json string be used in
a reliable way to stream line parse an json file? I didn't find a good way.
- Should the option be renamed to
SARIF_REPORTER_DISABLE_DEFAULT_WORKSPACE_IN_OUTPUT or alike. As the pre existing normalization still happens? (We don't change that pre existing behaviour in this PR, only the DEFAULT_WORKSPACE prefix part).

## Proposed Changes

1. Move the SARIF Logic to an earlier phase 
2. Add optional removal of DEFAULT_WORKSPACE prefix
3. Activated by SARIF_REPORTER_NORMALIZE_LINTERS_OUTPUT

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
