### PR TITLE
Set max-parallel to matrix in jobs

### DIFF
--- a/.github/workflows/deploy-ALPHA-flavors.yml
+++ b/.github/workflows/deploy-ALPHA-flavors.yml
@@ -46,6 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         os: [ubuntu-latest]
         # flavors-start

--- a/.github/workflows/deploy-BETA-flavors.yml
+++ b/.github/workflows/deploy-BETA-flavors.yml
@@ -48,6 +48,7 @@ jobs:
       name: beta-flavors
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         os: [ubuntu-latest]
         # flavors-start

--- a/.github/workflows/deploy-BETA-linters.yml
+++ b/.github/workflows/deploy-BETA-linters.yml
@@ -63,6 +63,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         os: [ubuntu-latest]
         # linters-start

--- a/.github/workflows/deploy-DEV-linters.yml
+++ b/.github/workflows/deploy-DEV-linters.yml
@@ -65,6 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
         os: [ubuntu-latest]
         # linters-start

--- a/.github/workflows/deploy-RELEASE-flavors.yml
+++ b/.github/workflows/deploy-RELEASE-flavors.yml
@@ -38,6 +38,7 @@ jobs:
       name: latest-flavors
     strategy:
       fail-fast: false
+      max-parallel: 6
       matrix:
         os: [ubuntu-latest]
         # flavors-start

--- a/.github/workflows/deploy-RELEASE-linters.yml
+++ b/.github/workflows/deploy-RELEASE-linters.yml
@@ -39,6 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         os: [ubuntu-latest]
         # linters-start


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Should help when we are running out of runners. These are just a naive estimation of what could be useful. We could probably better tune these later easily, if we feel that a certain matrix is too long because of these limits, and that it doesn't end up having too long of a queue in busy (contribution-wise) times.

The branch on my fork was failing for some tests of sfdx

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
