### PR TITLE
fix(pre-commit): corrected pre-commit args for megalinter-full

### DIFF
--- a/.github/linters/.cspell.json
+++ b/.github/linters/.cspell.json
@@ -93,6 +93,7 @@
         "Crefrange",
         "Cres",
         "Csrf",
+        "drbothen",
         "C\u00e9dric",
         "DARTANALYZER",
         "DEVSKIM",

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -36,7 +36,8 @@
   require_serial: true
   args:
     - mega-linter-runner
-    - --containername megalinter-full
+    - --containername 
+    - "megalinter-full"
     - --remove-container
     - --fix
     - --env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Added **cli_lint_fix_arg_name** parameter to **powershell formatter** descriptor as without it, autofix does not work, by @bdovaz in [#2294](https://github.com/oxsecurity/megalinter/pull/2294)
   - Created **ProtolintLinter** class to fix the problem that returns exit code 1 when it encounters a problem to correct even though it corrects it correctly, by @bdovaz in [#2294](https://github.com/oxsecurity/megalinter/pull/2294)
   - Concatenate **--output** parameter correctly to **xmllint** linter, by @bdovaz in [#2294](https://github.com/oxsecurity/megalinter/pull/2294)
+  - Modified the .pre-commit-hooks.yaml for megalinter-full so the containername agument is corrected split between two lines, by @drbothen [#2411](https://github.com/oxsecurity/megalinter/pull/2411)
 
 - Documentation
   - Change **swiftlint** example that did not correctly reflect the **--fix** parameter, by @bdovaz in [#2294](https://github.com/oxsecurity/megalinter/pull/2294)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Added **cli_lint_fix_arg_name** parameter to **powershell formatter** descriptor as without it, autofix does not work, by @bdovaz in [#2294](https://github.com/oxsecurity/megalinter/pull/2294)
   - Created **ProtolintLinter** class to fix the problem that returns exit code 1 when it encounters a problem to correct even though it corrects it correctly, by @bdovaz in [#2294](https://github.com/oxsecurity/megalinter/pull/2294)
   - Concatenate **--output** parameter correctly to **xmllint** linter, by @bdovaz in [#2294](https://github.com/oxsecurity/megalinter/pull/2294)
-  - Modified the .pre-commit-hooks.yaml for megalinter-full so the containername agument is corrected split between two lines, by @drbothen [#2411](https://github.com/oxsecurity/megalinter/pull/2411)
+  - Modified the .pre-commit-hooks.yaml for megalinter-full so the containername argument is correctly split between two lines, by @drbothen [#2411](https://github.com/oxsecurity/megalinter/pull/2411)
 
 - Documentation
   - Change **swiftlint** example that did not correctly reflect the **--fix** parameter, by @bdovaz in [#2294](https://github.com/oxsecurity/megalinter/pull/2294)


### PR DESCRIPTION
containername argument contained both the flag and value on the same line. These have to be on a separate line

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

This corrects an error with the use of pre-commit with megalinter-full. An error would return about not having a specified container name.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1.  Modified .pre-commit-hooks.yaml megalinter-full args containername to match magalinter-megalinter-incremental

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
