### PR TITLE
Fix npm permissions in v6.20.0

### DIFF
--- a/.automation/build.py
+++ b/.automation/build.py
@@ -470,7 +470,7 @@ def build_dockerfile(
     if len(npm_packages) > 0:
         npm_install_command = (
             "WORKDIR /node-deps\n"
-            + "RUN npm --no-cache install --force --ignore-scripts \\\n                "
+            + "RUN npm --no-cache install --force --ignore-scripts --production \\\n                "
             + " \\\n                ".join(list(dict.fromkeys(npm_packages)))
             + " && \\\n"
             + "    npm doctor || true \\\n"

--- a/.automation/build.py
+++ b/.automation/build.py
@@ -470,7 +470,7 @@ def build_dockerfile(
     if len(npm_packages) > 0:
         npm_install_command = (
             "WORKDIR /node-deps\n"
-            + "RUN npm --no-cache install --force --ignore-scripts --production \\\n                "
+            + "RUN npm --no-cache install --ignore-scripts --omit=dev \\\n                "
             + " \\\n                ".join(list(dict.fromkeys(npm_packages)))
             + " && \\\n"
             + "    npm doctor || true \\\n"

--- a/.automation/build.py
+++ b/.automation/build.py
@@ -474,7 +474,7 @@ def build_dockerfile(
             + " \\\n                ".join(list(dict.fromkeys(npm_packages)))
             + " && \\\n"
             + "    && npm doctor || true \\\n"
-            + "    npm audit fix --audit-level=critical || true \\\n"
+            + "    && npm audit fix --audit-level=critical || true \\\n"
             + "    && npm cache clean --force || true \\\n"
             + "    && rm -rf /root/.npm/_cacache \\\n"
             + '    && find . -name "*.d.ts" -delete \\\n'

--- a/.automation/build.py
+++ b/.automation/build.py
@@ -473,7 +473,7 @@ def build_dockerfile(
             + "RUN npm --no-cache install --force --ignore-scripts \\\n                "
             + " \\\n                ".join(list(dict.fromkeys(npm_packages)))
             + " && \\\n"
-            + "    && npm doctor || true \\\n"
+            + "    npm doctor || true \\\n"
             + "    && npm audit fix --audit-level=critical || true \\\n"
             + "    && npm cache clean --force || true \\\n"
             + "    && rm -rf /root/.npm/_cacache \\\n"

--- a/.automation/build.py
+++ b/.automation/build.py
@@ -473,6 +473,7 @@ def build_dockerfile(
             + "RUN npm --no-cache install --force --ignore-scripts \\\n                "
             + " \\\n                ".join(list(dict.fromkeys(npm_packages)))
             + " && \\\n"
+            + "    && npm doctor || true \\\n"
             + "    npm audit fix --audit-level=critical || true \\\n"
             + "    && npm cache clean --force || true \\\n"
             + "    && rm -rf /root/.npm/_cacache \\\n"

--- a/Dockerfile
+++ b/Dockerfile
@@ -240,7 +240,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 @typescript-eslint/eslint-plugin \
                 @typescript-eslint/parser && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/Dockerfile
+++ b/Dockerfile
@@ -189,14 +189,13 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 sfdx-cli \
                 typescript \
                 @coffeelint/cli \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \
-                stylelint-config-sass-guidelines \
                 stylelint-scss \
                 gherkin-lint \
                 graphql \

--- a/Dockerfile
+++ b/Dockerfile
@@ -239,7 +239,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 prettyjson \
                 @typescript-eslint/eslint-plugin \
                 @typescript-eslint/parser && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -189,7 +189,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 sfdx-cli \
                 typescript \
                 @coffeelint/cli \

--- a/Dockerfile
+++ b/Dockerfile
@@ -239,6 +239,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 prettyjson \
                 @typescript-eslint/eslint-plugin \
                 @typescript-eslint/parser && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/ci_light/Dockerfile
+++ b/flavors/ci_light/Dockerfile
@@ -103,7 +103,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
                 npm-groovy-lint \
                 @prantlf/jsonlint \

--- a/flavors/ci_light/Dockerfile
+++ b/flavors/ci_light/Dockerfile
@@ -103,7 +103,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 jscpd \
                 npm-groovy-lint \
                 @prantlf/jsonlint \

--- a/flavors/ci_light/Dockerfile
+++ b/flavors/ci_light/Dockerfile
@@ -115,7 +115,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 secretlint \
                 @secretlint/secretlint-rule-preset-recommend \
                 @secretlint/secretlint-formatter-sarif && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/ci_light/Dockerfile
+++ b/flavors/ci_light/Dockerfile
@@ -115,6 +115,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 secretlint \
                 @secretlint/secretlint-rule-preset-recommend \
                 @secretlint/secretlint-formatter-sarif && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/ci_light/Dockerfile
+++ b/flavors/ci_light/Dockerfile
@@ -116,7 +116,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 @secretlint/secretlint-rule-preset-recommend \
                 @secretlint/secretlint-formatter-sarif && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/flavors/cupcake/Dockerfile
+++ b/flavors/cupcake/Dockerfile
@@ -154,12 +154,11 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 typescript \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \
-                stylelint-config-sass-guidelines \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/cupcake/Dockerfile
+++ b/flavors/cupcake/Dockerfile
@@ -199,6 +199,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 prettyjson \
                 @typescript-eslint/eslint-plugin \
                 @typescript-eslint/parser && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/cupcake/Dockerfile
+++ b/flavors/cupcake/Dockerfile
@@ -154,7 +154,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 typescript \
                 jscpd \
                 stylelint \

--- a/flavors/cupcake/Dockerfile
+++ b/flavors/cupcake/Dockerfile
@@ -200,7 +200,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 @typescript-eslint/eslint-plugin \
                 @typescript-eslint/parser && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/flavors/cupcake/Dockerfile
+++ b/flavors/cupcake/Dockerfile
@@ -199,7 +199,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 prettyjson \
                 @typescript-eslint/eslint-plugin \
                 @typescript-eslint/parser && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/documentation/Dockerfile
+++ b/flavors/documentation/Dockerfile
@@ -119,7 +119,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \

--- a/flavors/documentation/Dockerfile
+++ b/flavors/documentation/Dockerfile
@@ -119,11 +119,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \
-                stylelint-config-sass-guidelines \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/documentation/Dockerfile
+++ b/flavors/documentation/Dockerfile
@@ -145,7 +145,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/documentation/Dockerfile
+++ b/flavors/documentation/Dockerfile
@@ -146,7 +146,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 sql-lint \
                 tekton-lint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/flavors/documentation/Dockerfile
+++ b/flavors/documentation/Dockerfile
@@ -145,6 +145,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/dotnet/Dockerfile
+++ b/flavors/dotnet/Dockerfile
@@ -136,11 +136,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \
-                stylelint-config-sass-guidelines \
                 stylelint-scss \
                 gherkin-lint \
                 graphql \

--- a/flavors/dotnet/Dockerfile
+++ b/flavors/dotnet/Dockerfile
@@ -136,7 +136,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \

--- a/flavors/dotnet/Dockerfile
+++ b/flavors/dotnet/Dockerfile
@@ -165,7 +165,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/dotnet/Dockerfile
+++ b/flavors/dotnet/Dockerfile
@@ -165,6 +165,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/dotnet/Dockerfile
+++ b/flavors/dotnet/Dockerfile
@@ -166,7 +166,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 sql-lint \
                 tekton-lint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/flavors/go/Dockerfile
+++ b/flavors/go/Dockerfile
@@ -126,7 +126,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \

--- a/flavors/go/Dockerfile
+++ b/flavors/go/Dockerfile
@@ -152,6 +152,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/go/Dockerfile
+++ b/flavors/go/Dockerfile
@@ -152,7 +152,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/go/Dockerfile
+++ b/flavors/go/Dockerfile
@@ -153,7 +153,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 sql-lint \
                 tekton-lint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/flavors/go/Dockerfile
+++ b/flavors/go/Dockerfile
@@ -126,11 +126,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \
-                stylelint-config-sass-guidelines \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/java/Dockerfile
+++ b/flavors/java/Dockerfile
@@ -119,7 +119,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \

--- a/flavors/java/Dockerfile
+++ b/flavors/java/Dockerfile
@@ -119,11 +119,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \
-                stylelint-config-sass-guidelines \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/java/Dockerfile
+++ b/flavors/java/Dockerfile
@@ -145,7 +145,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/java/Dockerfile
+++ b/flavors/java/Dockerfile
@@ -146,7 +146,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 sql-lint \
                 tekton-lint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/flavors/java/Dockerfile
+++ b/flavors/java/Dockerfile
@@ -145,6 +145,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/javascript/Dockerfile
+++ b/flavors/javascript/Dockerfile
@@ -167,7 +167,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 @typescript-eslint/eslint-plugin \
                 @typescript-eslint/parser && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/flavors/javascript/Dockerfile
+++ b/flavors/javascript/Dockerfile
@@ -118,13 +118,12 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 typescript \
                 @coffeelint/cli \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \
-                stylelint-config-sass-guidelines \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/javascript/Dockerfile
+++ b/flavors/javascript/Dockerfile
@@ -166,7 +166,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 prettyjson \
                 @typescript-eslint/eslint-plugin \
                 @typescript-eslint/parser && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/javascript/Dockerfile
+++ b/flavors/javascript/Dockerfile
@@ -166,6 +166,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 prettyjson \
                 @typescript-eslint/eslint-plugin \
                 @typescript-eslint/parser && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/javascript/Dockerfile
+++ b/flavors/javascript/Dockerfile
@@ -118,7 +118,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 typescript \
                 @coffeelint/cli \
                 jscpd \

--- a/flavors/php/Dockerfile
+++ b/flavors/php/Dockerfile
@@ -156,6 +156,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/php/Dockerfile
+++ b/flavors/php/Dockerfile
@@ -156,7 +156,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/php/Dockerfile
+++ b/flavors/php/Dockerfile
@@ -130,7 +130,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \

--- a/flavors/php/Dockerfile
+++ b/flavors/php/Dockerfile
@@ -130,11 +130,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \
-                stylelint-config-sass-guidelines \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/php/Dockerfile
+++ b/flavors/php/Dockerfile
@@ -157,7 +157,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 sql-lint \
                 tekton-lint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/flavors/python/Dockerfile
+++ b/flavors/python/Dockerfile
@@ -129,7 +129,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \

--- a/flavors/python/Dockerfile
+++ b/flavors/python/Dockerfile
@@ -155,6 +155,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/python/Dockerfile
+++ b/flavors/python/Dockerfile
@@ -156,7 +156,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 sql-lint \
                 tekton-lint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/flavors/python/Dockerfile
+++ b/flavors/python/Dockerfile
@@ -155,7 +155,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/python/Dockerfile
+++ b/flavors/python/Dockerfile
@@ -129,11 +129,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \
-                stylelint-config-sass-guidelines \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/ruby/Dockerfile
+++ b/flavors/ruby/Dockerfile
@@ -145,7 +145,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 sql-lint \
                 tekton-lint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/flavors/ruby/Dockerfile
+++ b/flavors/ruby/Dockerfile
@@ -118,7 +118,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \

--- a/flavors/ruby/Dockerfile
+++ b/flavors/ruby/Dockerfile
@@ -144,7 +144,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/ruby/Dockerfile
+++ b/flavors/ruby/Dockerfile
@@ -144,6 +144,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/ruby/Dockerfile
+++ b/flavors/ruby/Dockerfile
@@ -118,11 +118,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \
-                stylelint-config-sass-guidelines \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/rust/Dockerfile
+++ b/flavors/rust/Dockerfile
@@ -145,7 +145,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 sql-lint \
                 tekton-lint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/flavors/rust/Dockerfile
+++ b/flavors/rust/Dockerfile
@@ -118,7 +118,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \

--- a/flavors/rust/Dockerfile
+++ b/flavors/rust/Dockerfile
@@ -144,7 +144,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/rust/Dockerfile
+++ b/flavors/rust/Dockerfile
@@ -144,6 +144,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/rust/Dockerfile
+++ b/flavors/rust/Dockerfile
@@ -118,11 +118,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \
-                stylelint-config-sass-guidelines \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/salesforce/Dockerfile
+++ b/flavors/salesforce/Dockerfile
@@ -147,6 +147,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/salesforce/Dockerfile
+++ b/flavors/salesforce/Dockerfile
@@ -148,7 +148,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 sql-lint \
                 tekton-lint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/flavors/salesforce/Dockerfile
+++ b/flavors/salesforce/Dockerfile
@@ -118,12 +118,11 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 sfdx-cli \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \
-                stylelint-config-sass-guidelines \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/salesforce/Dockerfile
+++ b/flavors/salesforce/Dockerfile
@@ -118,7 +118,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 sfdx-cli \
                 jscpd \
                 stylelint \

--- a/flavors/salesforce/Dockerfile
+++ b/flavors/salesforce/Dockerfile
@@ -147,7 +147,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/security/Dockerfile
+++ b/flavors/security/Dockerfile
@@ -110,7 +110,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 secretlint \
                 @secretlint/secretlint-rule-preset-recommend \
                 @secretlint/secretlint-formatter-sarif && \

--- a/flavors/security/Dockerfile
+++ b/flavors/security/Dockerfile
@@ -114,6 +114,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 secretlint \
                 @secretlint/secretlint-rule-preset-recommend \
                 @secretlint/secretlint-formatter-sarif && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/security/Dockerfile
+++ b/flavors/security/Dockerfile
@@ -114,7 +114,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 secretlint \
                 @secretlint/secretlint-rule-preset-recommend \
                 @secretlint/secretlint-formatter-sarif && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/security/Dockerfile
+++ b/flavors/security/Dockerfile
@@ -110,7 +110,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 secretlint \
                 @secretlint/secretlint-rule-preset-recommend \
                 @secretlint/secretlint-formatter-sarif && \

--- a/flavors/security/Dockerfile
+++ b/flavors/security/Dockerfile
@@ -115,7 +115,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 @secretlint/secretlint-rule-preset-recommend \
                 @secretlint/secretlint-formatter-sarif && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/flavors/swift/Dockerfile
+++ b/flavors/swift/Dockerfile
@@ -120,11 +120,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \
-                stylelint-config-sass-guidelines \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/swift/Dockerfile
+++ b/flavors/swift/Dockerfile
@@ -146,6 +146,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/swift/Dockerfile
+++ b/flavors/swift/Dockerfile
@@ -147,7 +147,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 sql-lint \
                 tekton-lint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/flavors/swift/Dockerfile
+++ b/flavors/swift/Dockerfile
@@ -120,7 +120,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \

--- a/flavors/swift/Dockerfile
+++ b/flavors/swift/Dockerfile
@@ -146,7 +146,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/terraform/Dockerfile
+++ b/flavors/terraform/Dockerfile
@@ -124,7 +124,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \

--- a/flavors/terraform/Dockerfile
+++ b/flavors/terraform/Dockerfile
@@ -150,6 +150,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/flavors/terraform/Dockerfile
+++ b/flavors/terraform/Dockerfile
@@ -124,11 +124,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
                 stylelint \
                 stylelint-config-standard \
-                stylelint-config-sass-guidelines \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/terraform/Dockerfile
+++ b/flavors/terraform/Dockerfile
@@ -151,7 +151,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 sql-lint \
                 tekton-lint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/flavors/terraform/Dockerfile
+++ b/flavors/terraform/Dockerfile
@@ -150,7 +150,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 cspell \
                 sql-lint \
                 tekton-lint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/coffee_coffeelint/Dockerfile
+++ b/linters/coffee_coffeelint/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 @coffeelint/cli && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/coffee_coffeelint/Dockerfile
+++ b/linters/coffee_coffeelint/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 @coffeelint/cli && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/coffee_coffeelint/Dockerfile
+++ b/linters/coffee_coffeelint/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 @coffeelint/cli && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/coffee_coffeelint/Dockerfile
+++ b/linters/coffee_coffeelint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 @coffeelint/cli && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/coffee_coffeelint/Dockerfile
+++ b/linters/coffee_coffeelint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 @coffeelint/cli && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/copypaste_jscpd/Dockerfile
+++ b/linters/copypaste_jscpd/Dockerfile
@@ -86,7 +86,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/copypaste_jscpd/Dockerfile
+++ b/linters/copypaste_jscpd/Dockerfile
@@ -88,7 +88,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 jscpd && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/copypaste_jscpd/Dockerfile
+++ b/linters/copypaste_jscpd/Dockerfile
@@ -89,7 +89,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 jscpd && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/copypaste_jscpd/Dockerfile
+++ b/linters/copypaste_jscpd/Dockerfile
@@ -88,6 +88,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 jscpd && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/copypaste_jscpd/Dockerfile
+++ b/linters/copypaste_jscpd/Dockerfile
@@ -86,7 +86,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 jscpd && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/css_stylelint/Dockerfile
+++ b/linters/css_stylelint/Dockerfile
@@ -91,7 +91,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 stylelint-config-sass-guidelines \
                 stylelint-scss && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/css_stylelint/Dockerfile
+++ b/linters/css_stylelint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 stylelint \
                 stylelint-config-standard \
                 stylelint-config-sass-guidelines \

--- a/linters/css_stylelint/Dockerfile
+++ b/linters/css_stylelint/Dockerfile
@@ -90,6 +90,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 stylelint-config-standard \
                 stylelint-config-sass-guidelines \
                 stylelint-scss && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/css_stylelint/Dockerfile
+++ b/linters/css_stylelint/Dockerfile
@@ -90,7 +90,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 stylelint-config-standard \
                 stylelint-config-sass-guidelines \
                 stylelint-scss && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/css_stylelint/Dockerfile
+++ b/linters/css_stylelint/Dockerfile
@@ -85,10 +85,9 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 stylelint \
                 stylelint-config-standard \
-                stylelint-config-sass-guidelines \
                 stylelint-scss && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/gherkin_gherkin_lint/Dockerfile
+++ b/linters/gherkin_gherkin_lint/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 gherkin-lint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/gherkin_gherkin_lint/Dockerfile
+++ b/linters/gherkin_gherkin_lint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 gherkin-lint && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/gherkin_gherkin_lint/Dockerfile
+++ b/linters/gherkin_gherkin_lint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 gherkin-lint && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/gherkin_gherkin_lint/Dockerfile
+++ b/linters/gherkin_gherkin_lint/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 gherkin-lint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/gherkin_gherkin_lint/Dockerfile
+++ b/linters/gherkin_gherkin_lint/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 gherkin-lint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/graphql_graphql_schema_linter/Dockerfile
+++ b/linters/graphql_graphql_schema_linter/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 graphql \
                 graphql-schema-linter && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/graphql_graphql_schema_linter/Dockerfile
+++ b/linters/graphql_graphql_schema_linter/Dockerfile
@@ -89,7 +89,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 graphql \
                 graphql-schema-linter && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/graphql_graphql_schema_linter/Dockerfile
+++ b/linters/graphql_graphql_schema_linter/Dockerfile
@@ -88,6 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 graphql \
                 graphql-schema-linter && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/graphql_graphql_schema_linter/Dockerfile
+++ b/linters/graphql_graphql_schema_linter/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 graphql \
                 graphql-schema-linter && \
     npm doctor || true \

--- a/linters/graphql_graphql_schema_linter/Dockerfile
+++ b/linters/graphql_graphql_schema_linter/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 graphql \
                 graphql-schema-linter && \
     npm doctor || true \

--- a/linters/groovy_npm_groovy_lint/Dockerfile
+++ b/linters/groovy_npm_groovy_lint/Dockerfile
@@ -88,7 +88,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 npm-groovy-lint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/groovy_npm_groovy_lint/Dockerfile
+++ b/linters/groovy_npm_groovy_lint/Dockerfile
@@ -86,7 +86,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 npm-groovy-lint && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/groovy_npm_groovy_lint/Dockerfile
+++ b/linters/groovy_npm_groovy_lint/Dockerfile
@@ -88,6 +88,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 npm-groovy-lint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/groovy_npm_groovy_lint/Dockerfile
+++ b/linters/groovy_npm_groovy_lint/Dockerfile
@@ -89,7 +89,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 npm-groovy-lint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/groovy_npm_groovy_lint/Dockerfile
+++ b/linters/groovy_npm_groovy_lint/Dockerfile
@@ -86,7 +86,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 npm-groovy-lint && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/html_htmlhint/Dockerfile
+++ b/linters/html_htmlhint/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 htmlhint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/html_htmlhint/Dockerfile
+++ b/linters/html_htmlhint/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 htmlhint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/html_htmlhint/Dockerfile
+++ b/linters/html_htmlhint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 htmlhint && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/html_htmlhint/Dockerfile
+++ b/linters/html_htmlhint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 htmlhint && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/html_htmlhint/Dockerfile
+++ b/linters/html_htmlhint/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 htmlhint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/javascript_es/Dockerfile
+++ b/linters/javascript_es/Dockerfile
@@ -100,6 +100,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 @babel/core \
                 @babel/eslint-parser \
                 @microsoft/eslint-formatter-sarif && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/javascript_es/Dockerfile
+++ b/linters/javascript_es/Dockerfile
@@ -101,7 +101,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 @babel/eslint-parser \
                 @microsoft/eslint-formatter-sarif && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/javascript_es/Dockerfile
+++ b/linters/javascript_es/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 eslint \
                 eslint-config-airbnb \
                 eslint-config-prettier \

--- a/linters/javascript_es/Dockerfile
+++ b/linters/javascript_es/Dockerfile
@@ -100,7 +100,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 @babel/core \
                 @babel/eslint-parser \
                 @microsoft/eslint-formatter-sarif && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/javascript_es/Dockerfile
+++ b/linters/javascript_es/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 eslint \
                 eslint-config-airbnb \
                 eslint-config-prettier \

--- a/linters/javascript_prettier/Dockerfile
+++ b/linters/javascript_prettier/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 prettier && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/javascript_prettier/Dockerfile
+++ b/linters/javascript_prettier/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 prettier && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/javascript_prettier/Dockerfile
+++ b/linters/javascript_prettier/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 prettier && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/javascript_prettier/Dockerfile
+++ b/linters/javascript_prettier/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 prettier && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/javascript_prettier/Dockerfile
+++ b/linters/javascript_prettier/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 prettier && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/javascript_standard/Dockerfile
+++ b/linters/javascript_standard/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 standard && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/javascript_standard/Dockerfile
+++ b/linters/javascript_standard/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 standard && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/javascript_standard/Dockerfile
+++ b/linters/javascript_standard/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 standard && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/javascript_standard/Dockerfile
+++ b/linters/javascript_standard/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 standard && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/javascript_standard/Dockerfile
+++ b/linters/javascript_standard/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 standard && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/json_eslint_plugin_jsonc/Dockerfile
+++ b/linters/json_eslint_plugin_jsonc/Dockerfile
@@ -89,6 +89,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 eslint \
                 eslint-plugin-jsonc \
                 @microsoft/eslint-formatter-sarif && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/json_eslint_plugin_jsonc/Dockerfile
+++ b/linters/json_eslint_plugin_jsonc/Dockerfile
@@ -90,7 +90,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 eslint-plugin-jsonc \
                 @microsoft/eslint-formatter-sarif && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/json_eslint_plugin_jsonc/Dockerfile
+++ b/linters/json_eslint_plugin_jsonc/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 eslint \
                 eslint-plugin-jsonc \
                 @microsoft/eslint-formatter-sarif && \

--- a/linters/json_eslint_plugin_jsonc/Dockerfile
+++ b/linters/json_eslint_plugin_jsonc/Dockerfile
@@ -89,7 +89,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 eslint \
                 eslint-plugin-jsonc \
                 @microsoft/eslint-formatter-sarif && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/json_eslint_plugin_jsonc/Dockerfile
+++ b/linters/json_eslint_plugin_jsonc/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 eslint \
                 eslint-plugin-jsonc \
                 @microsoft/eslint-formatter-sarif && \

--- a/linters/json_jsonlint/Dockerfile
+++ b/linters/json_jsonlint/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 @prantlf/jsonlint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/json_jsonlint/Dockerfile
+++ b/linters/json_jsonlint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 @prantlf/jsonlint && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/json_jsonlint/Dockerfile
+++ b/linters/json_jsonlint/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 @prantlf/jsonlint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/json_jsonlint/Dockerfile
+++ b/linters/json_jsonlint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 @prantlf/jsonlint && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/json_jsonlint/Dockerfile
+++ b/linters/json_jsonlint/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 @prantlf/jsonlint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/json_npm_package_json_lint/Dockerfile
+++ b/linters/json_npm_package_json_lint/Dockerfile
@@ -89,7 +89,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 npm-package-json-lint \
                 npm-package-json-lint-config-default && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/json_npm_package_json_lint/Dockerfile
+++ b/linters/json_npm_package_json_lint/Dockerfile
@@ -88,6 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 npm-package-json-lint \
                 npm-package-json-lint-config-default && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/json_npm_package_json_lint/Dockerfile
+++ b/linters/json_npm_package_json_lint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 npm-package-json-lint \
                 npm-package-json-lint-config-default && \
     npm doctor || true \

--- a/linters/json_npm_package_json_lint/Dockerfile
+++ b/linters/json_npm_package_json_lint/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 npm-package-json-lint \
                 npm-package-json-lint-config-default && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/json_npm_package_json_lint/Dockerfile
+++ b/linters/json_npm_package_json_lint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 npm-package-json-lint \
                 npm-package-json-lint-config-default && \
     npm doctor || true \

--- a/linters/json_prettier/Dockerfile
+++ b/linters/json_prettier/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 prettier && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/json_prettier/Dockerfile
+++ b/linters/json_prettier/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 prettier && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/json_prettier/Dockerfile
+++ b/linters/json_prettier/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 prettier && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/json_prettier/Dockerfile
+++ b/linters/json_prettier/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 prettier && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/json_prettier/Dockerfile
+++ b/linters/json_prettier/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 prettier && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/json_v8r/Dockerfile
+++ b/linters/json_v8r/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 v8r && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/json_v8r/Dockerfile
+++ b/linters/json_v8r/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 v8r && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/json_v8r/Dockerfile
+++ b/linters/json_v8r/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 v8r && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/json_v8r/Dockerfile
+++ b/linters/json_v8r/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 v8r && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/json_v8r/Dockerfile
+++ b/linters/json_v8r/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 v8r && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/jsx_eslint/Dockerfile
+++ b/linters/jsx_eslint/Dockerfile
@@ -91,7 +91,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 eslint-plugin-jsx-a11y \
                 @microsoft/eslint-formatter-sarif && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/jsx_eslint/Dockerfile
+++ b/linters/jsx_eslint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 eslint \
                 eslint-plugin-react \
                 eslint-plugin-jsx-a11y \

--- a/linters/jsx_eslint/Dockerfile
+++ b/linters/jsx_eslint/Dockerfile
@@ -90,7 +90,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 eslint-plugin-react \
                 eslint-plugin-jsx-a11y \
                 @microsoft/eslint-formatter-sarif && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/jsx_eslint/Dockerfile
+++ b/linters/jsx_eslint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 eslint \
                 eslint-plugin-react \
                 eslint-plugin-jsx-a11y \

--- a/linters/jsx_eslint/Dockerfile
+++ b/linters/jsx_eslint/Dockerfile
@@ -90,6 +90,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 eslint-plugin-react \
                 eslint-plugin-jsx-a11y \
                 @microsoft/eslint-formatter-sarif && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/markdown_markdown_link_check/Dockerfile
+++ b/linters/markdown_markdown_link_check/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 markdown-link-check && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/markdown_markdown_link_check/Dockerfile
+++ b/linters/markdown_markdown_link_check/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 markdown-link-check && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/markdown_markdown_link_check/Dockerfile
+++ b/linters/markdown_markdown_link_check/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 markdown-link-check && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/markdown_markdown_link_check/Dockerfile
+++ b/linters/markdown_markdown_link_check/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 markdown-link-check && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/markdown_markdown_link_check/Dockerfile
+++ b/linters/markdown_markdown_link_check/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 markdown-link-check && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/markdown_markdown_table_formatter/Dockerfile
+++ b/linters/markdown_markdown_table_formatter/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 markdown-table-formatter && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/markdown_markdown_table_formatter/Dockerfile
+++ b/linters/markdown_markdown_table_formatter/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 markdown-table-formatter && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/markdown_markdown_table_formatter/Dockerfile
+++ b/linters/markdown_markdown_table_formatter/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 markdown-table-formatter && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/markdown_markdown_table_formatter/Dockerfile
+++ b/linters/markdown_markdown_table_formatter/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 markdown-table-formatter && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/markdown_markdown_table_formatter/Dockerfile
+++ b/linters/markdown_markdown_table_formatter/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 markdown-table-formatter && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/markdown_markdownlint/Dockerfile
+++ b/linters/markdown_markdownlint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 markdownlint-cli && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/markdown_markdownlint/Dockerfile
+++ b/linters/markdown_markdownlint/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 markdownlint-cli && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/markdown_markdownlint/Dockerfile
+++ b/linters/markdown_markdownlint/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 markdownlint-cli && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/markdown_markdownlint/Dockerfile
+++ b/linters/markdown_markdownlint/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 markdownlint-cli && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/markdown_markdownlint/Dockerfile
+++ b/linters/markdown_markdownlint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 markdownlint-cli && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/markdown_remark_lint/Dockerfile
+++ b/linters/markdown_remark_lint/Dockerfile
@@ -88,6 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 remark-cli \
                 remark-preset-lint-recommended && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/markdown_remark_lint/Dockerfile
+++ b/linters/markdown_remark_lint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 remark-cli \
                 remark-preset-lint-recommended && \
     npm doctor || true \

--- a/linters/markdown_remark_lint/Dockerfile
+++ b/linters/markdown_remark_lint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 remark-cli \
                 remark-preset-lint-recommended && \
     npm doctor || true \

--- a/linters/markdown_remark_lint/Dockerfile
+++ b/linters/markdown_remark_lint/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 remark-cli \
                 remark-preset-lint-recommended && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/markdown_remark_lint/Dockerfile
+++ b/linters/markdown_remark_lint/Dockerfile
@@ -89,7 +89,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 remark-cli \
                 remark-preset-lint-recommended && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/openapi_spectral/Dockerfile
+++ b/linters/openapi_spectral/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 @stoplight/spectral-cli && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/openapi_spectral/Dockerfile
+++ b/linters/openapi_spectral/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 @stoplight/spectral-cli && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/openapi_spectral/Dockerfile
+++ b/linters/openapi_spectral/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 @stoplight/spectral-cli && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/openapi_spectral/Dockerfile
+++ b/linters/openapi_spectral/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 @stoplight/spectral-cli && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/openapi_spectral/Dockerfile
+++ b/linters/openapi_spectral/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 @stoplight/spectral-cli && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/repository_secretlint/Dockerfile
+++ b/linters/repository_secretlint/Dockerfile
@@ -89,6 +89,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 secretlint \
                 @secretlint/secretlint-rule-preset-recommend \
                 @secretlint/secretlint-formatter-sarif && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/repository_secretlint/Dockerfile
+++ b/linters/repository_secretlint/Dockerfile
@@ -90,7 +90,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 @secretlint/secretlint-rule-preset-recommend \
                 @secretlint/secretlint-formatter-sarif && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/repository_secretlint/Dockerfile
+++ b/linters/repository_secretlint/Dockerfile
@@ -89,7 +89,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 secretlint \
                 @secretlint/secretlint-rule-preset-recommend \
                 @secretlint/secretlint-formatter-sarif && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/repository_secretlint/Dockerfile
+++ b/linters/repository_secretlint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 secretlint \
                 @secretlint/secretlint-rule-preset-recommend \
                 @secretlint/secretlint-formatter-sarif && \

--- a/linters/repository_secretlint/Dockerfile
+++ b/linters/repository_secretlint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 secretlint \
                 @secretlint/secretlint-rule-preset-recommend \
                 @secretlint/secretlint-formatter-sarif && \

--- a/linters/salesforce_sfdx_scanner_apex/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_apex/Dockerfile
@@ -86,7 +86,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 sfdx-cli && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/salesforce_sfdx_scanner_apex/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_apex/Dockerfile
@@ -88,6 +88,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 sfdx-cli && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/salesforce_sfdx_scanner_apex/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_apex/Dockerfile
@@ -86,7 +86,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 sfdx-cli && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/salesforce_sfdx_scanner_apex/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_apex/Dockerfile
@@ -88,7 +88,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 sfdx-cli && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/salesforce_sfdx_scanner_apex/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_apex/Dockerfile
@@ -89,7 +89,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 sfdx-cli && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/salesforce_sfdx_scanner_aura/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_aura/Dockerfile
@@ -86,7 +86,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 sfdx-cli && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/salesforce_sfdx_scanner_aura/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_aura/Dockerfile
@@ -88,6 +88,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 sfdx-cli && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/salesforce_sfdx_scanner_aura/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_aura/Dockerfile
@@ -86,7 +86,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 sfdx-cli && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/salesforce_sfdx_scanner_aura/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_aura/Dockerfile
@@ -88,7 +88,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 sfdx-cli && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/salesforce_sfdx_scanner_aura/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_aura/Dockerfile
@@ -89,7 +89,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 sfdx-cli && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/salesforce_sfdx_scanner_lwc/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_lwc/Dockerfile
@@ -86,7 +86,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 sfdx-cli && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/salesforce_sfdx_scanner_lwc/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_lwc/Dockerfile
@@ -88,6 +88,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 sfdx-cli && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/salesforce_sfdx_scanner_lwc/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_lwc/Dockerfile
@@ -86,7 +86,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 sfdx-cli && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/salesforce_sfdx_scanner_lwc/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_lwc/Dockerfile
@@ -88,7 +88,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 sfdx-cli && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/salesforce_sfdx_scanner_lwc/Dockerfile
+++ b/linters/salesforce_sfdx_scanner_lwc/Dockerfile
@@ -89,7 +89,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 sfdx-cli && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/spell_cspell/Dockerfile
+++ b/linters/spell_cspell/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 cspell && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/spell_cspell/Dockerfile
+++ b/linters/spell_cspell/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 cspell && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/spell_cspell/Dockerfile
+++ b/linters/spell_cspell/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 cspell && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/spell_cspell/Dockerfile
+++ b/linters/spell_cspell/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 cspell && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/spell_cspell/Dockerfile
+++ b/linters/spell_cspell/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 cspell && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/sql_sql_lint/Dockerfile
+++ b/linters/sql_sql_lint/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 sql-lint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/sql_sql_lint/Dockerfile
+++ b/linters/sql_sql_lint/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 sql-lint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/sql_sql_lint/Dockerfile
+++ b/linters/sql_sql_lint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 sql-lint && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/sql_sql_lint/Dockerfile
+++ b/linters/sql_sql_lint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 sql-lint && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/sql_sql_lint/Dockerfile
+++ b/linters/sql_sql_lint/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 sql-lint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/tekton_tekton_lint/Dockerfile
+++ b/linters/tekton_tekton_lint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 tekton-lint && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/tekton_tekton_lint/Dockerfile
+++ b/linters/tekton_tekton_lint/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 tekton-lint && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/tekton_tekton_lint/Dockerfile
+++ b/linters/tekton_tekton_lint/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 tekton-lint && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/tekton_tekton_lint/Dockerfile
+++ b/linters/tekton_tekton_lint/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 tekton-lint && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/tekton_tekton_lint/Dockerfile
+++ b/linters/tekton_tekton_lint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 tekton-lint && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/tsx_eslint/Dockerfile
+++ b/linters/tsx_eslint/Dockerfile
@@ -99,7 +99,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 @typescript-eslint/eslint-plugin \
                 @typescript-eslint/parser \
                 @microsoft/eslint-formatter-sarif && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/tsx_eslint/Dockerfile
+++ b/linters/tsx_eslint/Dockerfile
@@ -100,7 +100,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 @typescript-eslint/parser \
                 @microsoft/eslint-formatter-sarif && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/tsx_eslint/Dockerfile
+++ b/linters/tsx_eslint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 typescript \
                 eslint \
                 eslint-config-airbnb \

--- a/linters/tsx_eslint/Dockerfile
+++ b/linters/tsx_eslint/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 typescript \
                 eslint \
                 eslint-config-airbnb \

--- a/linters/tsx_eslint/Dockerfile
+++ b/linters/tsx_eslint/Dockerfile
@@ -99,6 +99,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 @typescript-eslint/eslint-plugin \
                 @typescript-eslint/parser \
                 @microsoft/eslint-formatter-sarif && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/typescript_es/Dockerfile
+++ b/linters/typescript_es/Dockerfile
@@ -102,6 +102,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 @typescript-eslint/eslint-plugin \
                 @typescript-eslint/parser \
                 @microsoft/eslint-formatter-sarif && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/typescript_es/Dockerfile
+++ b/linters/typescript_es/Dockerfile
@@ -103,7 +103,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 @typescript-eslint/parser \
                 @microsoft/eslint-formatter-sarif && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/typescript_es/Dockerfile
+++ b/linters/typescript_es/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 typescript \
                 eslint \
                 eslint-config-airbnb \

--- a/linters/typescript_es/Dockerfile
+++ b/linters/typescript_es/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 typescript \
                 eslint \
                 eslint-config-airbnb \

--- a/linters/typescript_es/Dockerfile
+++ b/linters/typescript_es/Dockerfile
@@ -102,7 +102,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 @typescript-eslint/eslint-plugin \
                 @typescript-eslint/parser \
                 @microsoft/eslint-formatter-sarif && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/typescript_prettier/Dockerfile
+++ b/linters/typescript_prettier/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 typescript \
                 prettier && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/typescript_prettier/Dockerfile
+++ b/linters/typescript_prettier/Dockerfile
@@ -88,6 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 typescript \
                 prettier && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/typescript_prettier/Dockerfile
+++ b/linters/typescript_prettier/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 typescript \
                 prettier && \
     npm doctor || true \

--- a/linters/typescript_prettier/Dockerfile
+++ b/linters/typescript_prettier/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 typescript \
                 prettier && \
     npm doctor || true \

--- a/linters/typescript_prettier/Dockerfile
+++ b/linters/typescript_prettier/Dockerfile
@@ -89,7 +89,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 typescript \
                 prettier && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/typescript_standard/Dockerfile
+++ b/linters/typescript_standard/Dockerfile
@@ -90,7 +90,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 standard \
                 @typescript-eslint/eslint-plugin \
                 @typescript-eslint/parser && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/typescript_standard/Dockerfile
+++ b/linters/typescript_standard/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 typescript \
                 standard \
                 @typescript-eslint/eslint-plugin \

--- a/linters/typescript_standard/Dockerfile
+++ b/linters/typescript_standard/Dockerfile
@@ -91,7 +91,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 @typescript-eslint/eslint-plugin \
                 @typescript-eslint/parser && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/typescript_standard/Dockerfile
+++ b/linters/typescript_standard/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 typescript \
                 standard \
                 @typescript-eslint/eslint-plugin \

--- a/linters/typescript_standard/Dockerfile
+++ b/linters/typescript_standard/Dockerfile
@@ -90,6 +90,7 @@ RUN npm --no-cache install --force --ignore-scripts \
                 standard \
                 @typescript-eslint/eslint-plugin \
                 @typescript-eslint/parser && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/yaml_prettier/Dockerfile
+++ b/linters/yaml_prettier/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 prettier && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/yaml_prettier/Dockerfile
+++ b/linters/yaml_prettier/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 prettier && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/yaml_prettier/Dockerfile
+++ b/linters/yaml_prettier/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 prettier && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/yaml_prettier/Dockerfile
+++ b/linters/yaml_prettier/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 prettier && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/yaml_prettier/Dockerfile
+++ b/linters/yaml_prettier/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 prettier && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/yaml_v8r/Dockerfile
+++ b/linters/yaml_v8r/Dockerfile
@@ -87,6 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 v8r && \
+    && npm doctor || true \
     npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/linters/yaml_v8r/Dockerfile
+++ b/linters/yaml_v8r/Dockerfile
@@ -88,7 +88,7 @@ WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 v8r && \
     && npm doctor || true \
-    npm audit fix --audit-level=critical || true \
+    && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \
     && find . -name "*.d.ts" -delete \

--- a/linters/yaml_v8r/Dockerfile
+++ b/linters/yaml_v8r/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts --production \
+RUN npm --no-cache install --ignore-scripts --omit=dev \
                 v8r && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/yaml_v8r/Dockerfile
+++ b/linters/yaml_v8r/Dockerfile
@@ -85,7 +85,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
     NODE_ENV=production
 #NPM__START
 WORKDIR /node-deps
-RUN npm --no-cache install --force --ignore-scripts \
+RUN npm --no-cache install --force --ignore-scripts --production \
                 v8r && \
     npm doctor || true \
     && npm audit fix --audit-level=critical || true \

--- a/linters/yaml_v8r/Dockerfile
+++ b/linters/yaml_v8r/Dockerfile
@@ -87,7 +87,7 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --force --ignore-scripts \
                 v8r && \
-    && npm doctor || true \
+    npm doctor || true \
     && npm audit fix --audit-level=critical || true \
     && npm cache clean --force || true \
     && rm -rf /root/.npm/_cacache \

--- a/megalinter/descriptors/css.megalinter-descriptor.yml
+++ b/megalinter/descriptors/css.megalinter-descriptor.yml
@@ -30,7 +30,7 @@ linters:
       npm:
         - stylelint
         - stylelint-config-standard
-        - stylelint-config-sass-guidelines
+        # - stylelint-config-sass-guidelines
         - stylelint-scss
     ide:
       atom:


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Might fix #2348 

**Do not merge yet** as I want to have a image built and pushed as a tag to test before (I only adapted so that I could remove the --force flag in npm install. )

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Disable temporarily stylelint-config-sass-guidelines (see https://github.com/bjankord/stylelint-config-sass-guidelines/issues/273)
2. Remove `--force` flag of `npm install`
3. Add `npm doctor` to diagnose issues with the installed packages
4. 

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
