### PR TITLE
Ensure jscpd respects configured threshold (#2450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Prevent jscpd to create output folder if the repo isn't writable. Fixes [#2108](https://github.com/oxsecurity/megalinter/issues/2108)
   - Fix corrective .cspell.json file generated from cspell output
   - Deprecate misspell, as it is not maintained since 2018
+  - Ensure jscpd respects configured threshold, by @Kurt-von-Laven in
+    [#2451](https://github.com/oxsecurity/megalinter/pull/2451).
 
 - Reporters
   - Enhancements and fixes on Gitlab Comment Reporter

--- a/megalinter/descriptors/copypaste.megalinter-descriptor.yml
+++ b/megalinter/descriptors/copypaste.megalinter-descriptor.yml
@@ -40,8 +40,6 @@ linters:
     cli_lint_extra_args:
       - "--reporters"
       - "console,html"
-      - "--exitCode"
-      - "1"
     cli_lint_extra_args_after:
       - "."
     cli_lint_errors_count: regex_number

--- a/megalinter/linters/JsCpdLinter.py
+++ b/megalinter/linters/JsCpdLinter.py
@@ -18,6 +18,14 @@ class JsCpdLinter(Linter):
                 f"{self.report_folder}/copy-paste/",
             ]
         cmd = super().build_lint_command(file)
+        # COPYPASTE_JSCPD_DISABLE_ERRORS_IF_LESS_THAN only has effect if jscpd
+        # exits nonzero, and by default jscpd exits 0 when clones are found.
+        # Only pass --exitCode 1 when
+        # COPYPASTE_JSCPD_DISABLE_ERRORS_IF_LESS_THAN > 0, because the jscpd
+        # threshold option becomes moot once jscpd exits nonzero whenever any
+        # clones are found.
+        if self.disable_errors_if_less_than:
+            cmd += ["--exitCode", "1"]
         return cmd
 
     # Perform additional actions and provide additional details in text reporter logs


### PR DESCRIPTION
Stop passing `--exitCode 1`, because this causes jscpd to exit with a status code of `1` whenever any clones are found. This creates problems for users who configure a threshold greater than `0`.

Fixes #2450

## Proposed Changes

1. Remove `--exitCode 1` from list of extra args passed to jscpd.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
