### PR TITLE
Ensure ESLint actually runs in project mode (#1572)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Medias
 
 - Linter enhancements & fixes
+  - Ensure ESLint actually runs in project mode rather than silently doing
+    nothing, by @Kurt-von-Laven
+    [#2455](https://github.com/oxsecurity/megalinter/pull/2455).
 
 - Core
 

--- a/megalinter/linters/EslintLinter.py
+++ b/megalinter/linters/EslintLinter.py
@@ -12,4 +12,6 @@ class EslintLinter(Linter):
         cmd = super().build_lint_command(file)
         if "--ignore-path" in cmd or "--ignore-pattern" in cmd:
             cmd = list(filter(lambda a: a != "--no-ignore", cmd))
+        if self.cli_lint_mode == "project":
+            cmd.append(".")
         return cmd


### PR DESCRIPTION
Fixes #1572

In project mode, ESLint succeeds without doing anything when called without any files, so pass it the current directory.

## Proposed Changes

1. In `EslintLinter.py`, pass ESLint an extra `.` at the end of its command line when it is in project mode.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
