### PR TITLE
Pin markdown-link-check to 3.10.3 (#2498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Core
   - Fix version displayed in logs
+  - Pin markdown-link-check to 3.10.3 until [tcort/markdown-link-check#246](https://github.com/tcort/markdown-link-check/issues/246)
+    is fixed, by @Kurt-von-Laven ([#2498](https://github.com/oxsecurity/megalinter/issues/2498)).
 
 - Documentation
 

--- a/megalinter/descriptors/markdown.megalinter-descriptor.yml
+++ b/megalinter/descriptors/markdown.megalinter-descriptor.yml
@@ -114,9 +114,11 @@ linters:
     examples:
       - "markdown-link-check myfile.md"
       - "markdown-link-check -c .markdown-link-check.json myfile.md"
+    # Unpin once https://github.com/tcort/markdown-link-check/issues/246 is fixed.
+    downgraded_version: true
     install:
       npm:
-        - markdown-link-check
+        - markdown-link-check@3.10.3
   # Markdown table formatter
   - linter_name: markdown-table-formatter
     is_formatter: true


### PR DESCRIPTION
Fixes #2498.

markdown-link-check config files are ignored at the current latest version of markdown-link-check, 3.11.0.

## Proposed Changes

1. Downgrade markdown-link-check from latest version to 3.10.3.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`