### PR TITLE
AzureCommentReporter vars reflect official Azure DevOps naming

### DIFF
--- a/.github/linters/.cspell.json
+++ b/.github/linters/.cspell.json
@@ -451,6 +451,7 @@
         "bottomrule",
         "btxg",
         "bucketname",
+        "BUILDID",
         "buildx",
         "builtins",
         "cacache",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Medias
 
 - Linter enhancements & fixes
+  - Changed vars in AzureCommentReporter to reflects official Azure DevOps naming convention + fallback to keep backward compatibility, see [#2509](https://github.com/oxsecurity/megalinter/issues/2509)
 
 - Core
 
 - Documentation
+  - Updated usage scenario for Azure DevOps, see [#2509](https://github.com/oxsecurity/megalinter/issues/2509)
 
 - Linter versions upgrades
 <!-- linter-versions-end -->
@@ -91,7 +93,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Core
   - Run CI linter jobs only on Pull requests to avoid doubling jobs
-  
+
 - Documentation
   - mega-linter-runner: doc fix for env list of values, see [#2448](https://github.com/oxsecurity/megalinter/issues/2448), by @DariuszPorowski in <https://github.com/oxsecurity/megalinter/pull/2449>
 

--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ Add the following job in your `azure-pipelines.yaml` file
       - script: |
           docker run -v $(System.DefaultWorkingDirectory):/tmp/lint \
             --env-file <(env | grep -e SYSTEM_ -e BUILD_ -e TF_ -e AGENT_) \
+            -e CI=true \
             -e SYSTEM_ACCESSTOKEN=$(System.AccessToken) \
             -e GIT_AUTHORIZATION_BEARER=$(System.AccessToken) \
             oxsecurity/megalinter:v6

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ _Github PR reporter_
 <!-- table-of-contents-start -->
 ## Table of Contents
 
-- [MegaLinter, by](#megalinter-by-)
+- [MegaLinter](#megalinter-by-)
   - [Table of Contents](#table-of-contents)
   - [Why MegaLinter](#why-megalinter)
   - [Quick Start](#quick-start)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <!-- header-logo-end -->
 <!-- mega-linter-title-start -->
 
-## MegaLinter, by [![OX Security](https://www.ox.security/wp-content/uploads/2022/06/logo.svg?ref=megalinter_readme)](https://www.ox.security/?ref=megalinter)
+# MegaLinter, by [![OX Security](https://www.ox.security/wp-content/uploads/2022/06/logo.svg?ref=megalinter_readme)](https://www.ox.security/?ref=megalinter)
 
 <!-- mega-linter-title-end -->
 <!-- mega-linter-badges-start -->
@@ -73,7 +73,7 @@ _Github PR reporter_
 <!-- table-of-contents-start -->
 ## Table of Contents
 
-- [MegaLinter](#megalinter)
+- [MegaLinter, by](#megalinter-by-)
   - [Table of Contents](#table-of-contents)
   - [Why MegaLinter](#why-megalinter)
   - [Quick Start](#quick-start)
@@ -87,14 +87,15 @@ _Github PR reporter_
     - [Upgrade to MegaLinter v6](#upgrade-to-megalinter-v6)
     - [Manual installation](#manual-installation)
     - [GitHub Action](#github-action)
-    - [Azure Pipelines](#azure-pipelines)
     - [GitLab CI](#gitlab-ci)
+    - [Azure Pipelines](#azure-pipelines)
     - [Jenkins](#jenkins)
     - [Concourse](#concourse)
       - [Pipeline step](#pipeline-step)
       - [Use it as reusable task](#use-it-as-reusable-task)
     - [Drone CI](#drone-ci)
-    - [Docker container](#docker)
+      - [(Optional) Adjusting trigger rules](#optional-adjusting-trigger-rules)
+    - [Docker container](#docker-container)
     - [Run MegaLinter locally](#run-megalinter-locally)
   - [Configuration](#configuration)
     - [Common variables](#common-variables)
@@ -117,12 +118,15 @@ _Github PR reporter_
     - [Create plugins](#create-plugins)
       - [Limitations](#limitations)
   - [Articles](#articles)
+    - [English](#english)
+    - [French](#french)
+    - [Videos](#videos)
   - [Frequently Asked Questions](#frequently-asked-questions)
   - [How to contribute](#how-to-contribute)
   - [Special thanks](#special-thanks)
     - [Contributors](#contributors)
     - [Sites referring to MegaLinter](#sites-referring-to-megalinter)
-      - [Global](#global)
+      - [Web Sites](#web-sites)
       - [Linters](#linters)
     - [Open-source teams](#open-source-teams)
     - [Super-Linter team](#super-linter-team)
@@ -139,7 +143,7 @@ _Github PR reporter_
     - [Enhanced Documentation](#enhanced-documentation)
     - [Plugins management](#plugins-management)
     - [Simplify architecture and evolutive maintenance](#simplify-architecture-and-evolutive-maintenance)
-    - [Improve robustness & stability](#improve-robustness--stability)
+    - [Improve robustness \& stability](#improve-robustness--stability)
   - [V4 versus V5](#v4-versus-v5)
 <!-- table-of-contents-end -->
 
@@ -507,7 +511,6 @@ Create a Gitlab access token and define it in a variable **GITLAB_ACCESS_TOKEN_M
 
 ![Screenshot](https://github.com/oxsecurity/megalinter/blob/main/docs/assets/images/TextReporter_gitlab_1.jpg?raw=true>)
 
-
 ### Azure Pipelines
 
 Use the following Azure Pipelines [YAML template](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema)
@@ -527,15 +530,9 @@ Add the following job in your `azure-pipelines.yaml` file
       # Run MegaLinter
       - script: |
           docker run -v $(System.DefaultWorkingDirectory):/tmp/lint \
-            -e GIT_AUTHORIZATION_BEARER=$(System.AccessToken) \
-            -e CI=true \
-            -e TF_BUILD=true \
+            --env-file <(env | grep -e SYSTEM_ -e BUILD_ -e TF_) \
             -e SYSTEM_ACCESSTOKEN=$(System.AccessToken) \
-            -e SYSTEM_COLLECTIONURI=$(System.CollectionUri) \
-            -e SYSTEM_PULLREQUEST_PULLREQUESTID=$(System.PullRequest.PullRequestId) \
-            -e SYSTEM_TEAMPROJECT="$(System.TeamProject)" \
-            -e BUILD_BUILD_ID=$(Build.BuildId) \
-            -e BUILD_REPOSITORY_ID=$(Build.Repository.ID) \
+            -e GIT_AUTHORIZATION_BEARER=$(System.AccessToken) \
             oxsecurity/megalinter:v6
         displayName: Run MegaLinter
 
@@ -571,7 +568,7 @@ stage('MegaLinter') {
     }
     post {
         always {
-            archiveArtifacts allowEmptyArchive: true, artifacts: 'mega-linter.log,megalinter-reports/**/*', defaultExcludes: false, followSymlinks: false  
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'mega-linter.log,megalinter-reports/**/*', defaultExcludes: false, followSymlinks: false
         }
     }
 }
@@ -693,7 +690,7 @@ name: MegaLinter
 workspace:
   path: /tmp/lint
 
-steps: 
+steps:
 
 - name: megalinter
   image: oxsecurity/megalinter:v6
@@ -715,13 +712,13 @@ name: MegaLinter
 workspace:
   path: /tmp/lint
 
-steps: 
+steps:
 
 - name: megalinter
   image: oxsecurity/megalinter:v6
   environment:
     DEFAULT_WORKSPACE: /tmp/lint
-    
+
 trigger:
   event:
   - push
@@ -857,7 +854,7 @@ DISABLE: PHP
 - Run all linters except PHP_PHPSTAN and PHP_PSALM linters
 
 ```yaml
-DISABLE_LINTERS: 
+DISABLE_LINTERS:
   - PHP_PHPSTAN
   - PHP_PSALM
 ```
@@ -1037,6 +1034,7 @@ You can show MegaLinter status with a badge in your repository README
 [![MegaLinter](https://github.com/oxsecurity/megalinter/workflows/MegaLinter/badge.svg?branch=main)](https://github.com/oxsecurity/megalinter/actions?query=workflow%3AMegaLinter+branch%3Amain)
 
 _If your main branch is **master** , replace **main** by **master** in URLs_
+
 ### Markdown
 
 - Format
@@ -1100,11 +1098,11 @@ PLUGINS:
 
 ### Plugins Catalog
 
-* [jupyfmt](https://github.com/kpj/jupyfmt): The uncompromising Jupyter notebook formatter ([usage](https://github.com/kpj/jupyfmt#mega-linter-integration))
-* [linkcheck](https://github.com/shiranr/linkcheck): Plugin to check and validate markdown links exist and working.
-* [nitpick](https://github.com/andreoliwa/nitpick): Command-line tool and flake8 plugin to enforce the same settings across multiple language-independent projects. ([usage](https://github.com/andreoliwa/nitpick#run-as-a-megalinter-plugin))
-* [mustache](https://github.com/one-acre-fund/mega-linter-plugin-logstash): Plugin to validate [Logstash](https://www.elastic.co/guide/en/logstash/current/configuration.html) pipeline definition files using [mustache](https://github.com/breml/logstash-config)
-* [salt-lint](https://github.com/ssc-services/mega-linter-plugin-salt): Checks Salt State files (SLS) for best practices and behavior that could potentially be improved.
+- [jupyfmt](https://github.com/kpj/jupyfmt): The uncompromising Jupyter notebook formatter ([usage](https://github.com/kpj/jupyfmt#mega-linter-integration))
+- [linkcheck](https://github.com/shiranr/linkcheck): Plugin to check and validate markdown links exist and working.
+- [nitpick](https://github.com/andreoliwa/nitpick): Command-line tool and flake8 plugin to enforce the same settings across multiple language-independent projects. ([usage](https://github.com/andreoliwa/nitpick#run-as-a-megalinter-plugin))
+- [mustache](https://github.com/one-acre-fund/mega-linter-plugin-logstash): Plugin to validate [Logstash](https://www.elastic.co/guide/en/logstash/current/configuration.html) pipeline definition files using [mustache](https://github.com/breml/logstash-config)
+- [salt-lint](https://github.com/ssc-services/mega-linter-plugin-salt): Checks Salt State files (SLS) for best practices and behavior that could potentially be improved.
 
 Submit a PR if you want your plugin to appear here :)
 
@@ -1253,7 +1251,6 @@ description: List of all contributors, websites and linters that help MegaLinter
 <a href="https://github.com/oxsecurity/megalinter/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=oxsecurity/megalinter" />
 </a>
-
 
 ### Sites referring to MegaLinter
 

--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ Add the following job in your `azure-pipelines.yaml` file
       # Run MegaLinter
       - script: |
           docker run -v $(System.DefaultWorkingDirectory):/tmp/lint \
-            --env-file <(env | grep -e SYSTEM_ -e BUILD_ -e TF_) \
+            --env-file <(env | grep -e SYSTEM_ -e BUILD_ -e TF_ -e AGENT_) \
             -e SYSTEM_ACCESSTOKEN=$(System.AccessToken) \
             -e GIT_AUTHORIZATION_BEARER=$(System.AccessToken) \
             oxsecurity/megalinter:v6

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -193,6 +193,7 @@ Add the following job in your `azure-pipelines.yaml` file
       - script: |
           docker run -v $(System.DefaultWorkingDirectory):/tmp/lint \
             --env-file <(env | grep -e SYSTEM_ -e BUILD_ -e TF_ -e AGENT_) \
+            -e CI=true \
             -e SYSTEM_ACCESSTOKEN=$(System.AccessToken) \
             -e GIT_AUTHORIZATION_BEARER=$(System.AccessToken) \
             oxsecurity/megalinter:v6

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -192,15 +192,9 @@ Add the following job in your `azure-pipelines.yaml` file
       # Run MegaLinter
       - script: |
           docker run -v $(System.DefaultWorkingDirectory):/tmp/lint \
-            -e GIT_AUTHORIZATION_BEARER=$(System.AccessToken) \
-            -e CI=true \
-            -e TF_BUILD=true \
+            --env-file <(env | grep -e SYSTEM_ -e BUILD_ -e TF_) \
             -e SYSTEM_ACCESSTOKEN=$(System.AccessToken) \
-            -e SYSTEM_COLLECTIONURI=$(System.CollectionUri) \
-            -e SYSTEM_PULLREQUEST_PULLREQUESTID=$(System.PullRequest.PullRequestId) \
-            -e SYSTEM_TEAMPROJECT="$(System.TeamProject)" \
-            -e BUILD_BUILD_ID=$(Build.BuildId) \
-            -e BUILD_REPOSITORY_ID=$(Build.Repository.ID) \
+            -e GIT_AUTHORIZATION_BEARER=$(System.AccessToken) \
             oxsecurity/megalinter:v6
         displayName: Run MegaLinter
 
@@ -236,7 +230,7 @@ stage('MegaLinter') {
     }
     post {
         always {
-            archiveArtifacts allowEmptyArchive: true, artifacts: 'mega-linter.log,megalinter-reports/**/*', defaultExcludes: false, followSymlinks: false  
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'mega-linter.log,megalinter-reports/**/*', defaultExcludes: false, followSymlinks: false
         }
     }
 }
@@ -358,7 +352,7 @@ name: MegaLinter
 workspace:
   path: /tmp/lint
 
-steps: 
+steps:
 
 - name: megalinter
   image: oxsecurity/megalinter:v6
@@ -380,13 +374,13 @@ name: MegaLinter
 workspace:
   path: /tmp/lint
 
-steps: 
+steps:
 
 - name: megalinter
   image: oxsecurity/megalinter:v6
   environment:
     DEFAULT_WORKSPACE: /tmp/lint
-    
+
 trigger:
   event:
   - push

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -192,7 +192,7 @@ Add the following job in your `azure-pipelines.yaml` file
       # Run MegaLinter
       - script: |
           docker run -v $(System.DefaultWorkingDirectory):/tmp/lint \
-            --env-file <(env | grep -e SYSTEM_ -e BUILD_ -e TF_) \
+            --env-file <(env | grep -e SYSTEM_ -e BUILD_ -e TF_ -e AGENT_) \
             -e SYSTEM_ACCESSTOKEN=$(System.AccessToken) \
             -e GIT_AUTHORIZATION_BEARER=$(System.AccessToken) \
             oxsecurity/megalinter:v6

--- a/docs/reporters/AzureCommentReporter.md
+++ b/docs/reporters/AzureCommentReporter.md
@@ -22,7 +22,7 @@ Example:
 ```yaml
       - script: |
           docker run -v $(System.DefaultWorkingDirectory):/tmp/lint \
-            --env-file <(env | grep -e SYSTEM_ -e BUILD_ -e TF_) \
+            --env-file <(env | grep -e SYSTEM_ -e BUILD_ -e TF_ -e AGENT_) \
             -e SYSTEM_ACCESSTOKEN=$(System.AccessToken) \
             -e GIT_AUTHORIZATION_BEARER=$(System.AccessToken) \
             oxsecurity/megalinter:v6

--- a/docs/reporters/AzureCommentReporter.md
+++ b/docs/reporters/AzureCommentReporter.md
@@ -23,6 +23,7 @@ Example:
       - script: |
           docker run -v $(System.DefaultWorkingDirectory):/tmp/lint \
             --env-file <(env | grep -e SYSTEM_ -e BUILD_ -e TF_ -e AGENT_) \
+            -e CI=true \
             -e SYSTEM_ACCESSTOKEN=$(System.AccessToken) \
             -e GIT_AUTHORIZATION_BEARER=$(System.AccessToken) \
             oxsecurity/megalinter:v6

--- a/docs/reporters/AzureCommentReporter.md
+++ b/docs/reporters/AzureCommentReporter.md
@@ -22,15 +22,9 @@ Example:
 ```yaml
       - script: |
           docker run -v $(System.DefaultWorkingDirectory):/tmp/lint \
-            -e GIT_AUTHORIZATION_BEARER=$(System.AccessToken) \
-            -e CI=true \
-            -e TF_BUILD=true \
+            --env-file <(env | grep -e SYSTEM_ -e BUILD_ -e TF_) \
             -e SYSTEM_ACCESSTOKEN=$(System.AccessToken) \
-            -e SYSTEM_COLLECTIONURI=$(System.CollectionUri) \
-            -e SYSTEM_PULLREQUEST_PULLREQUESTID=$(System.PullRequest.PullRequestId) \
-            -e SYSTEM_TEAMPROJECT="$(System.TeamProject)" \
-            -e BUILD_BUILD_ID=$(Build.BuildId) \
-            -e BUILD_REPOSITORY_ID=$(Build.Repository.ID) \
+            -e GIT_AUTHORIZATION_BEARER=$(System.AccessToken) \
             oxsecurity/megalinter:v6
         displayName: Run MegaLinter
 ```

--- a/megalinter/reporters/AzureCommentReporter.py
+++ b/megalinter/reporters/AzureCommentReporter.py
@@ -8,7 +8,7 @@ Requires the following vars sent to docker run:
 - SYSTEM_COLLECTIONURI
 - SYSTEM_PULLREQUEST_PULLREQUESTID
 - SYSTEM_TEAMPROJECT
-- BUILD_BUILD_ID
+- BUILD_BUILDID
 - BUILD_REPOSITORY_ID
 """
 import logging
@@ -45,17 +45,17 @@ class AzureCommentReporter(Reporter):
                 )
             SYSTEM_TEAMPROJECT = urllib.parse.quote(config.get("SYSTEM_TEAMPROJECT"))
             BUILD_REPOSITORY_ID = config.get("BUILD_REPOSITORY_ID")
-            BUILD_BUILD_ID = config.get("BUILD_BUILD_ID")
+            BUILD_BUILDID = config.get("BUILD_BUILDID", config.get("BUILD_BUILD_ID"))
             AZURE_COMMENT_REPORTER_LINKS_TYPE = config.get(
                 "AZURE_COMMENT_REPORTER_LINKS_TYPE", "artifacts"
             )
             if AZURE_COMMENT_REPORTER_LINKS_TYPE == "artifacts":
                 artifacts_url = (
                     f"{SYSTEM_COLLECTIONURI}{SYSTEM_TEAMPROJECT}/_build/results?buildId="
-                    f"{BUILD_BUILD_ID}&view=artifacts&pathAsName=false&type=publishedArtifacts"
+                    f"{BUILD_BUILDID}&view=artifacts&pathAsName=false&type=publishedArtifacts"
                 )
             else:
-                artifacts_url = f"{SYSTEM_COLLECTIONURI}{SYSTEM_TEAMPROJECT}/_build/results?buildId={BUILD_BUILD_ID}"
+                artifacts_url = f"{SYSTEM_COLLECTIONURI}{SYSTEM_TEAMPROJECT}/_build/results?buildId={BUILD_BUILDID}"
             url = (
                 f"{SYSTEM_COLLECTIONURI}{SYSTEM_TEAMPROJECT}/_apis/git/repositories/"
                 f"{BUILD_REPOSITORY_ID}/pullRequests/{SYSTEM_PULLREQUEST_PULLREQUESTID}"


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #2509 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Changed vars naming in AzureCommentReporter vars to reflects official Azure DevOps naming convention
2. Updated docs with Azure Pipelines usage scenario with passing build agent env vars - it eliminates explicite passing vars one-by-one (except SYSTEM_ACCESSTOKEN - it requires to be pass explicitly) and gives opportunity to work with ADO agent vars in the future. 
   - the rest env vars can be pure megalinter envs, it increases cleanness in the pipeline
4. Using old BUILD_BUILD_ID as fallback to keep backward compatibility
5. Not planned, but came up while working on it this fix: updated outdated ToC in main README + minor linting

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
