### PR TITLE
Update AzureCommentReport to have only one MegaLinter thread instead of a new one for each run of MegaLinter

### DIFF
--- a/.github/workflows/deploy-ALPHA-flavors.yml
+++ b/.github/workflows/deploy-ALPHA-flavors.yml
@@ -1,9 +1,9 @@
 ---
-#################################
-#################################
+#########################
+#########################
 ## Deploy Docker Image Flavors ##
-#################################
-#################################
+#########################
+#########################
 
 #
 # Documentation:
@@ -18,7 +18,6 @@ on:
   push:
     branches:
       - "alpha"
-      - "FlavoredMegaLinters"
     paths:
       - ".github/workflows/**"
       - "Dockerfile"
@@ -27,7 +26,7 @@ on:
       - "mega-linter-runner/**"
       - "**/linter-versions.json"
       - "TEMPLATES/**"
-      - "**/*.py"
+      - ".trivyignore"
       - "**/.sh"
 
 ###############
@@ -46,13 +45,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 10
       matrix:
         os: [ubuntu-latest]
         # flavors-start
         flavor:
           [
             "ci_light",
+            "cupcake",
             "documentation",
             "dotnet",
             "go",
@@ -63,6 +63,7 @@ jobs:
             "ruby",
             "rust",
             "salesforce",
+            "security",
             "swift",
             "terraform",
           ]
@@ -79,46 +80,45 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      ###################################
-      # Run Deploy script for Dockerhub #
-      ###################################
-      - name: Deploy latest image to DockerHub
-        env:
-          # Set the Env Vars
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          IMAGE_REPO: oxsecurity/megalinter-${{ matrix.flavor }}
-          IMAGE_VERSION: alpha
-          DOCKERFILE_PATH: flavors/${{ matrix.flavor }}/Dockerfile
-          DOCKER_BUILD_PLATFORMS: linux/amd64
-          REGISTRY: Docker
-          SQUASH: "true"
-        shell: bash
-        run: .automation/upload-docker.sh
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
-      ###################################################
-      # Run Deploy script for GitHub Container Registry #
-      ###################################################
-      - name: Deploy latest image to GitHub Container Registry
-        env:
-          # Set the Env Vars
-          GCR_USERNAME: ${{ secrets.GCR_USERNAME }}
-          GCR_TOKEN: ${{ secrets.GCR_PASSWORD }}
-          IMAGE_REPO: oxsecurity/megalinter-${{ matrix.flavor }}
-          IMAGE_VERSION: alpha
-          DOCKERFILE_PATH: flavors/${{ matrix.flavor }}/Dockerfile
-          DOCKER_BUILD_PLATFORMS: linux/amd64
-          REGISTRY: GCR
-          SQUASH: "true"
-        shell: bash
-        run: .automation/upload-docker.sh
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-      # Free disk space
-      - name: Free Disk space
-        shell: bash
-        run: |
-          sudo rm -rf /usr/local/lib/android  # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get current date
+        run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> ${GITHUB_ENV}
+
+      - name: Build Image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: flavors/${{ matrix.flavor }}/Dockerfile
+          platforms: linux/amd64
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            BUILD_REVISION=${{ github.sha }}
+            BUILD_VERSION=alpha
+          load: false
+          push: true
+          secrets: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          tags: |
+            oxsecurity/megalinter-${{ matrix.flavor }}:alpha
+            ghcr.io/oxsecurity/megalinter-${{ matrix.flavor }}:alpha
 
       ##############################################
       # Check Docker image security with Trivy #
@@ -133,4 +133,4 @@ jobs:
           security-checks: vuln
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
-          timeout: 5m0s
+          timeout: 10m0s

--- a/.github/workflows/deploy-ALPHA.yml
+++ b/.github/workflows/deploy-ALPHA.yml
@@ -27,16 +27,15 @@ on:
       - "**/linter-versions.json"
       - "TEMPLATES/**"
       - ".trivyignore"
-      - "**/*.py"
       - "**/.sh"
 
 ###############
 # Set the Job #
 ###############
-
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
+
 jobs:
 
   build:
@@ -46,8 +45,6 @@ jobs:
     runs-on: ubuntu-latest
     # Only run this on the main repo
     if: github.repository == 'oxsecurity/megalinter' && !contains(github.event.head_commit.message, 'skip deploy')
-    environment: 
-      name: alpha
     ##################
     # Load all steps #
     ##################
@@ -58,57 +55,57 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      #####################
-      # Run Deploy script #
-      #####################
-      - name: Deploy latest image to DockerHub
-        env:
-          # Set the Env Vars
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          IMAGE_REPO: oxsecurity/megalinter
-          IMAGE_VERSION: alpha
-          DOCKERFILE_PATH: Dockerfile
-          DOCKER_BUILD_PLATFORMS: linux/amd64
-          REGISTRY: Docker
-        shell: bash
-        run: .automation/upload-docker.sh
-
-      #############################
-      # Run Deploy script for GPR #
-      #############################
-      - name: Deploy Latest image to GitHub Container Registry
-        if: github.repository == 'disabled'
-        env:
-          # Set the Env Vars
-          GCR_USERNAME: ${{ secrets.GCR_USERNAME }}
-          GCR_TOKEN: ${{ secrets.GCR_PASSWORD }}
-          IMAGE_REPO: oxsecurity/megalinter
-          IMAGE_VERSION: alpha
-          DOCKERFILE_PATH: Dockerfile
-          DOCKER_BUILD_PLATFORMS: linux/amd64
-          REGISTRY: GCR
-        shell: bash
-        run: .automation/upload-docker.sh
-
-      # Free disk space
-      - name: Free Disk space
-        shell: bash
-        run: |
-          sudo rm -rf /usr/local/lib/android  # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-
-      ##############################################
-      # Check Docker image security with Trivy #
-      ##############################################
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+      ########################################################
+      # Publish updated version of mega-linter-runner on NPM #
+      ########################################################
+      - uses: actions/setup-node@v3.6.0
         with:
-          image-ref: "docker.io/oxsecurity/megalinter:alpha"
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          security-checks: vuln
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-          timeout: 5m0s
+          node-version: "18.x"
+          registry-url: "https://registry.npmjs.org"
+      - run: cd mega-linter-runner && yarn install --frozen-lockfile
+      - run: cd mega-linter-runner && ALPHAID=$(date '+%Y%m%d%H%M') && npm version prerelease --preid="alpha$ALPHAID"
+        shell: bash
+      - run: cd mega-linter-runner && npm publish --tag alpha || echo "mega-linter-runner alpha not published"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get current date
+        run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> ${GITHUB_ENV}
+
+      - name: Build & Push Docker Image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            BUILD_REVISION=${{ github.sha }}
+            BUILD_VERSION=alpha
+          load: false
+          push: true
+          secrets: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          tags: |
+            oxsecurity/megalinter:alpha
+            ghcr.io/oxsecurity/megalinter:alpha
+

--- a/.github/workflows/deploy-BETA.yml
+++ b/.github/workflows/deploy-BETA.yml
@@ -40,7 +40,7 @@ jobs:
 
   build:
     # Name the Job
-    name: Deploy Docker Image - PROD
+    name: Deploy Docker Image - BETA
     # Set the agent to run on
     runs-on: ubuntu-latest
     # Only run this on the main repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Medias
 
 - Linter enhancements & fixes
-  - Changed vars in AzureCommentReporter to reflects official Azure DevOps naming convention + fallback to keep backward compatibility, see [#2509](https://github.com/oxsecurity/megalinter/issues/2509)
 
 - Core
+  - Changed vars in AzureCommentReporter to reflects official Azure DevOps naming convention + fallback to keep backward compatibility, see [#2509](https://github.com/oxsecurity/megalinter/issues/2509)
+  - Update AzureCommentReport to have only one MegaLinter thread instead of a new one for each run of MegaLinter
 
 - Documentation
   - Updated usage scenario for Azure DevOps, see [#2509](https://github.com/oxsecurity/megalinter/issues/2509)

--- a/megalinter/reporters/AzureCommentReporter.py
+++ b/megalinter/reporters/AzureCommentReporter.py
@@ -74,9 +74,9 @@ class AzureCommentReporter(Reporter):
 
             # Create connection to Azure API
             access_token = config.get("SYSTEM_ACCESSTOKEN")
-            credentials = BasicTokenAuthentication(access_token=access_token)
+            credentials = BasicTokenAuthentication({"access_token": access_token})
             connection = Connection(
-                base_url=f"{SYSTEM_COLLECTIONURI}{SYSTEM_TEAMPROJECT}",
+                base_url=f"{SYSTEM_COLLECTIONURI}",
                 creds=credentials,
             )
             git_client: GitClient = connection.clients.get_git_client()

--- a/megalinter/reporters/AzureCommentReporter.py
+++ b/megalinter/reporters/AzureCommentReporter.py
@@ -89,7 +89,7 @@ class AzureCommentReporter(Reporter):
             existing_thread_comment = None
             existing_thread_comment_id = None
             for existing_thread in existing_threads:
-                for comment in existing_threads.comments or []:
+                for comment in existing_thread.comments or []:
                     if "<!-- MegaLinter Status Report -->" in (comment.content or ""):
                         existing_thread_comment = existing_thread
                         existing_thread_comment_id = existing_thread.comments[0].id

--- a/megalinter/reporters/AzureCommentReporter.py
+++ b/megalinter/reporters/AzureCommentReporter.py
@@ -126,8 +126,7 @@ class AzureCommentReporter(Reporter):
             new_thread_result = git_client.create_thread(
                 thread_data, BUILD_REPOSITORY_ID, SYSTEM_PULLREQUEST_PULLREQUESTID
             )
-            logging.info(str(new_thread_result))
-            if new_thread_result.status_code == 200:
+            if new_thread_result.id is not None and new_thread_result.id > 0:
                 logging.debug(f"Posted Azure Pipelines comment: {thread_data}")
                 logging.info(
                     "[Azure Comment Reporter] Posted summary as comment on "

--- a/megalinter/reporters/AzureCommentReporter.py
+++ b/megalinter/reporters/AzureCommentReporter.py
@@ -15,6 +15,9 @@ import logging
 import urllib.parse
 
 import requests
+from azure.devops.connection import Connection
+from azure.devops.released.git.git_client import GitClient
+from msrest.authentication import BasicTokenAuthentication
 from megalinter import Reporter, config
 from megalinter.utils_reporter import build_markdown_summary
 
@@ -30,8 +33,10 @@ class AzureCommentReporter(Reporter):
             self.is_active = True
 
     def produce_report(self):
-        # Post comment on GitHub pull request
+        # Post thread on Azure pull request
         if config.get("SYSTEM_ACCESSTOKEN", "") != "":
+
+            # Collect variables
             SYSTEM_COLLECTIONURI = config.get("SYSTEM_COLLECTIONURI")
             SYSTEM_PULLREQUEST_PULLREQUESTID = config.get(
                 "SYSTEM_PULLREQUEST_PULLREQUESTID", ""
@@ -46,6 +51,8 @@ class AzureCommentReporter(Reporter):
             SYSTEM_TEAMPROJECT = urllib.parse.quote(config.get("SYSTEM_TEAMPROJECT"))
             BUILD_REPOSITORY_ID = config.get("BUILD_REPOSITORY_ID")
             BUILD_BUILDID = config.get("BUILD_BUILDID", config.get("BUILD_BUILD_ID"))
+
+            # Build thread data
             AZURE_COMMENT_REPORTER_LINKS_TYPE = config.get(
                 "AZURE_COMMENT_REPORTER_LINKS_TYPE", "artifacts"
             )
@@ -56,26 +63,71 @@ class AzureCommentReporter(Reporter):
                 )
             else:
                 artifacts_url = f"{SYSTEM_COLLECTIONURI}{SYSTEM_TEAMPROJECT}/_build/results?buildId={BUILD_BUILDID}"
-            url = (
-                f"{SYSTEM_COLLECTIONURI}{SYSTEM_TEAMPROJECT}/_apis/git/repositories/"
-                f"{BUILD_REPOSITORY_ID}/pullRequests/{SYSTEM_PULLREQUEST_PULLREQUESTID}"
-                "/threads?api-version=6.0"
-            )
-            headers = {
-                "content-type": "application/json",
-                "Authorization": f"BEARER {config.get('SYSTEM_ACCESSTOKEN')}",
-            }
             p_r_msg = build_markdown_summary(self, artifacts_url)
             comment_status = "fixed" if self.master.return_code == 0 else 1
-            data = {
+            thread_data = {
                 "comments": [
                     {"parentCommentId": 0, "content": p_r_msg, "commentType": 1}
                 ],
                 "status": comment_status,
             }
-            r = requests.post(url=url, json=data, headers=headers)
-            if r.status_code == 200:
-                logging.debug(f"Posted Azure Pipelines comment: {p_r_msg}")
+
+            # Create connection to Azure API
+            access_token = config.get("SYSTEM_ACCESSTOKEN")
+            credentials = BasicTokenAuthentication(access_token=access_token)
+            connection = Connection(
+                base_url=f"{SYSTEM_COLLECTIONURI}{SYSTEM_TEAMPROJECT}",
+                creds=credentials,
+            )
+            git_client: GitClient = connection.clients.get_git_client()
+
+            # Look for existing MegaLinter thread
+            existing_threads = git_client.get_threads(
+                BUILD_REPOSITORY_ID, SYSTEM_PULLREQUEST_PULLREQUESTID
+            )
+            existing_thread_id = None
+            existing_thread_comment = None
+            existing_thread_comment_id = None
+            for existing_thread in existing_threads:
+                for comment in existing_threads.comments or []:
+                    if "<!-- MegaLinter Status Report -->" in (comment.content or ""):
+                        existing_thread_comment = existing_thread
+                        existing_thread_comment_id = existing_thread.comments[0].id
+                        existing_thread_id = existing_thread.id
+                        break
+                if existing_thread_id is not None:
+                    break
+
+            # Remove previous MegaLinter thread if existing
+            if existing_thread_id is not None:
+                git_client.delete_comment(
+                    BUILD_REPOSITORY_ID,
+                    SYSTEM_PULLREQUEST_PULLREQUESTID,
+                    existing_thread_id,
+                    existing_thread_comment_id,
+                )
+                existing_thread_comment = git_client.get_pull_request_thread(
+                    BUILD_REPOSITORY_ID,
+                    SYSTEM_PULLREQUEST_PULLREQUESTID,
+                    existing_thread_id,
+                )
+                existing_thread_comment = {
+                    "id": existing_thread_comment.id,
+                    "status": 4,  # = Closed
+                }
+                git_client.update_thread(
+                    existing_thread_comment,
+                    BUILD_REPOSITORY_ID,
+                    SYSTEM_PULLREQUEST_PULLREQUESTID,
+                    existing_thread_id,
+                )
+
+            # Post thread
+            new_thread_result = git_client.create_thread(
+                thread_data, BUILD_REPOSITORY_ID, SYSTEM_PULLREQUEST_PULLREQUESTID
+            )
+            if new_thread_result.status_code == 200:
+                logging.debug(f"Posted Azure Pipelines comment: {thread_data}")
                 logging.info(
                     "[Azure Comment Reporter] Posted summary as comment on "
                     + f"{SYSTEM_TEAMPROJECT} #PR{SYSTEM_PULLREQUEST_PULLREQUESTID}"
@@ -83,7 +135,7 @@ class AzureCommentReporter(Reporter):
             else:
                 logging.warning(
                     "[Azure Comment Reporter] Error while posting comment:"
-                    + r.reason
+                    + str(new_thread_result)
                     + "\n"
                     + "See https://megalinter.io/latest/reporters/AzureCommentReporter/"
                 )

--- a/megalinter/reporters/AzureCommentReporter.py
+++ b/megalinter/reporters/AzureCommentReporter.py
@@ -126,6 +126,7 @@ class AzureCommentReporter(Reporter):
             new_thread_result = git_client.create_thread(
                 thread_data, BUILD_REPOSITORY_ID, SYSTEM_PULLREQUEST_PULLREQUESTID
             )
+            logging.info(str(new_thread_result))
             if new_thread_result.status_code == 200:
                 logging.debug(f"Posted Azure Pipelines comment: {thread_data}")
                 logging.info(

--- a/megalinter/reporters/GitlabCommentReporter.py
+++ b/megalinter/reporters/GitlabCommentReporter.py
@@ -130,10 +130,7 @@ class GitlabCommentReporter(Reporter):
 
             # Check if there is already a MegaLinter comment
             for comment in existing_comments:
-                if (
-                    "See detailed report in [MegaLinter reports" in comment.body
-                    or "See detailed report in MegaLinter reports" in comment.body
-                ):
+                if "<!-- MegaLinter Status Report -->" in comment.body:
                     existing_comment = comment
 
             # Process comment

--- a/megalinter/setup.py
+++ b/megalinter/setup.py
@@ -21,6 +21,7 @@ setup(
         "pychalk",
         "pygithub",
         "python-gitlab",
+        "azure-devops",
         "commentjson",
         "pytablewriter",
         "pyyaml",

--- a/megalinter/utils_reporter.py
+++ b/megalinter/utils_reporter.py
@@ -148,6 +148,10 @@ def build_markdown_summary(reporter_self, action_run_url):
             + "(https://www.ox.security/wp-content/uploads/2022/06/"
             + "logo.svg?ref=megalinter_comment)](https://www.ox.security/?ref=megalinter)_"
         )
+    p_r_msg += (
+        os.linesep
+        + "<!-- MegaLinter Status Report -->"
+    )
     logging.debug("\n" + p_r_msg)
     return p_r_msg
 

--- a/megalinter/utils_reporter.py
+++ b/megalinter/utils_reporter.py
@@ -6,6 +6,7 @@ import urllib
 
 from megalinter import config, utils
 from megalinter.constants import (
+    DEFAULT_RELEASE,
     ML_DOC_URL,
     ML_DOC_URL_DESCRIPTORS_ROOT,
     ML_REPO,
@@ -124,7 +125,7 @@ def build_markdown_summary(reporter_self, action_run_url):
                 " if you use a MegaLinter flavor:" + os.linesep
             )
             for suggestion in reporter_self.master.flavor_suggestions:
-                build_version = os.environ.get("BUILD_VERSION", "v5")
+                build_version = os.environ.get("BUILD_VERSION", DEFAULT_RELEASE)
                 action_version = "v5" if len(build_version) > 20 else build_version
                 action_path = (
                     f"{ML_REPO}/flavors/{suggestion['flavor']}@{action_version}"

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,6 +5,8 @@ mkdocs
 multiprocessing_logging
 pychalk
 pygithub
+python-gitlab
+azure-devops
 commentjson
 pytablewriter
 pytest-cov


### PR DESCRIPTION
- Azure Comment reporter
  - In case there is already a MegaLinter thread on a PR, delete it before posting a new one, in order to always have the latest MegaLinter status report at the top of the PT threads
- Alpha CI jobs: fixes so they use build action