### PR TITLE
Prevent jscpd to create output folder if the repo is not writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,8 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Medias
 
 - Linter enhancements & fixes
-  - Ensure ESLint actually runs in project mode rather than silently doing
-    nothing, by @Kurt-von-Laven
-    [#2455](https://github.com/oxsecurity/megalinter/pull/2455).
+  - Ensure ESLint actually runs in project mode rather than silently doing nothing, by @Kurt-von-Laven [#2455](https://github.com/oxsecurity/megalinter/pull/2455).
+  - Prevent jscpd to create output folder if the repo is not writable. Fixes [#2108](https://github.com/oxsecurity/megalinter/issues/2108)
 
 - Core
   - Add support for idea plugins auto-install

--- a/megalinter/descriptors/copypaste.megalinter-descriptor.yml
+++ b/megalinter/descriptors/copypaste.megalinter-descriptor.yml
@@ -40,8 +40,6 @@ linters:
     cli_lint_extra_args:
       - "--reporters"
       - "console,html"
-      - "--output"
-      - "{{REPORT_FOLDER}}/copy-paste/"
       - "--exitCode"
       - "1"
     cli_lint_extra_args_after:

--- a/megalinter/linters/JsCpdLinter.py
+++ b/megalinter/linters/JsCpdLinter.py
@@ -10,7 +10,6 @@ from megalinter import Linter, utils
 
 
 class JsCpdLinter(Linter):
-
     # Special cases for build lint command
     def build_lint_command(self, file=None):
         if utils.can_write_report_files(self.master):

--- a/megalinter/linters/JsCpdLinter.py
+++ b/megalinter/linters/JsCpdLinter.py
@@ -6,10 +6,21 @@ https://github.com/kucherenko/jscpd
 import os
 import shutil
 
-from megalinter import Linter
+from megalinter import Linter, utils
 
 
 class JsCpdLinter(Linter):
+
+    # Special cases for build lint command
+    def build_lint_command(self, file=None):
+        if utils.can_write_report_files(self.master):
+            self.cli_lint_extra_args += [
+                "--output",
+                f"{self.report_folder}/copy-paste/",
+            ]
+        cmd = super().build_lint_command(file)
+        return cmd
+
     # Perform additional actions and provide additional details in text reporter logs
     def complete_text_reporter_report(self, reporter_self):
         if self.status == "success":

--- a/megalinter/reporters/ConfigReporter.py
+++ b/megalinter/reporters/ConfigReporter.py
@@ -4,11 +4,11 @@ Output results in console
 """
 import json
 import os
+import xml.dom.minidom
 from pathlib import Path
 from shutil import copyfile
 
 import commentjson
-import xml.dom.minidom
 from megalinter import Reporter, config, utils
 
 
@@ -134,7 +134,10 @@ IDE EXTENSIONS APPLICABLE TO YOUR PROJECT
             if os.path.isfile(idea_extensions_file):
                 dom = xml.dom.minidom.parse(idea_extensions_file)
                 for node in dom.documentElement.childNodes:
-                    if node.localName == "component" and node.getAttribute("name") == "ExternalDependencies":
+                    if (
+                        node.localName == "component"
+                        and node.getAttribute("name") == "ExternalDependencies"
+                    ):
                         ext_dep_component = node
             else:
                 impl = xml.dom.minidom.getDOMImplementation()
@@ -161,7 +164,5 @@ IDE EXTENSIONS APPLICABLE TO YOUR PROJECT
             # Write .idea/externalDependencies.xml file
             output_idea_extensions_file = f"{config_report_folder}{os.path.sep}.idea{os.path.sep}externalDependencies.xml"
             os.makedirs(os.path.dirname(output_idea_extensions_file), exist_ok=True)
-            with open(
-                output_idea_extensions_file, "w", encoding="utf-8"
-            ) as json_file:
+            with open(output_idea_extensions_file, "w", encoding="utf-8") as json_file:
                 json_file.write(dom.documentElement.toprettyxml())


### PR DESCRIPTION
Fixes https://github.com/oxsecurity/megalinter/issues/2108