### PR TITLE
Enhancement & fixes for GitlabCommentReporter

### DIFF
--- a/.github/linters/.cspell.json
+++ b/.github/linters/.cspell.json
@@ -900,6 +900,7 @@
         "mstruebing",
         "msvs",
         "multiline",
+        "multiplicating",
         "multline",
         "musl",
         "mvdan",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Prevent jscpd to create output folder if the repo is not writable. Fixes [#2108](https://github.com/oxsecurity/megalinter/issues/2108)
   - Fix corrective .cspell.json file generated from cspell output
 
+- Reporters
+  - Enhancements and fixes on Gitlab Comment Reporter
+    - New var GITLAB_COMMENT_REPORTER_OVERWRITE_COMMENT to allow to disable the overwrite of existing MegaLinter comment in case of new run
+    - In case of overwrite activated (by default), fetch all Merge Request comments, not the first 20.
+    - Display a different message in log when a Merge Request comment is created or updated.
+
 - Core
   - Add support for idea plugins auto-install
   - Upgrade base Docker image to python:3.11.3-alpine3.17

--- a/docs/reporters/GitlabCommentReporter.md
+++ b/docs/reporters/GitlabCommentReporter.md
@@ -13,6 +13,10 @@ Click on hyperlinks to access detailed logs (click on **Download** in **Artifact
 
 ![Screenshot](../assets/images/GitlabCommentReporter.jpg)
 
+After a first MegaLinter run, a comment is posted on the MR. To avoid multiplicating MegaLinter MR comments, future MegaLinter runs will update the existing MR comment instead of posting a new one.
+
+If you really want a new MR comment for each MegaLinter run, define variable `GITLAB_COMMENT_REPORTER_OVERWRITE_COMMENT` to `false`.
+
 ## Configuration
 
 - Create an [access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token) with scope **api**
@@ -22,8 +26,9 @@ Click on hyperlinks to access detailed logs (click on **Download** in **Artifact
 
 | Variable                       | Description                                                                                            | Default value |
 |--------------------------------|--------------------------------------------------------------------------------------------------------|---------------|
-| GITLAB_COMMENT_REPORTER        | Activates/deactivates reporter                                                                         | true          |
+| GITLAB_COMMENT_REPORTER        | Activates/deactivates reporter                                                                         | `true`          |
 | GITLAB_ACCESS_TOKEN_MEGALINTER | Must contain a Gitlab private access token defined with api access                                     | <!-- -->      |
+| GITLAB_COMMENT_REPORTER_OVERWRITE_COMMENT        | Set to false to not overwrite existing comments in case of new runs on the same Merge Request                                                                         | `true`          |
 | GITLAB_CUSTOM_CERTIFICATE      | SSL certificate value to connect to Gitlab                                                             | <!-- -->      |
 | GITLAB_CERTIFICATE_PATH        | Path to SSL certificate to connect to Gitlab (if SSL cert has been manually defined with PRE_COMMANDS) | <!-- -->      |
 | REPORTERS_MARKDOWN_TYPE        | Set to `simple` to avoid external images in generated markdown                                         | `advanced`    |

--- a/docs/reporters/GitlabCommentReporter.md
+++ b/docs/reporters/GitlabCommentReporter.md
@@ -24,14 +24,14 @@ If you really want a new MR comment for each MegaLinter run, define variable `GI
 
 ![config-gitlab-access-token](https://user-images.githubusercontent.com/17500430/151674446-1bcb1420-d9aa-4ae1-aaae-dcf51afb36ab.gif)
 
-| Variable                       | Description                                                                                            | Default value |
-|--------------------------------|--------------------------------------------------------------------------------------------------------|---------------|
-| GITLAB_COMMENT_REPORTER        | Activates/deactivates reporter                                                                         | `true`          |
-| GITLAB_ACCESS_TOKEN_MEGALINTER | Must contain a Gitlab private access token defined with api access                                     | <!-- -->      |
-| GITLAB_COMMENT_REPORTER_OVERWRITE_COMMENT        | Set to false to not overwrite existing comments in case of new runs on the same Merge Request                                                                         | `true`          |
-| GITLAB_CUSTOM_CERTIFICATE      | SSL certificate value to connect to Gitlab                                                             | <!-- -->      |
-| GITLAB_CERTIFICATE_PATH        | Path to SSL certificate to connect to Gitlab (if SSL cert has been manually defined with PRE_COMMANDS) | <!-- -->      |
-| REPORTERS_MARKDOWN_TYPE        | Set to `simple` to avoid external images in generated markdown                                         | `advanced`    |
+| Variable                                  | Description                                                                                            | Default value |
+|-------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------|
+| GITLAB_COMMENT_REPORTER                   | Activates/deactivates reporter                                                                         | `true`        |
+| GITLAB_ACCESS_TOKEN_MEGALINTER            | Must contain a Gitlab private access token defined with api access                                     | <!-- -->      |
+| GITLAB_COMMENT_REPORTER_OVERWRITE_COMMENT | Set to false to not overwrite existing comments in case of new runs on the same Merge Request          | `true`        |
+| GITLAB_CUSTOM_CERTIFICATE                 | SSL certificate value to connect to Gitlab                                                             | <!-- -->      |
+| GITLAB_CERTIFICATE_PATH                   | Path to SSL certificate to connect to Gitlab (if SSL cert has been manually defined with PRE_COMMANDS) | <!-- -->      |
+| REPORTERS_MARKDOWN_TYPE                   | Set to `simple` to avoid external images in generated markdown                                         | `advanced`    |
 
 ## Special Thanks
 

--- a/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
@@ -3597,6 +3597,13 @@
       "title": "Activate Gitlab MR Comments reporter",
       "type": "boolean"
     },
+    "GITLAB_COMMENT_REPORTER_OVERWRITE_COMMENT": {
+      "$id": "#/properties/GITLAB_COMMENT_REPORTER_OVERWRITE_COMMENT",
+      "default": true,
+      "description": "Set to false to disable the overwrite of existing MegaLinter Merge Request comment in case of new run",
+      "title": "Overwrite Gitlab Merge Request Comment",
+      "type": "boolean"
+    },
     "GITLAB_CUSTOM_CERTIFICATE": {
       "$id": "#/properties/GITLAB_CUSTOM_CERTIFICATE",
       "default": true,


### PR DESCRIPTION
- New var GITLAB_COMMENT_REPORTER_OVERWRITE_COMMENT to allow to disable the overwrite of existing MegaLinter comment in case of new run
- In case of overwrite activated (by default), fetch all Merge Request comments, not the first 20.
 - Display a different message in log when a Merge Request comment is created or updated.

Fixes https://github.com/oxsecurity/megalinter/issues/2561