### PR TITLE
Update stale workflow: remove trigger on comments and explicit permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     # every day at 0:00 UTC
     - cron: "0 0 * * *"
+permissions:
+  #contents: write # only for delete-branch option
+  issues: write
+  pull-requests: write
 
 ###############
 # Run the job #

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,8 +9,6 @@ on:
   schedule:
     # every day at 0:00 UTC
     - cron: "0 0 * * *"
-  issue_comment:
-    types: [created, deleted, edited]
 
 ###############
 # Run the job #


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->


Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Triggering on each issue/pr comment isn’t used anymore, dates back to 2021. 
2. Add explicit permissions, as recommended in https://github.com/actions/stale/tree/03af7c36d33f4905e618fac0a1bb7e6d05f0d41b#recommended-permissions

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
