### PR TITLE
Decouple updating docker pull stats from building docs

### DIFF
--- a/.automation/build.py
+++ b/.automation/build.py
@@ -42,6 +42,7 @@ from requests.packages.urllib3.util.retry import Retry
 from webpreview import web_preview
 
 RELEASE = "--release" in sys.argv
+UPDATE_STATS = "--stats" in sys.argv or RELEASE is True
 UPDATE_DOC = "--doc" in sys.argv or RELEASE is True
 UPDATE_DEPENDENTS = "--dependents" in sys.argv
 UPDATE_CHANGELOG = "--changelog" in sys.argv
@@ -127,7 +128,7 @@ def generate_all_flavors():
     for flavor, flavor_info in flavors.items():
         generate_flavor(flavor, flavor_info)
     update_mkdocs_and_workflow_yml_with_flavors()
-    if UPDATE_DOC is True:
+    if UPDATE_STATS is True:
         try:
             update_docker_pulls_counter()
         except requests.exceptions.ConnectionError as e:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Add instructions to install MegaLinter on Bitbucket Pipelines
   - Exclude licenses from search results
   - Automate External Plugins table generation using **.automation/plugins.yml** file
+  - Add `--stats` argument to `build.sh` to update docker pull stats only when requested (manually, or from CI job Auto-Update-Linters), by @echoix in [#2677](https://github.com/oxsecurity/megalinter/pull/2677)
 
 - Linter versions upgrades
   - [cfn-lint](https://github.com/aws-cloudformation/cfn-lint) from 0.76.1 to **0.76.2** on 2023-04-04

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ if [ "${UPGRADE_LINTERS_VERSION}" == "true" ]; then
   pip3 install --upgrade "markdown==3.3.7" mike mkdocs-material "pymdown-extensions==9.11" "mkdocs-glightbox==0.3.2" mdx_truly_sane_lists jsonschema json-schema-for-humans giturlparse webpreview "github-dependents-info==0.10.0"
   cd /tmp/lint || exit 1
   chmod +x build.sh
-  GITHUB_TOKEN="${GITHUB_TOKEN}" bash build.sh --doc --dependents
+  GITHUB_TOKEN="${GITHUB_TOKEN}" bash build.sh --doc --dependents --stats
   exit $?
 fi
 


### PR DESCRIPTION
Keep updating stats for automated daily updates, so users running "./build.sh --docs" for PRs won't clutter the review process.

Updating stats won't be called by default when using `./build.sh --doc`

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Add an `--stats` argument to `./build.sh`.
2. Add the `--stats` argument to the `./build.sh` call in entrypoint's `UPGRADE_LINTERS_VERSION` path. (This makes running with the `--stats` argument run on demand for the daily automatic update only.)
3. Add an `UPDATE_STATS` constant in build.py and use it to guard call to `update_docker_pulls_counter()`

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
