### PR TITLE
⬇️ fix(requirements.txt): downgrade pymdown-extensions from 10.0 to 9.11

### DIFF
--- a/.config/python/dev/requirements.txt
+++ b/.config/python/dev/requirements.txt
@@ -16,7 +16,7 @@ mkdocs-material
 multiprocessing_logging
 pychalk
 pygithub
-pymdown-extensions==10.0
+pymdown-extensions==9.11
 pytablewriter
 pytest-cov
 pytest-timeout


### PR DESCRIPTION
The pymdown-extensions package was downgraded to version 9.11 due to compatibility issues with other packages in the project. The newer version was causing conflicts, hence the need for the downgrade.
