### PR TITLE
Call trufflehog with `--only-verified` to avoid false positives in .git/config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Fixes
   - Fix TAP reporter (3 real dots instead if 3 dots character)
+  - Call trufflehog with `--only-verified` to avoid false positives in .git/config
 
 - Linter versions upgrades
   - [trufflehog](https://github.com/trufflesecurity/trufflehog) from 3.44.0 to **3.45.0** on 2023-07-25

--- a/megalinter/descriptors/repository.megalinter-descriptor.yml
+++ b/megalinter/descriptors/repository.megalinter-descriptor.yml
@@ -561,6 +561,7 @@ linters:
       - filesystem
       - "."
       - --fail
+      - --only-verified
     cli_help_arg_name: --help
     cli_version_arg_name: --version
     examples:


### PR DESCRIPTION
Fixes https://github.com/oxsecurity/megalinter/issues/2834