### PR TITLE
Configured Grype to automatically ignore CVE-2018-20225 which is disputed

### DIFF
--- a/TEMPLATES/.grype.yaml
+++ b/TEMPLATES/.grype.yaml
@@ -143,3 +143,9 @@ fail-on-severity: "high"
   #   using-cpes: true
   # stock:
   #   using-cpes: true
+
+ignore:
+
+  # Ignored by default; disputed and unwarranted CVE that causes Megalinter to fail
+  # @link https://nvd.nist.gov/vuln/detail/CVE-2018-20225
+  - vulnerability: CVE-2018-20225


### PR DESCRIPTION
CVE-2018-20225 is disputed and causes failure on all Python flavor installs.

Fixes #2862

## Proposed Changes

Add `CVE-2018-20225` as a default ignore, as recommended in:
https://github.com/oxsecurity/megalinter/security/advisories/GHSA-6fg8-c9rw-fgrr

## Readiness Checklist

### Author/Contributor
- [N/A] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [N/A] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
