### PR TITLE
Resolve error with purrr::keep in lintr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-linter.yml file, or with `oxsecurity/megalinter:beta` docker image
 
+- Fixes
+  - Fix crashes while collecting R lints with lintr
+
 - Linter versions upgrades
 - Secretlint logo - reduce size to 150 and remove background
   - [mypy](https://mypy.readthedocs.io/en/stable/) from 1.4.1 to **1.5.0** on 2023-08-11

--- a/megalinter/linters/RLinter.py
+++ b/megalinter/linters/RLinter.py
@@ -20,7 +20,7 @@ class RLinter(Linter):
         r_commands = [
             f"lints <- lintr::lint('{file}');",
             "print(lints);",
-            "errors <- purrr::keep(lints, \(x) x$type == 'error');",
+            "errors <- purrr::keep(lints, function(x) x$type == 'error');",
             "quit(save = 'no', status = if (length(errors) > 0) 1 else 0)",
         ]
         # Build shell command

--- a/megalinter/linters/RLinter.py
+++ b/megalinter/linters/RLinter.py
@@ -20,7 +20,7 @@ class RLinter(Linter):
         r_commands = [
             f"lints <- lintr::lint('{file}');",
             "print(lints);",
-            "errors <- purrr::keep(lints, ~ .type == 'error');",
+            "errors <- purrr::keep(lints, \(x) x$type == 'error');",
             "quit(save = 'no', status = if (length(errors) > 0) 1 else 0)",
         ]
         # Build shell command


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #2886.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Pass an anonymous function to `purrr::keep` rather than a formula as recommended by [the docs](https://purrr.tidyverse.org/reference/keep.html)

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
