### PR TITLE
Fix if condition in `mega-linter.yml` template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Media
 
 - Fixes
+  - Fix if condition in `mega-linter.yml` template #2985 
 
 - Doc
 

--- a/mega-linter-runner/generators/mega-linter/templates/mega-linter.yml
+++ b/mega-linter-runner/generators/mega-linter/templates/mega-linter.yml
@@ -92,7 +92,7 @@ jobs:
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3
-        if: ${{ success() }} || ${{ failure() }}
+        if: ${{ success() || failure() }}
         with:
           name: MegaLinter reports
           path: |


### PR DESCRIPTION
Fixes issue which actionlint complaints about:

> ❌ Linted [ACTION] files with [actionlint]: Found 1 error(s) - (0.04s)
> - Using [actionlint v1.6.26] https://megalinter.io/7.4.0/descriptors/action_actionlint
> - MegaLinter key: [ACTION_ACTIONLINT]
> - Rules config: identified by [actionlint]
> - Number of files analyzed: [5]
> --Error detail:
> .github/workflows/mega-linter.yaml:95:13: if: condition "${{ success() }} || ${{ failure() }}" is always evaluated to true because extra characters are around ${{ }} [if-cond]