### PR TITLE
Fix Typo in DJLint Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Doc
   - Display list of articles from newest to oldest
+  - Fix incorrect environment variable in djlint docs
 
 - CI
 

--- a/docs/descriptors/html_djlint.md
+++ b/docs/descriptors/html_djlint.md
@@ -23,7 +23,7 @@ DjLint can analyse multiple formats of HTML:
 - golang
 - angular
 
-For example, define `HTML_DJLINT_HTMLHINT_ARGUMENTS: ["--profile", "django"]` to select django format
+For example, define `HTML_DJLINT_ARGUMENTS: ["--profile", "django"]` to select django format
 
 ## djlint documentation
 

--- a/megalinter/descriptors/html.megalinter-descriptor.yml
+++ b/megalinter/descriptors/html.megalinter-descriptor.yml
@@ -20,7 +20,7 @@ linters:
       - golang
       - angular
 
-      For example, define `HTML_DJLINT_HTMLHINT_ARGUMENTS: ["--profile", "django"]` to select django format
+      For example, define `HTML_DJLINT_ARGUMENTS: ["--profile", "django"]` to select django format
     linter_url: https://djlint.com/
     linter_repo: https://github.com/Riverside-Healthcare/djlint
     linter_rules_url: https://djlint.com/docs/linter/


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Fix incorrect environment variable in djlint docs (`HTML_DJLINT_HTMLHINT_ARGUMENTS` -> `HTML_DJLINT_ARGUMENTS`)

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
