### PR TITLE
Improve lychee documentation to add an example of `.lycheeignore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Doc
   - Display list of articles from newest to oldest
   - Fix incorrect environment variable in djlint docs
+  - Improve lychee documentation to add an example of `.lycheeignore`
 
 - CI
 

--- a/megalinter/descriptors/spell.megalinter-descriptor.yml
+++ b/megalinter/descriptors/spell.megalinter-descriptor.yml
@@ -155,7 +155,7 @@ linters:
       https://twitter.com/intent/tweet*
       (.*some_url_part)
       https://github.com/sgerrand/alpine-pkg-glibc/releases/download
-      ``` 
+      ```
     test_folder: spell_lychee
     can_output_sarif: false
     descriptor_flavors:

--- a/megalinter/descriptors/spell.megalinter-descriptor.yml
+++ b/megalinter/descriptors/spell.megalinter-descriptor.yml
@@ -144,6 +144,18 @@ linters:
   - class: LycheeLinter
     linter_name: lychee
     name: SPELL_LYCHEE
+    linter_text: |
+      A file **.lycheeignore** can be defined at the root of the repository to ignore some urls.
+
+      Each line can contain Regular Expressions or glob format.
+
+      Example with glob, regex and full url:
+
+      ```
+      https://twitter.com/intent/tweet*
+      (.*some_url_part)
+      https://github.com/sgerrand/alpine-pkg-glibc/releases/download
+      ``` 
     test_folder: spell_lychee
     can_output_sarif: false
     descriptor_flavors:


### PR DESCRIPTION
Co-authored-by: Andrew Vaughan <1119590+andrewvaughan@users.noreply.github.com>

Fixes https://github.com/oxsecurity/megalinter/issues/2865
