### PR TITLE
Add the other maintainers globally to the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,24 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# Docs about the CODEOWNERS file are found here: 
+# https://help.github.com/articles/about-codeowners/
+
+# Order is important; the last matching pattern takes the most
+# precedence.
+
 ######################################################################
 # These owners will be the default owners for everything in the repo #
 ######################################################################
 
-.github/workflows @nvuillam
+# In the following rule, unless a later match takes precedence, one of
+# the maintainers will be requested for review when someone opens a
+# pull request.
 
-*       @nvuillam
+# Global rule:
+*       @nvuillam @echoix @bdovaz @Kurt-von-Laven
+
+
+# Workflow files can be part of branch protection rules, so they are
+# sensitive and must be attentively reviewed.
+.github/workflows @nvuillam

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Improve lychee documentation to add an example of `.lycheeignore`
 
 - CI
+  - Add the other maintainers globally to the CODEOWNERS file ([#3008](https://github.com/oxsecurity/megalinter/pull/3008))
 
 - Linter versions upgrades
   - [cfn-lint](https://github.com/aws-cloudformation/cfn-lint) from 0.80.2 to **0.80.3** on 2023-09-24


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->


<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Adds the other maintainers as code owners for the global rule, so they can also approve PRs.
2. Adds a little more explanation comments to the file.
3. Following GitHub's documentation, place the global rule above, and the exceptions below, since the last matching pattern takes precedence.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
