### PR TITLE
Ops: Updated DevSkim to have a default configuration file and reduce errors (closes #3017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Fixes
   - build.py: Remove exclusivity between pip, gem & cargo packages
   - Salesforce linters: Switch sfdx-cli to @salesforce/cli
+  - Added default `.devskim.json` to mitigate errors introduced when no config exists
 
 - Doc
   - Display list of articles from newest to oldest

--- a/TEMPLATES/.devskim.json
+++ b/TEMPLATES/.devskim.json
@@ -1,0 +1,3 @@
+{
+  "Globs": ["**/.git/**", "**/megalinter-reports/**"]
+}

--- a/docs/descriptors/repository_devskim.md
+++ b/docs/descriptors/repository_devskim.md
@@ -7,16 +7,22 @@ description: How to use devskim (configure, ignore files, ignore errors, help & 
 # <a href="https://github.com/microsoft/DevSkim" target="blank" title="Visit linter Web Site"><img src="https://github.com/microsoft/DevSkim/raw/main/media/devskim_logo.svg" alt="devskim" height="100px" class="megalinter-logo"></a>devskim
 [![GitHub stars](https://img.shields.io/github/stars/microsoft/DevSkim?cacheSeconds=3600)](https://github.com/microsoft/DevSkim) ![sarif](https://shields.io/badge/-SARIF-orange) [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/microsoft/DevSkim?sort=semver)](https://github.com/microsoft/DevSkim/releases) [![GitHub last commit](https://img.shields.io/github/last-commit/microsoft/DevSkim)](https://github.com/microsoft/DevSkim/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/microsoft/DevSkim)](https://github.com/microsoft/DevSkim/graphs/commit-activity/) [![GitHub contributors](https://img.shields.io/github/contributors/microsoft/DevSkim)](https://github.com/microsoft/DevSkim/graphs/contributors/)
 
-Use `--ignore-globs` to ignore files and/or folders
+Use the `Globs` configuration in a `.devskim.json` configuration file to ignore files and/or folders.
 
 Example:
-  `REPOSITORY_DEVSKIM_ARGUMENTS: ['--ignore-globs','**/megalinter-reports/**,**/.git/**,**/bin/**']`
+
+```json
+{
+  "Globs": ["**/.git/**", "**/megalinter-reports/**"]
+}
+```
 
 ## devskim documentation
 
 - Version in MegaLinter: **1.0.23**
 - Visit [Official Web Site](https://github.com/microsoft/DevSkim#readme){target=_blank}
 - See [How to configure devskim rules](https://github.com/microsoft/DevSkim/wiki/Analyze-Command){target=_blank}
+  - If custom `.devskim.json` config file isn't found, [.devskim.json](https://github.com/oxsecurity/megalinter/tree/main/TEMPLATES/.devskim.json){target=_blank} will be used
 - See [How to ignore files and directories with devskim](https://github.com/microsoft/DevSkim/wiki/Analyze-Command){target=_blank}
 
 [![DevSkim - GitHub](https://gh-card.dev/repos/microsoft/DevSkim.svg?fullname=)](https://github.com/microsoft/DevSkim){target=_blank}

--- a/megalinter/descriptors/repository.megalinter-descriptor.yml
+++ b/megalinter/descriptors/repository.megalinter-descriptor.yml
@@ -56,10 +56,18 @@ linters:
       - security
     ignore_for_flavor_suggestions: true
     linter_text: |
-      Use `--ignore-globs` to ignore files and/or folders
+      If you need to ignore folders,files or file extensions, use glob expressions `Glob` property of local `.devskim.json` file
 
       Example:
-        `REPOSITORY_DEVSKIM_ARGUMENTS: ['--ignore-globs','**/megalinter-reports/**,**/.git/**,**/bin/**']`
+
+      ```json
+      {
+        Glob: [
+          "**/.git/**",
+          "**/megalinter-reports/**"
+        ]
+      }
+      ```
     linter_url: https://github.com/microsoft/DevSkim
     linter_repo: https://github.com/microsoft/DevSkim
     linter_speed: 1

--- a/megalinter/descriptors/repository.megalinter-descriptor.yml
+++ b/megalinter/descriptors/repository.megalinter-descriptor.yml
@@ -75,6 +75,7 @@ linters:
     linter_rules_ignore_config_url: https://github.com/microsoft/DevSkim/wiki/Analyze-Command
     linter_image_url: https://github.com/microsoft/DevSkim/raw/main/media/devskim_logo.svg
     linter_icon_png_url: https://raw.githubusercontent.com/oxsecurity/megalinter/main/docs/assets/icons/linters/devskim.png
+    config_file_name: .devskim.json
     cli_lint_mode: project
     cli_lint_extra_args:
       - analyze


### PR DESCRIPTION
Fixes #3017 

## Proposed Changes

1. Add a default `.devskim.json` for the linter to remove errors with this missing

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
