### PR TITLE
Update and fix our ChatOps automations to only run on pull request comments

### DIFF
--- a/.github/workflows/build-command.yml
+++ b/.github/workflows/build-command.yml
@@ -41,15 +41,9 @@ jobs:
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v3
         with:
-## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
-          # token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.inputs.repository }}
           comment-id: ${{ github.event.inputs.comment-id }}
           issue-number: ${{ github.event.inputs.issue-number }}
-## These are if we want to use repository_dispatch (default)
-          # repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          # comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          # issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
           body: |
             > [Command run output](${{ steps.vars.outputs.run-url }})
             > Build command workflow started.
@@ -79,8 +73,6 @@ jobs:
       - name: Create comment starting build.sh
         uses: peter-evans/create-or-update-comment@v3
         with:
-## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
-          # token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.inputs.repository }}
           comment-id: ${{ github.event.inputs.comment-id }}
           issue-number: ${{ github.event.inputs.issue-number }}
@@ -97,8 +89,6 @@ jobs:
       - name: Add reaction
         uses: peter-evans/create-or-update-comment@v3
         with:
-## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
-          # token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.inputs.repository }}
           comment-id: ${{ github.event.inputs.comment-id }}
           issue-number: ${{ github.event.inputs.issue-number }}
@@ -107,8 +97,6 @@ jobs:
         if: steps.auto-commit-action.outputs.changes_detected == 'true'
         uses: peter-evans/create-or-update-comment@v3
         with:
-## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
-          # token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.inputs.repository }}
           comment-id: ${{ github.event.inputs.comment-id }}
           issue-number: ${{ github.event.inputs.issue-number }}
@@ -118,8 +106,6 @@ jobs:
         if: steps.auto-commit-action.outputs.changes_detected == 'false'
         uses: peter-evans/create-or-update-comment@v3
         with:
-## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
-          # token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.inputs.repository }}
           comment-id: ${{ github.event.inputs.comment-id }}
           issue-number: ${{ github.event.inputs.issue-number }}

--- a/.github/workflows/build-command.yml
+++ b/.github/workflows/build-command.yml
@@ -22,7 +22,7 @@ on:
         description: "The reference to pass to 'ref' to checkout action"
         required: true
       checkout-repository:
-        description: "The repository to pass to 'repository' to tcheckout action"
+        description: "The repository to pass to 'repository' to checkout action"
         required: false
   repository_dispatch:
     types: [build-command]

--- a/.github/workflows/build-command.yml
+++ b/.github/workflows/build-command.yml
@@ -63,7 +63,7 @@ jobs:
           repository: ${{ github.event.inputs.checkout-repository }}
           ref: ${{ github.event.inputs.checkout-ref }}
       - name: Setup Python
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4.7.1
         with:
           # Version range or exact version of Python or PyPy to use, using SemVer's version range syntax. Reads from .python-version if unset.
           python-version-file: '.python-version' # Read python version from a file .python-version

--- a/.github/workflows/build-command.yml
+++ b/.github/workflows/build-command.yml
@@ -26,14 +26,13 @@ on:
         required: false
   repository_dispatch:
     types: [build-command]
+permissions: {}
 jobs:
   build-sh:
     runs-on: ubuntu-latest
     permissions:
-      # Give the default GITHUB_TOKEN write permission to commit and push, comment issues & post new PR
-      # Remove the ones you do not need
+      # Give the default GITHUB_TOKEN write permission to commit and push and comment on PR
       contents: write
-      issues: write
       pull-requests: write
     steps:
       - name: Create URL to the run output
@@ -42,12 +41,12 @@ jobs:
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v3
         with:
-          ## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
+## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
           # token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.inputs.repository }}
           comment-id: ${{ github.event.inputs.comment-id }}
           issue-number: ${{ github.event.inputs.issue-number }}
-          ## These are if we want to use repository_dispatch (default)
+## These are if we want to use repository_dispatch (default)
           # repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           # comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           # issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
@@ -80,7 +79,7 @@ jobs:
       - name: Create comment starting build.sh
         uses: peter-evans/create-or-update-comment@v3
         with:
-          ## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
+## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
           # token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.inputs.repository }}
           comment-id: ${{ github.event.inputs.comment-id }}
@@ -98,7 +97,7 @@ jobs:
       - name: Add reaction
         uses: peter-evans/create-or-update-comment@v3
         with:
-          ## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
+## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
           # token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.inputs.repository }}
           comment-id: ${{ github.event.inputs.comment-id }}
@@ -108,7 +107,7 @@ jobs:
         if: steps.auto-commit-action.outputs.changes_detected == 'true'
         uses: peter-evans/create-or-update-comment@v3
         with:
-          ## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
+## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
           # token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.inputs.repository }}
           comment-id: ${{ github.event.inputs.comment-id }}
@@ -119,7 +118,7 @@ jobs:
         if: steps.auto-commit-action.outputs.changes_detected == 'false'
         uses: peter-evans/create-or-update-comment@v3
         with:
-          ## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
+## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
           # token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.inputs.repository }}
           comment-id: ${{ github.event.inputs.comment-id }}

--- a/.github/workflows/build-command.yml
+++ b/.github/workflows/build-command.yml
@@ -92,7 +92,7 @@ jobs:
           repository: ${{ github.event.inputs.repository }}
           comment-id: ${{ github.event.inputs.comment-id }}
           issue-number: ${{ github.event.inputs.issue-number }}
-          reaction-type: hooray
+          reactions: hooray
       - name: Create final comment updated files
         if: steps.auto-commit-action.outputs.changes_detected == 'true'
         uses: peter-evans/create-or-update-comment@v3

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -13,22 +13,24 @@ on:
         description: 'The comment-id of the slash command'
         required: true
       issue-number:
-       description: 'The issue number in which the slash command was made'
-       required: true
+        description: 'The issue number in which the slash command was made'
+        required: true
       actor:
-       description: 'The user who executed the slash command'
-       required: true
+        description: 'The user who executed the slash command'
+        required: true
   repository_dispatch:
     types: [help-command]
+permissions: {}
 jobs:
   help:
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions:
+      pull-requests: write
     steps:
       - name: Update comment
         uses: peter-evans/create-or-update-comment@v3
         with:
-          ## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
+## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
           # token: ${{ secrets.GITHUB_TOKEN }}
           ## These are if we want to use repository_dispatch (default)
           # repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -45,4 +45,4 @@ jobs:
             > /build | Updates the Dockerfile, documentation, and other files from the yml descriptors
             > /build [ref=...]| Same as /build, but executes workflow in any branch using the ref named argument. The reference can be a branch, tag, or a commit SHA. This can be useful to test workflows in PR branches before merging.
             > /help | Returns this help message
-          reaction-type: hooray
+          reactions: hooray

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -17,7 +17,13 @@ on:
         required: true
       actor:
         description: 'The user who executed the slash command'
-        required: true
+        required: false
+      checkout-ref:
+        description: "The reference to pass to 'ref' to checkout action"
+        required: false
+      checkout-repository:
+        description: "The repository to pass to 'repository' to checkout action"
+        required: false
   repository_dispatch:
     types: [help-command]
 permissions: {}

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -30,11 +30,6 @@ jobs:
       - name: Update comment
         uses: peter-evans/create-or-update-comment@v3
         with:
-## Use token if we want to use a PAT instead of GITHUB_TOKEN, GITHUB_TOKEN acts as github-actions[bot]
-          # token: ${{ secrets.GITHUB_TOKEN }}
-          ## These are if we want to use repository_dispatch (default)
-          # repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          # comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           repository: ${{ github.event.inputs.repository }}
           comment-id: ${{ github.event.inputs.comment-id }}
           issue-number: ${{ github.event.inputs.issue-number }}

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -4,6 +4,8 @@ on:
     types: [created]
 jobs:
   slashCommandDispatch:
+    # This job only runs for pull request comments
+    if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push, comment issues & post new PR
@@ -36,8 +38,8 @@ jobs:
             }
       - name: Dump the get-pr payload context
         env:
-          GETPR_OUTPUTS: ${{ toJson(steps.get-pr.outputs) }}
-        run: echo "$GETPR_OUTPUTS"
+          GET_PR_OUTPUTS: ${{ toJson(steps.get-pr.outputs) }}
+        run: echo "$GET_PR_OUTPUTS"
       - name: Slash Command Dispatch PR
         uses: peter-evans/slash-command-dispatch@v3
         id: scd
@@ -57,7 +59,7 @@ jobs:
             checkout-ref=${{ steps.get-pr.outputs.head_ref }}
             checkout-repository=${{ steps.get-pr.outputs.head_repo_full_name }}
       - name: Edit comment with error message
-        if: steps.scd.outputs.error-message
+        if: (success() || failure()) && steps.scd.outputs.error-message
         uses: peter-evans/create-or-update-comment@v3
         with:
           comment-id: ${{ github.event.comment.id }}

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -64,3 +64,10 @@ jobs:
           comment-id: ${{ github.event.comment.id }}
           body: |
             > ${{ steps.scd.outputs.error-message }}
+          reactions: confused
+      - name: Add failure reaction
+        if: failure()
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: -1

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -2,16 +2,14 @@ name: Slash Command Dispatch
 on:
   issue_comment:
     types: [created]
+permissions: {}
 jobs:
   slashCommandDispatch:
     # This job only runs for pull request comments
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     permissions:
-      # Give the default GITHUB_TOKEN write permission to commit and push, comment issues & post new PR
-      # Remove the ones you do not need
-      contents: write
-      issues: write
+      actions: write # needed to launch a workflow_dispatch
       pull-requests: write
     steps:
       - name: Dump the event payload context
@@ -50,6 +48,7 @@ jobs:
             build
             help
           issue-type: pull-request
+          permission: write   # Collaborator permission required: (`none`, `read`, `triage`, `write`, `maintain`, `admin`),  default: `write`
           dispatch-type: workflow
           static-args: |
             repository=${{ github.repository }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Add the other maintainers globally to the CODEOWNERS file ([#3008](https://github.com/oxsecurity/megalinter/pull/3008))
   - Free disk space earlier in the process to avoid failure during docker build
   - Set flavors-stats.json as a generated file in .gitattributes ([#3023](https://github.com/oxsecurity/megalinter/pull/3023))
+  - Update and fix our ChatOps automations to only run on pull request comments, by @echoix in [#3034](https://github.com/oxsecurity/megalinter/pull/3034)
 
 - Linter versions upgrades
   - [cfn-lint](https://github.com/aws-cloudformation/cfn-lint) from 0.80.2 to **0.80.3** on 2023-09-24


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Our slash-command-dispatcher was running for all comments, although we can only use them in pull requests. The github script would fail to get information about the PR when the job was run because of an issue comment.

While retesting in my fork, the transition from PAT to the workflow-level or job-level permissions were not correctly adjusted.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Run only the command dispatcher on PR comments.
2. Use only the required permissions for the jobs in the command dispatcher, or the commands.
3. Use the new input name `reactions` for `peter-evans/create-or-update-comment@v3`.
4. Add missing (but unneeded) inputs in the help command in order to successfully run.
5. Bump `actions/setup-python` to v4.7.1, v4.5.0 is removed (seems they had a bug if a project had a pyproject.toml file).

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
