### PR TITLE
Use App::cpm to install perlcritic faster, and clean `.perl-cpm` cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Free disk space earlier in the process to avoid failure during docker build
   - Set flavors-stats.json as a generated file in .gitattributes ([#3023](https://github.com/oxsecurity/megalinter/pull/3023))
   - Update and fix our ChatOps automations to only run on pull request comments, by @echoix in [#3034](https://github.com/oxsecurity/megalinter/pull/3034)
+  - Use App::cpm to install perlcritic faster, and clean `.perl-cpm` cache, by @echoix in [#3036](https://github.com/oxsecurity/megalinter/pull/3036) 
 
 - Linter versions upgrades
   - [cfn-lint](https://github.com/aws-cloudformation/cfn-lint) from 0.80.2 to **0.80.3** on 2023-09-24

--- a/Dockerfile
+++ b/Dockerfile
@@ -626,7 +626,9 @@ RUN wget --quiet https://github.com/pmd/pmd/releases/download/pmd_releases%2F${P
 # Managed with COPY --link --from=checkmake /checkmake /usr/bin/checkmake
 
 # perlcritic installation
-    && curl --retry 5 --retry-delay 5 -sL https://cpanmin.us/ | perl - -nq --no-wget Perl::Critic
+    && curl -fsSL https://raw.githubusercontent.com/skaji/cpm/main/cpm | perl - install -g --show-build-log-on-failure --without-build --without-test --without-runtime Perl::Critic \
+    && rm -rf /root/.perl-cpm
+
 
 # phpcs installation
 RUN --mount=type=secret,id=GITHUB_TOKEN GITHUB_AUTH_TOKEN="$(cat /run/secrets/GITHUB_TOKEN)" && export GITHUB_AUTH_TOKEN && phive --no-progress install phpcs -g --trust-gpg-keys 31C7E470E2138192

--- a/linters/perl_perlcritic/Dockerfile
+++ b/linters/perl_perlcritic/Dockerfile
@@ -124,7 +124,9 @@ ENV PATH="/node-deps/node_modules/.bin:${PATH}" \
 #############################################################################################
 #OTHER__START
 # perlcritic installation
-RUN curl --retry 5 --retry-delay 5 -sL https://cpanmin.us/ | perl - -nq --no-wget Perl::Critic
+RUN curl -fsSL https://raw.githubusercontent.com/skaji/cpm/main/cpm | perl - install -g --show-build-log-on-failure --without-build --without-test --without-runtime Perl::Critic \
+    && rm -rf /root/.perl-cpm
+
 
 #OTHER__END
 

--- a/megalinter/descriptors/perl.megalinter-descriptor.yml
+++ b/megalinter/descriptors/perl.megalinter-descriptor.yml
@@ -31,4 +31,6 @@ linters:
       - "perlcritic myfile.pl"
     install:
       dockerfile:
-        - RUN curl --retry 5 --retry-delay 5 -sL https://cpanmin.us/ | perl - -nq --no-wget Perl::Critic
+        - |
+          RUN curl -fsSL https://raw.githubusercontent.com/skaji/cpm/main/cpm | perl - install -g --show-build-log-on-failure --without-build --without-test --without-runtime Perl::Critic \
+              && rm -rf /root/.perl-cpm


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->
The installation of perlcritic left some cache files in the image, about 31 MB. This PR fixes that.
Also, I tried out other installation methods, and to see if I was able to remove the perl-dev dependency (I couldn't).
[App::cpm](https://metacpan.org/dist/App-cpm/view/script/cpm) is a fast CPAN module installer, and they claim it is 3x faster than cpanm. It can use multiple threads to parallelize the work to do. This PR uses that.

I used the tool called `dive` to look into the images, and `hyperfine` to benchmark building of the perl_perlcritic image.
Results are :

| Command | Mean [s] | Min [s] | Max [s] | Relative | Image size [MB] | Space Saved [MB] |
|:---|---:|---:|---:|---:|---:|---:|
| `docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpanminus" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpanminus . ` | 78.554 ± 0.821 | 78.020 | 79.499 | 1.49 ± 0.04 | 380 | - |
| `docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpanminus_clean" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpanminus-clean . ` | 75.322 ± 2.437 | 73.781 | 78.131 | 1.43 ± 0.06 | 349 | 31 |
| `docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpm" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpm . ` | 56.371 ± 2.916 | 53.776 | 59.526 | 1.07 ± 0.06 | 346 | 34.2 |
| `docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpm_pipe" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpm-pipe . ` | 52.754 ± 1.246 | 51.494 | 53.986 | 1.00 | 345 | 35.4 |
| `docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpm_pipe_workers2" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpm-pipe-workers-2 . ` | 58.401 ± 0.637 | 57.833 | 59.090 | 1.11 ± 0.03 | 345 | 35.4 |



<details><summary>Details of run time</summary>
<p>

```shell
hyperfine --min-runs 3  --export-markdown timings_perlcritic5.md  --export-json timings_perlcritic5.json  \
    'docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpanminus" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpanminus . ' \
    'docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpanminus_clean" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpanminus-clean . ' \
    'docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpm" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpm . '  \
    'docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpm_pipe" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpm-pipe . ' \
    'docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpm_pipe_workers2" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpm-pipe-workers-2 . '
Benchmark 1: docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpanminus" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpanminus . 
  Time (mean ± σ):     78.554 s ±  0.821 s    [User: 0.203 s, System: 0.198 s]
  Range (min … max):   78.020 s … 79.499 s    3 runs
 
Benchmark 2: docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpanminus_clean" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpanminus-clean . 
  Time (mean ± σ):     75.322 s ±  2.437 s    [User: 0.223 s, System: 0.169 s]
  Range (min … max):   73.781 s … 78.131 s    3 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 3: docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpm" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpm . 
  Time (mean ± σ):     56.371 s ±  2.916 s    [User: 0.201 s, System: 0.180 s]
  Range (min … max):   53.776 s … 59.526 s    3 runs
 
Benchmark 4: docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpm_pipe" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpm-pipe . 
  Time (mean ± σ):     52.754 s ±  1.246 s    [User: 0.174 s, System: 0.187 s]
  Range (min … max):   51.494 s … 53.986 s    3 runs
 
Benchmark 5: docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpm_pipe_workers2" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpm-pipe-workers-2 . 
  Time (mean ± σ):     58.401 s ±  0.637 s    [User: 0.208 s, System: 0.160 s]
  Range (min … max):   57.833 s … 59.090 s    3 runs
 
Summary
  docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpm_pipe" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpm-pipe .  ran
    1.07 ± 0.06 times faster than docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpm" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpm . 
    1.11 ± 0.03 times faster than docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpm_pipe_workers2" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpm-pipe-workers-2 . 
    1.43 ± 0.06 times faster than docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpanminus_clean" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpanminus-clean . 
    1.49 ± 0.04 times faster than docker buildx build --pull --rm -f "linters/perl_perlcritic/Dockerfile_cpanminus" --progress plain --no-cache -t megalinter-only-perl_perlcritic:test-echoix-cpanminus . 
```

</p>
</details> 


<details><summary>Details of disk usage</summary>
<p>

Using dive with a command similar to:
```shell
docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock wagoodman/dive:latest megalinter-only-perl_perlcritic:test-echoix-cpm-pipe
``` 

Note that there is missing the `-g` global flag in the installation screenshots for cpm, but the sizes are the same, only installed in another folder to be found without changing any paths.


Original installation:
![image](https://github.com/oxsecurity/megalinter/assets/27212526/11b2bc4d-c11e-424e-b9a3-d1ee3082401c)

Original installation, cleaning `/root/.cpanm` folder:
![image](https://github.com/oxsecurity/megalinter/assets/27212526/5177d1ce-eb0a-4f2a-8af2-e0a8c34825c2)

Installing and using App::Cpm, cleaning the` /root/.perl-cpm` folder:
![image](https://github.com/oxsecurity/megalinter/assets/27212526/7219e305-4835-4c89-b8ea-f8d6c8ffe5f4)

Using cpm directly from a pipe, without installing it: 
![image](https://github.com/oxsecurity/megalinter/assets/27212526/9bc9b091-de1b-4183-8866-904a3ef8afad)

Using cpm directly from a pipe, without installing it, and limiting to 2 workers, the closest I can get to what it will be on GitHub Actions runners: 
![image](https://github.com/oxsecurity/megalinter/assets/27212526/c25e362e-db11-4ce3-9b38-6db385392c1e)


</p>
</details> 


I also tested linting a Perl repo locally with the new installation method, and works as the original


<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes


1. Use cpm directly from pipe to install Perl Critic
2. Clean perl cache in same step

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
