### PR TITLE
Add failure message in ChatOps build-command and Slash dispatcher

### DIFF
--- a/.github/workflows/build-command.yml
+++ b/.github/workflows/build-command.yml
@@ -80,6 +80,7 @@ jobs:
             > Running script `./build.sh`
       - name: Run build script
         run: ./build.sh
+      - run: git pull
       - uses: stefanzweifel/git-auto-commit-action@v5
         id: auto-commit-action
         with:
@@ -111,3 +112,13 @@ jobs:
           issue-number: ${{ github.event.inputs.issue-number }}
           body: |
             > Build command workflow completed without updating files.
+      - name: Add failure reaction
+        if: failure()
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          repository: ${{ github.event.inputs.repository }}
+          comment-id: ${{ github.event.comment.id }}
+          issue-number: ${{ github.event.inputs.issue-number }}
+          body: |
+            > Build command workflow failed.
+          reactions: -1

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -12,6 +12,9 @@ jobs:
       actions: write # needed to launch a workflow_dispatch
       pull-requests: write
     steps:
+      - name: Create URL to the run output
+        id: vars
+        run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
       - name: Dump the event payload context
         env:
           EVENT_CONTEXT: ${{ toJson(github.event) }}
@@ -71,3 +74,6 @@ jobs:
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: -1
+          body: |
+            > Command dispatch failed.
+            > [Command run output](${{ steps.vars.outputs.run-url }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Free disk space earlier in the process to avoid failure during docker build
   - Set flavors-stats.json as a generated file in .gitattributes ([#3023](https://github.com/oxsecurity/megalinter/pull/3023))
   - Update and fix our ChatOps automations to only run on pull request comments, by @echoix in [#3034](https://github.com/oxsecurity/megalinter/pull/3034)
+  - Add failure message in ChatOps build-command and Slash dispatcher, by @echoix in [#3037](https://github.com/oxsecurity/megalinter/pull/3037)
 
 - Linter versions upgrades
   - [cfn-lint](https://github.com/aws-cloudformation/cfn-lint) from 0.80.2 to **0.80.3** on 2023-09-24


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

I found a flaw that if a commit was made before the build-command made its commit, the action would obviously fail, but wouldn't show up in the edited comment. So I added to try to git pull before the git commit action, if it could help, and update the comment if it fails

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
