### PR TITLE
Fix actionlint error in GitHub Action workflows

### DIFF
--- a/.github/workflows/auto-update-linters.yml
+++ b/.github/workflows/auto-update-linters.yml
@@ -106,7 +106,7 @@ jobs:
 
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
-        if: ${{ success() }} || ${{ failure() }}
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: MegaLinter reports

--- a/.github/workflows/deploy-DEV.yml
+++ b/.github/workflows/deploy-DEV.yml
@@ -225,7 +225,7 @@ jobs:
 
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
-        if: ${{ success() }} || ${{ failure() }}
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: MegaLinter reports
@@ -236,7 +236,7 @@ jobs:
             linter-versions.json
 
       - name: debug
-        if: ${{ success() }} || ${{ failure() }}
+        if: success() || failure()
         run: echo ${{ steps.docker_build.outcome }}
 
       # Clean disk space

--- a/.github/workflows/mega-linter-for-runner.yml
+++ b/.github/workflows/mega-linter-for-runner.yml
@@ -106,7 +106,7 @@ jobs:
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3
-        if: ${{ success() }} || ${{ failure() }}
+        if: success() || failure()
         with:
           name: MegaLinter reports
           path: |

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -106,7 +106,7 @@ jobs:
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3
-        if: ${{ success() }} || ${{ failure() }}
+        if: success() || failure()
         with:
           name: MegaLinter reports
           path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - [checkov](https://www.checkov.io/) from 3.0.12 to **3.0.13** on 2023-10-30
 <!-- linter-versions-end -->
 
+- Fixes
+  - Fix actionlint error in GitHub Action workflows
+
 ## [v7.5.0] - 2023-10-29
 
 - Core

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ jobs:
 
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
-        if: ${{ success() }} || ${{ failure() }}
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: MegaLinter reports

--- a/TEMPLATES/mega-linter.yml
+++ b/TEMPLATES/mega-linter.yml
@@ -101,7 +101,7 @@ jobs:
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3
-        if: ${{ success() }} || ${{ failure() }}
+        if: success() || failure()
         with:
           name: MegaLinter reports
           path: |

--- a/docs/install-github.md
+++ b/docs/install-github.md
@@ -82,7 +82,7 @@ jobs:
 
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
-        if: ${{ success() }} || ${{ failure() }}
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: MegaLinter reports

--- a/docs/reporters/SarifReporter.md
+++ b/docs/reporters/SarifReporter.md
@@ -23,7 +23,7 @@ If you want GitHub to handle the SARIF file to display it in its UI, add the fol
 
 ```yaml
 - name: Upload MegaLinter scan results to GitHub Security tab
-if: ${{ success() }} || ${{ failure() }}
+if: success() || failure()
 uses: github/codeql-action/upload-sarif@v2
 with:
     sarif_file: 'megalinter-reports/megalinter-report.sarif'


### PR DESCRIPTION
Fixes actionlint error in GitHub Action workflows:
```
"if: condition "${{ success() }} || ${{ failure() }}" is always evaluated to true because extra characters are around ${{ }} [if-cond]"
```