### PR TITLE
Set schedule earlier for auto-update-linters.yml, allow manual runs

### DIFF
--- a/.github/workflows/auto-update-linters.yml
+++ b/.github/workflows/auto-update-linters.yml
@@ -7,9 +7,11 @@ on:
       - main
       - auto-update
       - fixes/docgen
-  # Automatically run every day at midnight
+  # Automatically run every day at 22:00 UTC
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 22 * * *"
+  # Allow to manually trigger a run of the workflow
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/auto-update-linters.yml
+++ b/.github/workflows/auto-update-linters.yml
@@ -7,9 +7,9 @@ on:
       - main
       - auto-update
       - fixes/docgen
-  # Automatically run every day at 22:00 UTC
+  # Automatically run every day at 21:49 UTC, before a start of hour peak
   schedule:
-    - cron: "0 22 * * *"
+    - cron: "49 21 * * *"
   # Allow to manually trigger a run of the workflow
   workflow_dispatch:
 


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Allow auto update workflow to be called manually, and start the daily checks earlier. It is easier to review on the same day if it isn’t started too late. Also, scheduled actions can be delayed on periods of high load, like the start of every hour. For example, the 00:00 utc runs in the repo often start at 00:35. Since I would like to be able to review the PRs at least an hour and a half earlier (to restart jobs if needed), and the initial job can take 45 minutes before creating the PR, and that the CI on the PRs take at least 55 mins, if passing on the first try, I suggest at least before 22:00 UTC.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
