### PR TITLE
Modernize dependabot.yml in correct directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
     directory: "/.automation/test/repository_grype/bad/"
     ignore:
       - dependency-name: "minimist"
+      - dependency-name: "chalk/ansi-regex"
     
   # Maintain dependencies for ruby with bundler
   - package-ecosystem: "bundler"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
     ignore:
       - dependency-name: "minimist"
       - dependency-name: "chalk/ansi-regex"
-    
+
   # Maintain dependencies for ruby with bundler
   - package-ecosystem: "bundler"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
     open-pull-requests-limit: 10
   - package-ecosystem: "npm"
     directory: "/.automation/test/repository_grype/bad/"
+    schedule:
+      interval: monthly
     ignore:
       - dependency-name: "minimist"
       - dependency-name: "chalk/ansi-regex"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,18 @@ updates:
 
   # Maintain dependencies for js with npm
   - package-ecosystem: "npm"
-    directory: "/dependencies"
+    directory: "/mega-linter-runner"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-
+  - package-ecosystem: "npm"
+    directory: "/.automation/test/repository_grype/bad/"
+    ignore:
+      - dependency-name: "minimist"
+    
   # Maintain dependencies for ruby with bundler
   - package-ecosystem: "bundler"
-    directory: "/dependencies"
+    directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
@@ -32,7 +36,17 @@ updates:
 
   # Maintain dependencies for python with pip
   - package-ecosystem: "pip"
-    directory: "/dependencies"
+    directory: "/.config/python/dev/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "pip"
+    directory: "/megalinter"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "pip"
+    directory: "/server"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Allows to also specifically ignore some security flagging of a package.json designed for a vulnerability scanner (grype).


<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Sets the npm directory from a non existent `dependencies` folder to `/mega-linter-runner`, where the npm deps are
2. Adds the `server` folder as a directory where there are some python dependencies to check
3. Adds the `megalinter` folder as directory where there are some python dependencies to check, that will function correctly when the project will convert to pyproject.toml instead of setup.py
4. Adds the folder `.config/python/dev` as a folder for python.
5. We don't have gemfiles, but we don't have a dependencies folder too.
 
## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
