### PR TITLE
Fixed Gitleaks --no-git doesn't work anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Updated lintr config template to use `linters_with_defaults()` (formerly `with_defaults()`)
 - Update base image to `python:3.11.6-alpine3.18`
 
+- Fixes
+  - Fix issue Gitleaks `--no-git` does not work anymore, [#2945](https://github.com/oxsecurity/megalinter/issues/2945), in [PR 3112](https://github.com/oxsecurity/megalinter/pull/3112)
+
 - CI
   - Upgrade pymdown-extensions and markdown, by @BryanQuigley in [#3053](https://github.com/oxsecurity/megalinter/pull/3053)
-
 
 - Linter versions upgrades
   - [protolint](https://github.com/yoheimuta/protolint) from 0.46.2 to **0.46.3** on 2023-10-29

--- a/megalinter/linters/GitleaksLinter.py
+++ b/megalinter/linters/GitleaksLinter.py
@@ -81,17 +81,18 @@ class GitleaksLinter(Linter):
     # Manage presence of --no-git in command line
     def build_lint_command(self, file=None):
         cmd = super().build_lint_command(file)
-        # --no-git / --redact has been sent by user in REPOSITORY_GITLEAKS_ARGUMENTS
+        # --redact has been sent by user in REPOSITORY_GITLEAKS_ARGUMENTS
         # make sure that it's only once in the arguments list
-        if (
-            "--redact" in self.cli_lint_user_args
-            or "--no-git" in self.cli_lint_user_args
-        ):
+        if "--redact" in self.cli_lint_user_args:
             cmd = list(dict.fromkeys(cmd))
 
+        # --no-git has been sent by user in REPOSITORY_GITLEAKS_ARGUMENTS
+        # make sure that it's only once in the arguments list
+        if "--no-git" in self.cli_lint_user_args:
+            cmd = list(dict.fromkeys(cmd))
         # --no-git has been sent by default from ML descriptor
         # but as it is a git repo, remove all --no-git from arguments list
-        if "--no-git" in cmd and utils.is_git_repo(self.workspace):
+        elif "--no-git" in cmd and utils.is_git_repo(self.workspace):
             cmd = list(filter(lambda a: a != "--no-git", cmd))
 
         if (


### PR DESCRIPTION
Contributes to #2945

<!-- markdownlint-disable -->

* Regression on the `--no-git` option which was systematically deleted.

  This prevents Gitleaks from treating git repository as a regular directory and scan those files.

<!-- markdownlint-restore -->

## Proposed Changes

1. Split condition `--redact` or `--no-git`
2. Get back to previous `--no-git` condition

## Readiness Checklist

### Author/Contributor

- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
