### PR TITLE
Add semgrep ruleset to validation schema

### DIFF
--- a/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
@@ -14354,6 +14354,22 @@
       "title": "REPOSITORY_SEMGREP: Define or override a list of bash commands to run before the linter",
       "type": "array"
     },
+    "REPOSITORY_SEMGREP_RULESETS": {
+      "$id": "#/properties/REPOSITORY_SEMGREP_RULESETS",
+      "description": "REPOSITORY_SEMGREP: Specify custom ruleset(s) for semgrep",
+      "examples:": [
+        "auto",
+        "p/ci"
+      ],
+      "items": {
+        "type": "string"
+      },
+      "title": "REPOSITORY_SEMGREP: Custom arguments",
+      "type": [
+        "array",
+        "string"
+      ]
+    },
     "REPOSITORY_SEMGREP_UNSECURED_ENV_VARIABLES": {
       "$id": "#/properties/REPOSITORY_SEMGREP_UNSECURED_ENV_VARIABLES",
       "default": [],


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #3152 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

Add a `REPOSITORY_SEMGREP_RULESETS` section to the JSON schema document used to validate `.mega-linter.yml` files.

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
