### PR TITLE
Undowngrade stylelint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -209,9 +209,8 @@ RUN npm --no-cache install --ignore-scripts --omit=dev \
                 typescript \
                 @coffeelint/cli \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss \
                 gherkin-lint \
                 graphql \

--- a/flavors/c_cpp/Dockerfile
+++ b/flavors/c_cpp/Dockerfile
@@ -144,9 +144,8 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/cupcake/Dockerfile
+++ b/flavors/cupcake/Dockerfile
@@ -178,9 +178,8 @@ WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 typescript \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/documentation/Dockerfile
+++ b/flavors/documentation/Dockerfile
@@ -142,9 +142,8 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/dotnet/Dockerfile
+++ b/flavors/dotnet/Dockerfile
@@ -151,9 +151,8 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss \
                 gherkin-lint \
                 graphql \

--- a/flavors/dotnetweb/Dockerfile
+++ b/flavors/dotnetweb/Dockerfile
@@ -153,9 +153,8 @@ RUN npm --no-cache install --ignore-scripts --omit=dev \
                 typescript \
                 @coffeelint/cli \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss \
                 gherkin-lint \
                 graphql \

--- a/flavors/go/Dockerfile
+++ b/flavors/go/Dockerfile
@@ -149,9 +149,8 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/java/Dockerfile
+++ b/flavors/java/Dockerfile
@@ -142,9 +142,8 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/javascript/Dockerfile
+++ b/flavors/javascript/Dockerfile
@@ -143,9 +143,8 @@ RUN npm --no-cache install --ignore-scripts --omit=dev \
                 typescript \
                 @coffeelint/cli \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/php/Dockerfile
+++ b/flavors/php/Dockerfile
@@ -153,9 +153,8 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/python/Dockerfile
+++ b/flavors/python/Dockerfile
@@ -153,9 +153,8 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/ruby/Dockerfile
+++ b/flavors/ruby/Dockerfile
@@ -141,9 +141,8 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/rust/Dockerfile
+++ b/flavors/rust/Dockerfile
@@ -141,9 +141,8 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/salesforce/Dockerfile
+++ b/flavors/salesforce/Dockerfile
@@ -142,9 +142,8 @@ WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 @salesforce/cli \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/swift/Dockerfile
+++ b/flavors/swift/Dockerfile
@@ -143,9 +143,8 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/terraform/Dockerfile
+++ b/flavors/terraform/Dockerfile
@@ -147,9 +147,8 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss \
                 graphql \
                 graphql-schema-linter \

--- a/linters/css_stylelint/Dockerfile
+++ b/linters/css_stylelint/Dockerfile
@@ -95,9 +95,8 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 #NPM__START
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
-                stylelint-config-sass-guidelines \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-scss  && \
     echo "Cleaning npm cache…" \
     && npm cache clean --force || true \

--- a/megalinter/descriptors/css.megalinter-descriptor.yml
+++ b/megalinter/descriptors/css.megalinter-descriptor.yml
@@ -27,12 +27,12 @@ linters:
       - "stylelint --config .stylelintrc.json myfile.css myfile2.css myfile3.css"
       - "stylelint --fix --config .stylelintrc.json myfile.css myfile2.css myfile3.css"
     downgraded_version: true
-    downgraded_reason: Dependencies not compliant yet with stylelint 16, we'll upgrade when they are ready :)
+    downgraded_reason: Some dependencies not compliant yet with stylelint 16, we'll upgrade stylelint-config-sass-guidelines when it is ready :)
     install:
       npm:
-        - stylelint@15.11.0
-        - stylelint-config-standard@34.0.0
-        - stylelint-config-sass-guidelines
+        - stylelint
+        - stylelint-config-standard
+        #- stylelint-config-sass-guidelines
         - stylelint-scss
     ide:
       atom:


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

This PR is for discussion, I’m not completely sure what we want to choose. 

There was two options to solve the version conflicts that fail in main. Either downgrade stylelint-scss to 5.3.2 (instead of getting the new 6.0.0 that works with stylelint 16 only https://github.com/stylelint-scss/stylelint-scss/releases/tag/v5.3.2, or disable stylelint-config-sass-guidelines temporarily. Last time for stylelint 15, it took a long time to get it working (about one month, feb 9 to march 13). 

See https://github.com/bjankord/stylelint-config-sass-guidelines/issues/299


<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
