### PR TITLE
mega-linter-runner: Improve check if running as script or module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - mega-linter-runner: Remove container by default, except of `no-remove-container` option is sent
   - Upgrade base image from python:3.11.6-alpine3.18 to python:3.11.7-alpine3.18, by @echoix in [#3212](https://github.com/oxsecurity/megalinter/pull/3212)
   - Upgrade actions/upload-artifact@v3 to actions/upload-artifact@v4 in default workflows
+  - mega-linter-runner: Improve check if running as script or module, by @echoix in [#3233](https://github.com/oxsecurity/megalinter/pull/3233)
 
 - Media
 

--- a/mega-linter-runner/lib/index.js
+++ b/mega-linter-runner/lib/index.js
@@ -3,11 +3,26 @@
 import { MegaLinterRunner } from "./runner.js";
 import { MegaLinterRunnerCli } from "./cli.js";
 
+import { realpathSync } from "fs";
+import { pathToFileURL } from "url";
+
 // Run only if called by script
-const runningAsScript = (this === undefined);
+// This check handles symlinks as well
+// See https://stackoverflow.com/a/71925565 and
+// https://exploringjs.com/nodejs-shell-scripting/ch_nodejs-path.html#detecting-if-module-is-main
+function wasCalledAsScript() {
+  // We use realpathSync to resolve symlinks, as cli scripts will often
+  // be executed from symlinks in the `node_modules/.bin`-folder
+  const realPath = realpathSync(process.argv[1]);
+
+  // Convert the file-path to a file-url before comparing it
+  const realPathAsUrl = pathToFileURL(realPath).href;
+
+  return import.meta.url === realPathAsUrl;
+}
 
 // Run asynchronously to use the returned status for process.exit
-if (runningAsScript) {
+if (wasCalledAsScript()) {
   (async () => {
     await new MegaLinterRunnerCli().run(process.argv);
   })();


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Apparently the check for using the command line arguments to create the MegaLinterRunnerCli() when run as a script wasn’t working correctly since changed to use modules, at least in tests. That meant that all command line arguments (of the test invocation) were passed when the tests for modules was used (since called before), and since the no docker pull option isn’t in the argv of the mocha invocation, it pulled the latest Megalinter docker image (a second one) and started to lint the workspace instead of just doing the tests.

Here, the argv is really only passed when it is called a script and not a module.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
