### PR TITLE
Undowngrade stylelint-config-sass-guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Fixes
   - tekton-lint is now published as @ibm/tekton-lint, by @echoix in [#3210](https://github.com/oxsecurity/megalinter/pull/3210)
   - PHP PHIVE: Use keys.openpgp.org and fingerprint for phive key verification, by @echoix in [#3230](https://github.com/oxsecurity/megalinter/pull/3230)
+  - Undowngrade sass linters, by @echoix in [#3260](https://github.com/oxsecurity/megalinter/pull/3260)
 
 - Doc
   - Upgrade url to [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), as now the original repo is not maintained anymore.

--- a/Dockerfile
+++ b/Dockerfile
@@ -209,10 +209,10 @@ RUN npm --no-cache install --ignore-scripts --omit=dev \
                 typescript \
                 @coffeelint/cli \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2 \
+                stylelint-scss \
                 gherkin-lint \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/c_cpp/Dockerfile
+++ b/flavors/c_cpp/Dockerfile
@@ -144,10 +144,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2 \
+                stylelint-scss \
                 graphql \
                 graphql-schema-linter \
                 npm-groovy-lint \

--- a/flavors/cupcake/Dockerfile
+++ b/flavors/cupcake/Dockerfile
@@ -178,10 +178,10 @@ WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 typescript \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2 \
+                stylelint-scss \
                 graphql \
                 graphql-schema-linter \
                 npm-groovy-lint \

--- a/flavors/documentation/Dockerfile
+++ b/flavors/documentation/Dockerfile
@@ -142,10 +142,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2 \
+                stylelint-scss \
                 graphql \
                 graphql-schema-linter \
                 npm-groovy-lint \

--- a/flavors/dotnet/Dockerfile
+++ b/flavors/dotnet/Dockerfile
@@ -151,10 +151,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2 \
+                stylelint-scss \
                 gherkin-lint \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/dotnetweb/Dockerfile
+++ b/flavors/dotnetweb/Dockerfile
@@ -153,10 +153,10 @@ RUN npm --no-cache install --ignore-scripts --omit=dev \
                 typescript \
                 @coffeelint/cli \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2 \
+                stylelint-scss \
                 gherkin-lint \
                 graphql \
                 graphql-schema-linter \

--- a/flavors/go/Dockerfile
+++ b/flavors/go/Dockerfile
@@ -149,10 +149,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2 \
+                stylelint-scss \
                 graphql \
                 graphql-schema-linter \
                 npm-groovy-lint \

--- a/flavors/java/Dockerfile
+++ b/flavors/java/Dockerfile
@@ -142,10 +142,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2 \
+                stylelint-scss \
                 graphql \
                 graphql-schema-linter \
                 npm-groovy-lint \

--- a/flavors/javascript/Dockerfile
+++ b/flavors/javascript/Dockerfile
@@ -143,10 +143,10 @@ RUN npm --no-cache install --ignore-scripts --omit=dev \
                 typescript \
                 @coffeelint/cli \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2 \
+                stylelint-scss \
                 graphql \
                 graphql-schema-linter \
                 npm-groovy-lint \

--- a/flavors/php/Dockerfile
+++ b/flavors/php/Dockerfile
@@ -153,10 +153,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2 \
+                stylelint-scss \
                 graphql \
                 graphql-schema-linter \
                 npm-groovy-lint \

--- a/flavors/python/Dockerfile
+++ b/flavors/python/Dockerfile
@@ -153,10 +153,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2 \
+                stylelint-scss \
                 graphql \
                 graphql-schema-linter \
                 npm-groovy-lint \

--- a/flavors/ruby/Dockerfile
+++ b/flavors/ruby/Dockerfile
@@ -141,10 +141,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2 \
+                stylelint-scss \
                 graphql \
                 graphql-schema-linter \
                 npm-groovy-lint \

--- a/flavors/rust/Dockerfile
+++ b/flavors/rust/Dockerfile
@@ -141,10 +141,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2 \
+                stylelint-scss \
                 graphql \
                 graphql-schema-linter \
                 npm-groovy-lint \

--- a/flavors/salesforce/Dockerfile
+++ b/flavors/salesforce/Dockerfile
@@ -142,10 +142,10 @@ WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 @salesforce/cli \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2 \
+                stylelint-scss \
                 graphql \
                 graphql-schema-linter \
                 npm-groovy-lint \

--- a/flavors/swift/Dockerfile
+++ b/flavors/swift/Dockerfile
@@ -143,10 +143,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2 \
+                stylelint-scss \
                 graphql \
                 graphql-schema-linter \
                 npm-groovy-lint \

--- a/flavors/terraform/Dockerfile
+++ b/flavors/terraform/Dockerfile
@@ -147,10 +147,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
                 jscpd \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2 \
+                stylelint-scss \
                 graphql \
                 graphql-schema-linter \
                 npm-groovy-lint \

--- a/linters/css_stylelint/Dockerfile
+++ b/linters/css_stylelint/Dockerfile
@@ -95,10 +95,10 @@ ENV NODE_OPTIONS="--max-old-space-size=8192" \
 #NPM__START
 WORKDIR /node-deps
 RUN npm --no-cache install --ignore-scripts --omit=dev \
-                stylelint@15.11.0 \
-                stylelint-config-standard@34.0.0 \
+                stylelint \
+                stylelint-config-standard \
                 stylelint-config-sass-guidelines \
-                stylelint-scss@5.3.2  && \
+                stylelint-scss  && \
     echo "Cleaning npm cache…" \
     && npm cache clean --force || true \
     && echo "Changing owner of node_modules files…" \

--- a/megalinter/descriptors/css.megalinter-descriptor.yml
+++ b/megalinter/descriptors/css.megalinter-descriptor.yml
@@ -26,14 +26,12 @@ linters:
       - "stylelint myfile.css"
       - "stylelint --config .stylelintrc.json myfile.css myfile2.css myfile3.css"
       - "stylelint --fix --config .stylelintrc.json myfile.css myfile2.css myfile3.css"
-    downgraded_version: true
-    downgraded_reason: Dependencies not compliant yet with stylelint 16, we'll upgrade when they are ready :)
     install:
       npm:
-        - stylelint@15.11.0
-        - stylelint-config-standard@34.0.0
+        - stylelint
+        - stylelint-config-standard
         - stylelint-config-sass-guidelines
-        - stylelint-scss@5.3.2
+        - stylelint-scss
     ide:
       atom:
         - name: linter-stylelint


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

stylelint-config-sass-guidelines@v11.0.0 was released this morning, so we can undowngrade the linters pinned in the css descriptor.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
