### PR TITLE
Fixed console reporter warning symbol width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Downgrade stylelint to avoid crash with not v16 compliant dependencies
   - Fix count of yaml-lint errors
   - Remove openssl reinstall, as base image has updated version from alpine 3.18.5 by @echoix in <https://github.com/oxsecurity/megalinter/pull/3181>
+  - Fixed console reporter warning symbol width
 
 - CI
   - Add arguments to make use of pytest-xdist, by @echoix

--- a/megalinter/reporters/ConsoleReporter.py
+++ b/megalinter/reporters/ConsoleReporter.py
@@ -70,7 +70,7 @@ class ConsoleReporter(Reporter):
                 status = (
                     "✅"
                     if linter.status == "success" and linter.return_code == 0
-                    else "⚠️"
+                    else "⚠️ "
                     if linter.status != "success" and linter.return_code == 0
                     else "❌"
                 )


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

The width of the warning symbol ⚠️ seems to be too short by one character in the console reporter, at least with the terminals and fonts I've tried (iTerm2 and Terminal on Mac OS X). This leads to table alignment issues in the summary report. I've added one extra space to this symbol and updated the CHANGELOG. Not sure whether other people have the same issue or whether it's specific to my environment.

## Readiness Checklist

### Author/Contributor
- [X] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
