### PR TITLE
docs: Removed obsolete warning for semgrep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Fixes
 
 - Doc
+  - Removed obsolete warning for semgrep as the issue has been fixed
 
 - CI
 
@@ -269,7 +270,6 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Updated lintr config template to use `linters_with_defaults()` (formerly `with_defaults()`)
   - Fix csharp installation dependencies, by @nvuillam in <https://github.com/oxsecurity/megalinter/pull/3075>
   - Fix powershell installation by @nvuillam in <https://github.com/oxsecurity/megalinter/pull/3126>
-
 
 - Doc
   - Update lintr links to their current locations, by @echoix in [#3122](https://github.com/oxsecurity/megalinter/issues/3122)

--- a/megalinter/descriptors/repository.megalinter-descriptor.yml
+++ b/megalinter/descriptors/repository.megalinter-descriptor.yml
@@ -385,8 +385,6 @@ linters:
     linter_repo: https://github.com/returntocorp/semgrep
     linter_speed: 1
     linter_text: |
-      **Disabled until https://github.com/semgrep/semgrep/issues/9632 is solved**
-
       To use SemGrep in MegaLinter you must define a list of rulesets to use.
 
       Example: `REPOSITORY_SEMGREP_RULESETS: ["p/docker-compose","p/owasp-top-ten"]`


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes https://github.com/oxsecurity/megalinter/issues/3372

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Readiness Checklist

### Author/Contributor
- [X] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [X] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
