### PR TITLE
fix(trivy): update scanner from `config` to `misconfig`

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -992,6 +992,7 @@
         "mhutchie",
         "midrule",
         "miniprettier",
+        "misconfig",
         "mkdir",
         "mkdirs",
         "mkdocs",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - New linters
 
 - Fixes
+  - Trivy: use `misconfig` instead of the deprecated `config` scanner, updating the default arguments
 
 - Doc
   - Removed obsolete warning for semgrep as the issue has been fixed

--- a/megalinter/descriptors/repository.megalinter-descriptor.yml
+++ b/megalinter/descriptors/repository.megalinter-descriptor.yml
@@ -491,14 +491,14 @@ linters:
     cli_lint_extra_args:
       - fs
       - --scanners
-      - vuln,config
+      - vuln,misconfig
       - --exit-code
       - "1"
     cli_lint_extra_args_after:
       - "."
     test_folder: trivy
     examples:
-      - "trivy fs --scanners vuln,config ."
+      - "trivy fs --scanners vuln,misconfig ."
     install:
       dockerfile:
         - |


### PR DESCRIPTION
The scanner `config` was deprecated and replaced by `misconfig`.

```
2024-02-13T08:04:44.128Z	WARN	'--scanner config' is deprecated. Use '--scanner misconfig' instead. See https://github.com/aquasecurity/trivy/discussions/5586 for the detail.
```

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
