### PR TITLE
fix(pmd): error count in summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Trivy: use `misconfig` instead of the deprecated `config` scanner, updating the default arguments
   - Update calls to sfdx-scanner to output a CSV file for Aura & LWC
   - Kics: fixed error count in the summary table
+  - pmd: fixed error count in the summary table
 
 - Doc
   - Removed obsolete warning for semgrep as the issue has been fixed

--- a/megalinter/descriptors/java.megalinter-descriptor.yml
+++ b/megalinter/descriptors/java.megalinter-descriptor.yml
@@ -80,6 +80,8 @@ linters:
     cli_lint_mode: list_of_files
     cli_executable: /usr/bin/pmd/bin/run.sh
     config_file_name: java-pmd-ruleset.xml
+    cli_lint_errors_count: "regex_sum"
+    cli_lint_errors_regex: "Found ([0-9]+) errors"
     cli_config_arg_name: "--rulesets"
     cli_sarif_args:
       - --format


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes error count for pmd linter

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

```yml
cli_lint_errors_count: "regex_sum"
cli_lint_errors_regex: "Found ([0-9]+) errors"
```

## Readiness Checklist

### Author/Contributor
- [X] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [X] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
