### PR TITLE
Fix conflict prettier/yamllint

### DIFF
--- a/TEMPLATES/.yamllint.yml
+++ b/TEMPLATES/.yamllint.yml
@@ -8,6 +8,8 @@
 ###########################################
 extends: default
 rules:
+  braces:
+    max-spaces-inside: 1
   new-lines:
     level: warning
     type: unix


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes conflict between prettier and yamlint in megalinter on yaml files
Prettier will reformat {jobName: !Ref XXX}" to { jobName: !Ref XXX }
Yamllint will then output an error regarding spaces in braces.

Proposed change is to relax Yamllint to support prettier reformatted file.

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
