### PR TITLE
Ensure trufflehog does not auto-update itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Fixes
   - Fix conflict between prettier and yamllint about spaces
+  - Ensure [trufflehog](https://github.com/trufflesecurity/trufflehog) does not auto-update itself
 
 - Doc
 

--- a/megalinter/descriptors/repository.megalinter-descriptor.yml
+++ b/megalinter/descriptors/repository.megalinter-descriptor.yml
@@ -577,6 +577,7 @@ linters:
       - "."
       - --fail
       - --only-verified
+      - --no-update
     cli_help_arg_name: --help
     cli_version_arg_name: --version
     examples:


### PR DESCRIPTION
It looks like that the [trufflehog](https://github.com/trufflesecurity/trufflehog) linter auto-updates itself to the latest version when run. That makes the pinning of its version ineffective and causes builds to be non deterministic.

I have discovered such behavior by suddenly stumbling upon a false positive, probably due to a [change](https://github.com/trufflesecurity/trufflehog/pull/2372) introduced in the latest release [v3.70.0](https://github.com/trufflesecurity/trufflehog/releases/tag/v3.70.0).

## Proposed Changes

1. Ensure trufflehog does not auto-update itself

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
