### PR TITLE
fix: remove `TEMPLATES/.secretlintignore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Salesforce linters: use sf + default Flow Scanner rules
   - Disable JSON_ESLINT_PLUGIN_JSONC until <https://github.com/ota-meshi/eslint-plugin-jsonc/issues/328> is fixed
   - Upgrade tar in mega-linter-runner
+  - secretlint: remove default `.secretlintignore` that was never used but `.gitignore` is used instead. Fixes [#3328](https://github.com/oxsecurity/megalinter/issues/3328)
 
 - Doc
   - Update R2DevOps logo

--- a/TEMPLATES/.secretlintignore
+++ b/TEMPLATES/.secretlintignore
@@ -1,1 +1,0 @@
-megalinter-reports

--- a/docs/descriptors/repository_secretlint.md
+++ b/docs/descriptors/repository_secretlint.md
@@ -20,7 +20,7 @@ description: How to use secretlint (configure, ignore files, ignore errors, help
 - See [How to configure secretlint rules](https://github.com/secretlint/secretlint#configuration){target=_blank}
   - If custom `.secretlintrc.json` config file isn't found, [.secretlintrc.json](https://github.com/oxsecurity/megalinter/tree/main/TEMPLATES/.secretlintrc.json){target=_blank} will be used
 - See [How to ignore files and directories with secretlint](https://github.com/secretlint/secretlint/blob/master/docs/configuration.md#secretlintignore){target=_blank}
-  - If custom `.secretlintignore` ignore file is not found, [.secretlintignore](https://github.com/oxsecurity/megalinter/tree/main/TEMPLATES/.secretlintignore){target=_blank} will be used
+  - You can define a `.secretlintignore` file to ignore files and folders
 - See [Index of problems detected by secretlint](https://github.com/secretlint/secretlint#rule-packages){target=_blank}
 
 [![secretlint - GitHub](https://gh-card.dev/repos/secretlint/secretlint.svg?fullname=)](https://github.com/secretlint/secretlint){target=_blank}


### PR DESCRIPTION
Removes the default `.secretlintignore`
that was actually never applied.

If `.secretlintignore` is absent,
`.gitignore` is used instead.

Removing this default config will adjust
the misleading documentation as well.

Fixes #3328

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
