### PR TITLE
[build-command] Use uv to install Python deps for CI

### DIFF
--- a/.github/workflows/build-command.yml
+++ b/.github/workflows/build-command.yml
@@ -69,7 +69,8 @@ jobs:
           python-version-file: '.python-version' # Read python version from a file .python-version
           # Used to specify a package manager for caching in the default directory. Supported values: pip, pipenv, poetry.
           cache: pip # optional
-      - run: pip install -r .config/python/dev/requirements.txt
+      - run: python -m pip install uv
+      - run: uv pip install --system -r .config/python/dev/requirements.txt
       - name: Create comment starting build.sh
         uses: peter-evans/create-or-update-comment@v4
         with:


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

I just wanted to try it out with an upcoming PR, and it’s quite impressive.
With cached dependencies, the old way method took 25-40s to install the deps. (https://github.com/echoix/megalinter/actions/runs/9121261204/job/25080127542#step:8:1 and https://github.com/echoix/megalinter/actions/runs/9120700814/job/25078549631#step:8:1)

Here, WITHOUT cached dependencies, it took less than 5 secs (https://github.com/echoix/megalinter/actions/runs/9121318153/job/25080283053#step:9:1)


I used the pip to install uv, but it could’ve been with the shell script one liner.

I had to use the `--system` flag to let it use the global install in CI, and to not require a venv.

Otherwise, it’s quite easy.


<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
