### PR TITLE
Update `ktlint` descriptor to support `list_of_files` and better error counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - `API_SPECTRAL` was added as replacement for `OPENAPI_SPECTRAL` (deprecated), supporting AsyncAPI and OpenAPI by default. Uses Spectral's standard config file name `.spectral.yaml` instead of `.openapirc.yml` with a default config with rulesets for AsyncAPI and OpenAPI enabled. Fixes [#3387](https://github.com/oxsecurity/megalinter/issues/3387)
   - Disable SQL_TSQLLINT until security issues are solved. Related to <https://github.com/tsqllint/tsqllint/issues/333>
   - PHP linters (PHP_PHPCS, PHP_PHPLINT, PHP_PHPSTAN) add support to SARIF report output format with help of <https://github.com/llaville/sarif-php-sdk>
+  - `KOTLIN_KTLINT` now supports `list_of_files` mode, and has better error counting
 
 - Reporters
 

--- a/megalinter/descriptors/kotlin.megalinter-descriptor.yml
+++ b/megalinter/descriptors/kotlin.megalinter-descriptor.yml
@@ -22,6 +22,9 @@ linters:
     linter_banner_image_url: https://miro.medium.com/max/655/1*sLboL6JnC9yUodFsdSMB-w.png
     linter_megalinter_ref_url: https://github.com/pinterest/ktlint#-with-continuous-integration
     cli_lint_fix_arg_name: "--format"
+    cli_lint_mode: list_of_files
+    cli_lint_errors_count: regex_sum
+    cli_lint_errors_regex: '\s+[\w\-_]+:[\w\-_]+: ([0-9]+)'
     cli_sarif_args:
       - --reporter=sarif,output={{SARIF_OUTPUT_FILE}}
     examples:


### PR DESCRIPTION
Fixes #1441

## Proposed Changes

1. Enable `list_of_files` mode in `KOTLIN_KTLINT` (which it [supports OOB](https://pinterest.github.io/ktlint/latest/install/cli/#globs))
2. Configured regex to better count violations

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

Unfortunately, I haven't been able for the life of me to run a proper build and test, as `make` is causing all sorts of headaches that I couldn't figure out... The `make` version in MacOS is very old (3.81 from 2006) and the newer version I installed (4.4.1, called `gmake`) somehow hangs even on trivial tasks like `gmake help`.

So I've only been able to test by compiling a local image, since the dockerfile appears unchanged (`docker buildx build -f linters/kotlin_ktlint/Dockerfile .`) and run it, but I couldn't rebuild everything and run tests...

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
