### PR TITLE
fix(pylint): overgeneral-exceptions fully qualified name

### DIFF
--- a/.github/linters/.pylintrc
+++ b/.github/linters/.pylintrc
@@ -461,4 +461,4 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/TEMPLATES/.pylintrc
+++ b/TEMPLATES/.pylintrc
@@ -467,4 +467,4 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes errors like this:
```
- MegaLinter key: [PYTHON_PYLINT]
- Rules config: [.pylintrc]
- Number of files analyzed: [6]
--Error detail:
pylint: Command line or configuration file:1: UserWarning: 'Exception' is not a proper value for the 'overgeneral-exceptions' option. Use fully qualified name (maybe 'builtins.Exception' ?) instead. This will cease to be checked at runtime when the configuration upgrader is released.
```

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

The `overgeneral-exceptions` option in pylint [now requires](https://github.com/pylint-dev/pylint/pull/8411) a fully qualified name.
Even though this has already been fixed in the megalinter pylint docs: 
https://github.com/oxsecurity/megalinter/blob/69b1261c1aacc1d4d61d5a024ff69b9aacede81c/docs/descriptors/python_pylint.md?plain=1#L723-L726

Ps. Perhaps linter config should also be auto updated in addition to the [linter docs](https://github.com/oxsecurity/megalinter/pull/3488)?

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
