### PR TITLE
enhancement: Powershell Error Table Format Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Fixes
   - [syft](https://github.com/anchore/syft) use `scan` instead of deprecated `packages` arg
+  - [Powershell](https://github.com/PowerShell/PSScriptAnalyzer#readme) Error table truncation improvements
 
 - Doc
 

--- a/megalinter/linters/PowershellLinter.py
+++ b/megalinter/linters/PowershellLinter.py
@@ -6,7 +6,7 @@ https://github.com/PowerShell/PSScriptAnalyzer
 import sys
 from shutil import get_terminal_size
 
-from megalinter import Linter, config
+from megalinter import Linter, config, utils
 
 
 class PowershellLinter(Linter):
@@ -56,17 +56,10 @@ class PowershellLinter(Linter):
             and self.cli_lint_fix_arg_name is not None
         ):
             pwsh_script[0] += f" {self.cli_lint_fix_arg_name}"
+
         if self.linter_name == "powershell":
-            # Enforce table output for easier parsing of number of errors
-            # (severity first)
-            pwsh_script[
-                0
-            ] += " | Format-Table -AutoSize -Wrap -Property Severity, RuleName, ScriptName, Line, Message"
-            # Format output to fit in terminal, respecting the terminal width.
-            # Use good defaults, shutil respects COLUMNS env var. For more info:
-            # https://stackoverflow.com/a/76889369
-            size = get_terminal_size()
-            pwsh_script[0] += f" | Out-String -Width {size.columns}"
+            pwsh_script[0] = self.format_powershell_output(pwsh_script[0])
+
         cmd = [
             *self.cli_executable,
             "-NoProfile",
@@ -75,6 +68,24 @@ class PowershellLinter(Linter):
             "\n".join(pwsh_script),
         ]
         return cmd
+
+    def format_powershell_output(self, pwsh_script):
+        if utils.is_ci():
+            width = 150  # Use a default width in CI environments to prevent output cutoff
+        else:
+            width = get_terminal_size().columns  # Use the terminal width when not in CI
+
+        # Format the output to a table with specific columns
+        pwsh_script += " | Format-Table -AutoSize -Wrap -Property " \
+                   "@{Name='Severity'; Expression={$_.Severity}; Alignment='left'}," \
+                   " @{Name='RuleName'; Expression={$_.RuleName}; Alignment='left'}," \
+                   " @{Name='ScriptName'; Expression={$_.ScriptName}; Alignment='left'}," \
+                   " @{Name='Line'; Expression={$_.Line}; Alignment='right'}," \
+                   " @{Name='Message'; Expression={$_.Message}; Alignment='left'}"
+
+        # Ensure the output string fits within the specified width
+        pwsh_script += f" | Out-String -Width {width}"
+        return pwsh_script
 
     # Build the CLI command to get linter version
     def build_version_command(self):


### PR DESCRIPTION
Fixes #3603


## Proposed Changes

1. Check if we are running in a CI environment (github_actions, gitlab_ci, azure_pipelines) and if so use a default table width of 150.
2. Default back to getting the terminal size if we are not in a CI environment. (Existing functionality)
3. Cleaned up alignment of columns.

## Test Results

**AZURE DEVOPS**
![image](https://github.com/oxsecurity/megalinter/assets/8810400/e4d41bf3-a88a-4db2-898e-a15e1e0eedd1)

**GITLAB**
![image](https://github.com/oxsecurity/megalinter/assets/8810400/62653fb0-2013-4d18-9c14-1036c3f61060)

**GITHUB**
![image](https://github.com/oxsecurity/megalinter/assets/8810400/bc891c8b-66b1-4bde-8d0d-83dece447928)


## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)

### Reviewing Maintainer
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
