### PR TITLE
Add python package Pygments to rst-lint venv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Media
 
 - Linters
+  - Add python package Pygments to rst-lint venv
 
 - Reporters
 

--- a/megalinter/descriptors/rst.megalinter-descriptor.yml
+++ b/megalinter/descriptors/rst.megalinter-descriptor.yml
@@ -16,6 +16,7 @@ linters:
       - "rst-lint myfile.rst"
     install:
       pip:
+        - Pygments
         - restructuredtext_lint
   # rstcheck
   - linter_name: rstcheck


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Add Pygments to venv of rst-lint linter

* used to scan the code block of rst files 
* removes the warning like this

`WARNING path/to/file.rst:52 Cannot analyze code. Pygments package not found.`

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
