### PR TITLE
Add label to renovate PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,7 +6,8 @@
     "customManagers:dockerfileVersions",
     ":maintainLockFilesWeekly",
     ":separateMultipleMajorReleases",
-    ":semanticCommits"
+    ":semanticCommits",
+    ":label(dependencies)"
   ],
   "customManagers": [
     // This is "customManagers:dockerfileVersions":


### PR DESCRIPTION

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

I observed that dependabot PRs had labels while renovate didn't have some assigned.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
