### PR TITLE
enhancement: CSharpier config filename and path override ability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Linters
   - Add python package Pygments to rst-lint venv
+  - [CSharpier](https://csharpier.com) added ability to override config filename and path
 
 - Reporters
 

--- a/megalinter/descriptors/csharp.megalinter-descriptor.yml
+++ b/megalinter/descriptors/csharp.megalinter-descriptor.yml
@@ -45,6 +45,8 @@ linters:
     linter_rules_configuration_url: https://csharpier.com/docs/Configuration
     linter_rules_ignore_config_url: https://csharpier.com/docs/Ignore
     ignore_file_name: .csharpierignore
+    config_file_name: .csharpierrc
+    cli_config_arg_name: "--config-path"
     cli_executable: dotnet-csharpier
     cli_lint_mode: list_of_files
     cli_lint_extra_args:

--- a/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
@@ -3297,6 +3297,13 @@
       "title": "CSHARP_CSHARPIER: Override default cli lint mode",
       "type": "string"
     },
+    "CSHARP_CSHARPIER_CONFIG_FILE": {
+      "$id": "#/properties/CSHARP_CSHARPIER_CONFIG_FILE",
+      "default": ".csharpierrc",
+      "description": "CSHARP_CSHARPIER: User custom config file name if different from default",
+      "title": "CSHARP_CSHARPIER: Custom config file name",
+      "type": "string"
+    },
     "CSHARP_CSHARPIER_COMMAND_REMOVE_ARGUMENTS": {
       "$id": "#/properties/CSHARP_CSHARPIER_COMMAND_REMOVE_ARGUMENTS",
       "description": "CSHARP_CSHARPIER: User custom arguments to remove before calling linter",
@@ -3392,6 +3399,12 @@
       },
       "title": "CSHARP_CSHARPIER: Define or override a list of bash commands to run before the linter",
       "type": "array"
+    },
+    "CSHARP_CSHARPIER_RULES_PATH": {
+      "$id": "#/properties/CSHARP_CSHARPIER_RULES_PATH",
+      "description": "CSHARP_CSHARPIER: Path where to find linter configuration file",
+      "title": "CSHARP_CSHARPIER: Custom config file path",
+      "type": "string"
     },
     "CSHARP_CSHARPIER_UNSECURED_ENV_VARIABLES": {
       "$id": "#/properties/CSHARP_CSHARPIER_UNSECURED_ENV_VARIABLES",


### PR DESCRIPTION
Fixes #3553

# [CSharpier](https://csharpier.com) - Filename and path override improvements
This change adds the ability to override the location of the `.csharpierrc ` filename and path. Currently its using the default option for the command `-c` which is incorrect and requires `--config-path ` [csharpier documentation](https://csharpier.com/docs/CLI).
This also now allows the `.csharpierrc ` file to be placed in the default linter path which currently doesn't work due to the wrong command parameter.

Please note this doesn't allow an `.editorconfig` to work in another location as this isnt currently supported by csharpier. (see [issue 3553](https://github.com/oxsecurity/megalinter/issues/3553) for more info) However if this changes then the fix should also work nicely with this approach as well.

## Proposed Changes

1. Fixed config path option command.
2. Added default file name .csharpierrc.
3. Updated schema to reflext the 2 new available options avaiable. (assumed this was required but please say if this isn't or I need to update anything else?)

## Testing - Mixture of CI builds to demonstrate the fix

**GITLAB - Both filename and location overridden:**
![image](https://github.com/oxsecurity/megalinter/assets/8810400/8927ab96-9c23-4918-9e7f-853b85b4f6cf)
![image](https://github.com/oxsecurity/megalinter/assets/8810400/5fa7fd9e-3ee1-411d-b7b2-2bf8f12be49a)

**GITLAB - .csharpierrc in default Linter rules location:**
![image](https://github.com/oxsecurity/megalinter/assets/8810400/ad4a4c40-c358-4869-9986-12f7072a9732)

**AZURE - Filename overridden .csharpierrc.yml in default Linter rules location:**
![image](https://github.com/oxsecurity/megalinter/assets/8810400/eadd15c4-aa1e-4f30-87f3-d4b9ec867dba)
![image](https://github.com/oxsecurity/megalinter/assets/8810400/0ee29b73-b7c1-4cc5-85d4-847b50f544d9)

**GITHUB - Filename .csharpierrc.yml in root (no extra megalinter parameters set):**
![image](https://github.com/oxsecurity/megalinter/assets/8810400/168bd3db-8120-42d9-a86d-21b2ef1c2a1c)
