### PR TITLE
bug: CVE-2024-0057 re-ignored

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,6 @@
+# .NET sdk
+CVE-2024-0057
+
 # Devskim
 CVE-2018-8292
 CVE-2019-0820


### PR DESCRIPTION
Was removed in error from the `.trivyignore` on a previous PR which is now preventing images with dotnet passing `Trivy` tests.

`# .NET sdk`
`CVE-2024-0057`