### PR TITLE
Format mkdocs search index in place

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,8 +19,7 @@ fi
 # Prettify `search_index.json` after `mkdocs`
 # `mkdocs` removed its own prettify few years ago: https://github.com/mkdocs/mkdocs/pull/1128
 if type python3 >/dev/null 2>/dev/null; then
-  python3 -m json.tool ./site/search/search_index.json >./site/search/search_index_new.json
+  python3 -m json.tool --sort-keys --no-indent ./site/search/search_index.json ./site/search/search_index.json
 else
-  python -m json.tool ./site/search/search_index.json >./site/search/search_index_new.json
+  python -m json.tool --sort-keys --no-indent ./site/search/search_index.json ./site/search/search_index.json
 fi
-mv -f -- ./site/search/search_index_new.json ./site/search/search_index.json


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

The python module json.tool can use the same file as input and output, that formats in place.
We can also specify to sort the keys, since mkdocs does not assure the order of the keys. It will result in a smaller diff between page builds.

I also set the no indent flag, so there are newlines, but without extra spaces or tabs. The file is a little smaller (faster to load), and still the same facility for git to diff lines (instead of compact, where the whole file is in one line and needs to be replaced)
See https://docs.python.org/3/library/json.html#cmdoption-json.tool-indent



I was about to include this in my pyproject.toml PR, but it can be here alone first
<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
