### PR TITLE
JOB_SUMMARY_ADDITIONAL_MARKDOWN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Core
   - Allow to tag PRE_COMMANDS to run them before loading plugins, by @nvuillam in <https://github.com/oxsecurity/megalinter/pull/3944>
   - Replace usage of setup.py with a pyproject.toml package install, by @echoix in [#3893](https://github.com/oxsecurity/megalinter/pull/3893)
+  - Allow to add custom messages at the end of PR / MR MegaLinter Summary using variable **JOB_SUMMARY_ADDITIONAL_MARKDOWN**
 
 - New linters
   - New LUA linter: [**selene**](https://github.com/Kampfkarren/selene), by @AlejandroSuero in <https://github.com/oxsecurity/megalinter/pull/3978>

--- a/docs/reporters/AzureCommentReporter.md
+++ b/docs/reporters/AzureCommentReporter.md
@@ -42,3 +42,4 @@ Example:
 | AZURE_COMMENT_REPORTER            | Activates/deactivates reporter                                                     | true          |
 | AZURE_COMMENT_REPORTER_LINKS_TYPE | Set to `build` if you want comments linking to target Build and not artifacts page | `artifacts`   |
 | REPORTERS_MARKDOWN_TYPE           | Set to `simple` to avoid external images in generated markdown                     | `advanced`    |
+| JOB_SUMMARY_ADDITIONAL_MARKDOWN   | Custom markdown to add at the end of the summary message                           | <!-- -->      |

--- a/docs/reporters/BitbucketCommentReporter.md
+++ b/docs/reporters/BitbucketCommentReporter.md
@@ -27,3 +27,4 @@ If you really want a new PR comment for each MegaLinter run, define variable `BI
 | BITBUCKET_COMMENT_REPORTER                   | Activates/deactivates reporter                                                               | `true`        |
 | BITBUCKET_REPO_ACCESS_TOKEN                  | Must contain a Bitbucket repository access token defined with api access                     | <!-- -->      |
 | BITBUCKET_COMMENT_REPORTER_OVERWRITE_COMMENT | Set to false to not overwrite existing comments in case of new runs on the same Pull Request | `true`        |
+| JOB_SUMMARY_ADDITIONAL_MARKDOWN              | Custom markdown to add at the end of the summary message                                     | <!-- -->      |

--- a/docs/reporters/GitHubCommentReporter.md
+++ b/docs/reporters/GitHubCommentReporter.md
@@ -22,3 +22,4 @@ Click on hyperlinks to access detailed logs
 | GITHUB_SERVER_URL       | URL of the GitHub instance<br/>Must be overridden if using GitHub Enterprise              | `https://github.com`     |                                              |
 | CI_ACTION_RUN_URL       | URL of the CI job visualization page url (if using Github but not GitHub Actions)         | <!--  -->                |                                              |
 | REPORTERS_MARKDOWN_TYPE | Set to `simple` to avoid external images in generated markdown                            | `advanced`               |                                              |
+| JOB_SUMMARY_ADDITIONAL_MARKDOWN              | Custom markdown to add at the end of the summary message                                     | <!-- -->      |

--- a/docs/reporters/GitlabCommentReporter.md
+++ b/docs/reporters/GitlabCommentReporter.md
@@ -32,7 +32,7 @@ If you really want a new MR comment for each MegaLinter run, define variable `GI
 | GITLAB_CUSTOM_CERTIFICATE                 | SSL certificate value to connect to Gitlab                                                             | <!-- -->      |
 | GITLAB_CERTIFICATE_PATH                   | Path to SSL certificate to connect to Gitlab (if SSL cert has been manually defined with PRE_COMMANDS) | <!-- -->      |
 | REPORTERS_MARKDOWN_TYPE                   | Set to `simple` to avoid external images in generated markdown                                         | `advanced`    |
-| JOB_SUMMARY_ADDITIONAL_MARKDOWN              | Custom markdown to add at the end of the summary message                                     | <!-- -->      |
+| JOB_SUMMARY_ADDITIONAL_MARKDOWN           | Custom markdown to add at the end of the summary message                                               | <!-- -->      |
 
 ## Special Thanks
 

--- a/docs/reporters/GitlabCommentReporter.md
+++ b/docs/reporters/GitlabCommentReporter.md
@@ -32,6 +32,7 @@ If you really want a new MR comment for each MegaLinter run, define variable `GI
 | GITLAB_CUSTOM_CERTIFICATE                 | SSL certificate value to connect to Gitlab                                                             | <!-- -->      |
 | GITLAB_CERTIFICATE_PATH                   | Path to SSL certificate to connect to Gitlab (if SSL cert has been manually defined with PRE_COMMANDS) | <!-- -->      |
 | REPORTERS_MARKDOWN_TYPE                   | Set to `simple` to avoid external images in generated markdown                                         | `advanced`    |
+| JOB_SUMMARY_ADDITIONAL_MARKDOWN              | Custom markdown to add at the end of the summary message                                     | <!-- -->      |
 
 ## Special Thanks
 

--- a/docs/reporters/MarkdownSummaryReporter.md
+++ b/docs/reporters/MarkdownSummaryReporter.md
@@ -23,3 +23,4 @@ Activate the reporter (`MARKDOWN_SUMMARY_REPORTER: true`) to generate markdown s
 |-------------------------------------|---------------------------------------------------|------------------------|
 | MARKDOWN_SUMMARY_REPORTER           | Activates/deactivates reporter                    | `false`                |
 | MARKDOWN_SUMMARY_REPORTER_FILE_NAME | File name for MARKDOWN_SUMMARY report output file | `megalinter-report.md` |
+| JOB_SUMMARY_ADDITIONAL_MARKDOWN              | Custom markdown to add at the end of the summary message                                     | <!-- -->      |

--- a/docs/reporters/MarkdownSummaryReporter.md
+++ b/docs/reporters/MarkdownSummaryReporter.md
@@ -19,8 +19,8 @@ Activate the reporter (`MARKDOWN_SUMMARY_REPORTER: true`) to generate markdown s
 
 ## Configuration
 
-| Variable                            | Description                                       | Default value          |
-|-------------------------------------|---------------------------------------------------|------------------------|
-| MARKDOWN_SUMMARY_REPORTER           | Activates/deactivates reporter                    | `false`                |
-| MARKDOWN_SUMMARY_REPORTER_FILE_NAME | File name for MARKDOWN_SUMMARY report output file | `megalinter-report.md` |
-| JOB_SUMMARY_ADDITIONAL_MARKDOWN              | Custom markdown to add at the end of the summary message                                     | <!-- -->      |
+| Variable                            | Description                                              | Default value          |
+|-------------------------------------|----------------------------------------------------------|------------------------|
+| MARKDOWN_SUMMARY_REPORTER           | Activates/deactivates reporter                           | `false`                |
+| MARKDOWN_SUMMARY_REPORTER_FILE_NAME | File name for MARKDOWN_SUMMARY report output file        | `megalinter-report.md` |
+| JOB_SUMMARY_ADDITIONAL_MARKDOWN     | Custom markdown to add at the end of the summary message | <!-- -->               |

--- a/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
@@ -8138,6 +8138,12 @@
       "title": "Pre commands for JAVA descriptor",
       "type": "array"
     },
+    "JOB_SUMMARY_ADDITIONAL_MARKDOWN": {
+      "$id": "#/properties/JOB_SUMMARY_ADDITIONAL_MARKDOWN",
+      "description": "Custom markdown to add at the end of the summary message posted on a PR/MR",
+      "title": "Job Summary additional markdown",
+      "type": "string"
+    },
     "JSON_ESLINT_PLUGIN_JSONC_ARGUMENTS": {
       "$id": "#/properties/JSON_ESLINT_PLUGIN_JSONC_ARGUMENTS",
       "description": "JSON_ESLINT_PLUGIN_JSONC: User custom arguments to add in linter CLI call",

--- a/megalinter/utils_reporter.py
+++ b/megalinter/utils_reporter.py
@@ -158,6 +158,11 @@ def build_markdown_summary(reporter_self, action_run_url=""):
             + "(https://www.ox.security/wp-content/uploads/2022/06/"
             + "logo.svg?ref=megalinter_comment)](https://www.ox.security/?ref=megalinter)_"
         )
+    if config.exists(reporter_self.master.request_id, "JOB_SUMMARY_ADDITIONAL_MARKDOWN"):
+         p_r_msg += (
+            os.linesep
+            + config.get(reporter_self.master.request_id, "JOB_SUMMARY_ADDITIONAL_MARKDOWN", "")
+         )
     logging.debug("\n" + p_r_msg)
     return p_r_msg
 

--- a/megalinter/utils_reporter.py
+++ b/megalinter/utils_reporter.py
@@ -158,11 +158,12 @@ def build_markdown_summary(reporter_self, action_run_url=""):
             + "(https://www.ox.security/wp-content/uploads/2022/06/"
             + "logo.svg?ref=megalinter_comment)](https://www.ox.security/?ref=megalinter)_"
         )
-    if config.exists(reporter_self.master.request_id, "JOB_SUMMARY_ADDITIONAL_MARKDOWN"):
-         p_r_msg += (
-            os.linesep
-            + config.get(reporter_self.master.request_id, "JOB_SUMMARY_ADDITIONAL_MARKDOWN", "")
-         )
+    if config.exists(
+        reporter_self.master.request_id, "JOB_SUMMARY_ADDITIONAL_MARKDOWN"
+    ):
+        p_r_msg += os.linesep + config.get(
+            reporter_self.master.request_id, "JOB_SUMMARY_ADDITIONAL_MARKDOWN", ""
+        )
     logging.debug("\n" + p_r_msg)
     return p_r_msg
 


### PR DESCRIPTION
Allow to add custom messages at the end of PR / MR MegaLinter Summary using variable **JOB_SUMMARY_ADDITIONAL_MARKDOWN**

Fixes https://github.com/oxsecurity/megalinter/issues/4028