### PR TITLE
fix(doc): fixed NOTIF_API_BASIC_AUTH_PASSWORD typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Doc
   - Update PRE_COMMANDS documentation to describe all properties
+  - Update Grafana documentation to fix secrets typo
 
 - Flavors
 

--- a/docs/reporters/ApiReporter.md
+++ b/docs/reporters/ApiReporter.md
@@ -206,7 +206,7 @@ Copy value of Authentication -> User and paste it with variable `API_REPORTER_BA
 
 Example: `API_REPORTER_BASIC_AUTH_USERNAME=898189`
 
-Leave NOTIF_API_BASIC_AUTH_PASSWORD empty for now, you can't get it here
+Leave `API_REPORTER_BASIC_AUTH_PASSWORD` empty for now, you can't get it here
 
 ![](../assets/images/grafana-config-5.jpg)
 


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes
Fixed the grafana doc, the secret `NOTIF_API_BASIC_AUTH_PASSWORD` doesn't exist

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
