### PR TITLE
Fix AzureCommentReporter where repo names contain spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Reporters
   - Fix AzureCommentReporter not adding comments to PR on 2024-10-15
+  - Fix AzureCommentReporter fails when target repo contains spaces on 2024-10-23
 
 - Doc
   - Updated documentation with Azure central pipeline use case on 2024-10-16

--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ pool:
   vmImage: ubuntu-latest
 
 variables:
-  repoName: $[ split(variables['System.PullRequest.SourceRepositoryURI'], '/')[6] ]
+  repoName: $[ replace(split(variables['System.PullRequest.SourceRepositoryURI'], '/')[6], '%20', ' ') ]
 
 steps:
   # Checkout triggering repo

--- a/megalinter/reporters/AzureCommentReporter.py
+++ b/megalinter/reporters/AzureCommentReporter.py
@@ -116,7 +116,7 @@ class AzureCommentReporter(Reporter):
                     + "See https://learn.microsoft.com/en-us/azure/devops/pipelines/"
                     + "build/variables?view=azure-devops&tabs=yaml"
                 )
-                repository_name = SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI.split("/")[-1]
+                repository_name = SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI.split("/")[-1].replace('%20', ' ')
                 repository = git_client.get_repository(
                     repository_name, SYSTEM_TEAMPROJECT
                 )


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #4184 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

When using `SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI` variable any repositories that have spaces in the name will need the `%20` URL encoded space converted back to a space.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
