### PR TITLE
Add new flavor definition style, add bioinformatics flavor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-linter.yml file, or with `oxsecurity/megalinter:beta` docker image
 
 - Core
+  - Allow flavors to be completely defined in `flavor_factory.py`
 
 - New linters
 
@@ -36,6 +37,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Update DevSkim documentation to show a valid exclusion config file
 
 - Flavors
+  - Add bioinformatics flavor
 
 - CI
   - Also prune volumes before pulling and pushing to docker hub

--- a/megalinter/flavor_factory.py
+++ b/megalinter/flavor_factory.py
@@ -65,6 +65,21 @@ def list_megalinter_flavors():
         "security": {"label": "Optimized for security", "strict": True},
         "swift": {"label": "Optimized for SWIFT based projects"},
         "terraform": {"label": "Optimized for TERRAFORM based projects"},
+        "bioinformatics": {
+            "label": "Optimized for bioinformatics projects",
+            "strict": True,
+            "descriptors": [
+                "ACTION",
+                "BASH",
+                "GROOVY",
+                "JAVASCRIPT",
+                "JSON",
+                "PERL",
+                "PYTHON",
+                "R",
+                "YAML",
+            ]
+        },
     }
     return flavors
 


### PR DESCRIPTION
This is a somewhat provocative PR that does two things - no hard feelings if you reject either or both changes.

## Proposed Changes

1. Add logic to respect `descriptors` and `linters` entries in flavor info returned from `megalinter.flavor_factory.list_megalinter_flavors()`
    * It feels very non-[DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) to have each descriptor list all the flavors that include it, rather than having each flavor list the descriptors it includes.
    * I've added logic so that the flavor information dicts returned from `list_megalinter_flavors()` can include pre-filled `descriptors` and `linters` lists. That seems to allow a flavor to be completely defined within `flavor_factory.py`. 
2. Add a new `bioinformatics` flavor.

Based on local testing this seems to work as expected - the bioinformatics Dockerfile builds and runs appropriately, and bioinformatics appears as a new flavor (including being linked from each "This linter is available in the following flavors" section).

From the outside this seems like a cleaner way to define flavors, but I easily could be missing some critical reason why the current method is necessary.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
