### PR TITLE
Fix UpdatedSourcesReporter when APPLY_FIXES is list (array)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Fixes
 
 - Reporters
+  - Fix UpdatedSourcesReporter when `APPLY_FIXES` is list (array) on 2024-11-18
 
 - Doc
 

--- a/megalinter/reporters/UpdatedSourcesReporter.py
+++ b/megalinter/reporters/UpdatedSourcesReporter.py
@@ -65,9 +65,15 @@ class UpdatedSourcesReporter(Reporter):
                 f" in folder {updated_sources_dir}."
             )
 
+            auto_fixes = False
             if not config.exists(self.master.request_id, "GITHUB_REPOSITORY"):
                 apply_fixes = config.get(self.master.request_id, "APPLY_FIXES", "none")
-                if apply_fixes.lower() != "none":
+                if isinstance(apply_fixes, list):
+                    auto_fixes = True
+                else:
+                    if apply_fixes.lower() == "all":
+                        auto_fixes = True
+                if auto_fixes:
                     remote_branch = ""
                     SYSTEM_PULLREQUEST_SOURCEBRANCH = config.get(
                         self.master.request_id, "SYSTEM_PULLREQUEST_SOURCEBRANCH", ""


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #4270 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

Cater for when `APPLY_FIXES` is a list (array) of linters to perform auto fixes rather than only `none` or `all`

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
