### PR TITLE
Fix AzureCommentReporter when the repo contains a space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Fixes
 
 - Reporters
-  - Fix UpdatedSourcesReporter when `APPLY_FIXES` is list (array) on 2024-11-18
+  - Fix UpdatedSourcesReporter when `APPLY_FIXES` is list (array)
+  - Fix AzureCommentReporter when the repo contains a space (previous behavior available with `AZURE_COMMENT_REPORTER_REPLACE_WITH_SPACES: true`)
 
 - Doc
 

--- a/docs/reporters/AzureCommentReporter.md
+++ b/docs/reporters/AzureCommentReporter.md
@@ -41,5 +41,6 @@ Example:
 |-----------------------------------|------------------------------------------------------------------------------------|---------------|
 | AZURE_COMMENT_REPORTER            | Activates/deactivates reporter                                                     | true          |
 | AZURE_COMMENT_REPORTER_LINKS_TYPE | Set to `build` if you want comments linking to target Build and not artifacts page | `artifacts`   |
+| AZURE_COMMENT_REPORTER_REPLACE_WITH_SPACES | Replaces %20 by spaces in repo name if set to true | <!-- -->   |
 | REPORTERS_MARKDOWN_TYPE           | Set to `simple` to avoid external images in generated markdown                     | `advanced`    |
 | JOB_SUMMARY_ADDITIONAL_MARKDOWN   | Custom markdown to add at the end of the summary message                           | <!-- -->      |

--- a/megalinter/reporters/AzureCommentReporter.py
+++ b/megalinter/reporters/AzureCommentReporter.py
@@ -118,11 +118,17 @@ class AzureCommentReporter(Reporter):
                 )
                 repository_name = SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI.split("/")[
                     -1
-                ].replace("%20", " ")
-                repository = git_client.get_repository(
-                    repository_name, SYSTEM_TEAMPROJECT
-                )
-                repository_id = repository.id
+                ]
+                if config.get(self.master.request_id, "AZURE_COMMENT_REPORTER_REPLACE_WITH_SPACES", "") == "true":
+                    repository_name = repository_name.replace("%20", " ")
+                try:
+                    repository = git_client.get_repository(
+                        repository_name, SYSTEM_TEAMPROJECT
+                    )
+                    repository_id = repository.id
+                except Exception as err:
+                    logging.warning("[Azure Comment Reporter] Error while getting repo, use fallback: "+ str(err))
+                    repository_id = BUILD_REPOSITORY_ID
 
             # Look for existing MegaLinter thread
             existing_threads = git_client.get_threads(


### PR DESCRIPTION
Fixes https://github.com/oxsecurity/megalinter/issues/4281
previous behavior available with `AZURE_COMMENT_REPORTER_REPLACE_WITH_SPACES: true`
