### PR TITLE
Fix handling of submodule paths

### DIFF
--- a/megalinter/utils.py
+++ b/megalinter/utils.py
@@ -8,6 +8,7 @@ import re
 import tempfile
 import urllib.parse
 from fnmatch import fnmatch
+from pathlib import Path
 from typing import Any, Optional, Pattern, Sequence
 
 import git
@@ -314,6 +315,9 @@ def list_updated_files(repo_home):
         except git.InvalidGitRepositoryError:
             logging.warning("Unable to find git repository to list updated files")
             return []
+    if not Path(repo.git_dir).resolve().is_relative_to(Path(repo_home).resolve()):
+        logging.warning("Your linting root directory is not a Git working copy root (e.g., the linting root directory is inside a submodule)")
+        return []
     changed_files = [item.a_path for item in repo.index.diff(None)]
     return changed_files
 

--- a/megalinter/utils.py
+++ b/megalinter/utils.py
@@ -316,7 +316,7 @@ def list_updated_files(repo_home):
             logging.warning("Unable to find git repository to list updated files")
             return []
     if not Path(repo.git_dir).resolve().is_relative_to(Path(repo_home).resolve()):
-        logging.warning("Your linting root directory is not a Git working copy root (e.g., the linting root directory is inside a submodule)")
+        logging.warning("Your workspace is not a Git working copy root (e.g., the workspace is inside a submodule)")
         return []
     changed_files = [item.a_path for item in repo.index.diff(None)]
     return changed_files


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

If the workspace directory was a submodule, MegaLinter would consider this a valid Git working copy to detect changed files in. However, the `.git` directory may not be accessible from within the submodule, e.g., when the submodule was mounted inside a container as subpath, without `../.git`.

## Proposed Changes

1. Skip listing updated files when the `.git` directory is not a descendant of the workspace directory.

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
