### PR TITLE
Fix swiftlint error that is unable to find lintable swift files

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -992,6 +992,7 @@
         "linelength",
         "linesep",
         "linkcheck",
+        "lintable",
         "linterkey",
         "linterrc",
         "linterversion",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
       Learn more about context on [GH-4328](https://github.com/oxsecurity/megalinter/issues/4328)
 
 - Fixes
+  - [swiftlint](https://github.com/realm/SwiftLint) Fix swiftlint error where linter is unable to find lintable files. Fixes [#440](https://github.com/oxsecurity/megalinter/issues/440).
 
 - Reporters
 

--- a/docs/descriptors/swift_swiftlint.md
+++ b/docs/descriptors/swift_swiftlint.md
@@ -11,8 +11,8 @@ description: How to use swiftlint (configure, ignore files, ignore errors, help 
 
 - Version in MegaLinter: **0.57.1**
 - Visit [Official Web Site](https://github.com/realm/SwiftLint#readme){target=_blank}
-- Docker image: [norionomura/swiftlint:latest](https://hub.docker.com/r/norionomura/swiftlint){target=_blank}
-  - arguments: `-v {{WORKSPACE}}:/tmp/lint:rw`
+- Docker image: [ghcr.io/realm/swiftlint:latest](https://hub.docker.com/r/ghcr.io/realm/swiftlint){target=_blank}
+  - arguments: `-v {{WORKSPACE}}:/tmp/lint:rw -w /tmp/lint`
 - See [How to configure swiftlint rules](https://github.com/realm/SwiftLint#configuration){target=_blank}
 - See [How to disable swiftlint rules in files](https://github.com/realm/SwiftLint#disable-rules-in-code){target=_blank}
 - See [Index of problems detected by swiftlint](https://realm.github.io/SwiftLint/rule-directory.html){target=_blank}
@@ -82,11 +82,11 @@ swiftlint is called once on the whole project directory (`project` CLI lint mode
 ### Example calls
 
 ```shell
-docker run -v /tmp/lint:/tmp/lint:rw norionomura/swiftlint:latest swiftlint lint --path /tmp/lint --strict
+docker run -v /tmp/lint:/tmp/lint:rw ghcr.io/realm/swiftlint:latest swiftlint --strict
 ```
 
 ```shell
-docker run -v /tmp/lint:/tmp/lint:rw norionomura/swiftlint:latest swiftlint --fix --path /tmp/lint --strict
+docker run -v /tmp/lint:/tmp/lint:rw ghcr.io/realm/swiftlint:latest swiftlint --fix --strict
 ```
 
 

--- a/megalinter/descriptors/swift.megalinter-descriptor.yml
+++ b/megalinter/descriptors/swift.megalinter-descriptor.yml
@@ -19,15 +19,16 @@ linters:
     cli_lint_extra_args:
       - "lint"
     cli_lint_extra_args_after:
-      - "/tmp/lint"
       - "--strict"
     cli_lint_fix_arg_name: "--fix"
     cli_lint_fix_remove_args:
       - "lint"
-    cli_docker_image: norionomura/swiftlint
+    cli_docker_image: ghcr.io/realm/swiftlint
     cli_docker_args:
       - "-v"
       - "{{WORKSPACE}}:/tmp/lint:rw"
+      - "-w"
+      - "/tmp/lint"
     config_file_name: ".swiftlint.yml"
     cli_config_arg_name: ""
     cli_help_arg_name: "help"
@@ -35,8 +36,8 @@ linters:
     cli_lint_errors_count: regex_number
     cli_lint_errors_regex: "Found ([0-9]+) violations"
     examples:
-      - "docker run -v /tmp/lint:/tmp/lint:rw norionomura/swiftlint:latest swiftlint lint --path /tmp/lint --strict"
-      - "docker run -v /tmp/lint:/tmp/lint:rw norionomura/swiftlint:latest swiftlint --fix --path /tmp/lint --strict"
+      - "docker run -v /tmp/lint:/tmp/lint:rw ghcr.io/realm/swiftlint:latest swiftlint --strict"
+      - "docker run -v /tmp/lint:/tmp/lint:rw ghcr.io/realm/swiftlint:latest swiftlint --fix --strict"
     ide:
       atom:
         - name: linter-swiftlint


### PR DESCRIPTION
- Update swiftlint documentation

- Update to use [swiftlint's Docker image](https://github.com/realm/SwiftLint?tab=readme-ov-file#docker)

- Add "lintable" to cspell exclusion

Fixes #440

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
