### PR TITLE
Fix: PMD sarif report preview unavailable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Fixes
   - [swiftlint](https://github.com/realm/SwiftLint) Fix swiftlint error where linter is unable to find lintable files. Fixes [#440](https://github.com/oxsecurity/megalinter/issues/440).
+  - [SARIF_REPORTER](https://megalinter.io/latest/reporters/SarifReporter/) Fix PMD SARIF report preview unavailable. Fixes [#4522](https://github.com/oxsecurity/megalinter/issues/4522).
 
 - Reporters
 

--- a/megalinter/reporters/SarifReporter.py
+++ b/megalinter/reporters/SarifReporter.py
@@ -96,7 +96,7 @@ class SarifReporter(Reporter):
                         os.remove(linter.sarif_output_file)
         result_json = json.dumps(sarif_obj, sort_keys=True, indent=4)
         # Remove workspace prefix from file names
-        result_json = result_json.replace("file:///github/workspace", "")
+        result_json = result_json.replace("file:///github/workspace/", "")
         result_json = normalize_log_string(result_json)
         # Write output file
         sarif_file_name = f"{self.report_folder}{os.path.sep}" + config.get(

--- a/megalinter/reporters/SarifReporter.py
+++ b/megalinter/reporters/SarifReporter.py
@@ -96,6 +96,7 @@ class SarifReporter(Reporter):
                         os.remove(linter.sarif_output_file)
         result_json = json.dumps(sarif_obj, sort_keys=True, indent=4)
         # Remove workspace prefix from file names
+        result_json = result_json.replace("file:///github/workspace", "")
         result_json = normalize_log_string(result_json)
         # Write output file
         sarif_file_name = f"{self.report_folder}{os.path.sep}" + config.get(


### PR DESCRIPTION
According to the [GitHub documentation](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#specifying-the-location-for-source-files), the conversion of absolute URIs to relative URIs for the source root when uploading a SARIF report should not include the `file://` scheme.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #4522 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Replace `file:///github/workspace` to empty string for SARIF report before replacing `/github/workspace`.

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
