### PR TITLE
doc: correct default SARIF_REPORTER_FILE_NAME

### DIFF
--- a/docs/reporters/SarifReporter.md
+++ b/docs/reporters/SarifReporter.md
@@ -35,5 +35,5 @@ with:
 |-----------------------------------------|-------------------------------------------------------------------------------------------------------------------|----------------------------|
 | SARIF_REPORTER                          | Activates/deactivates reporter                                                                                    | `false`                    |
 | SARIF_REPORTER_NORMALIZE_LINTERS_OUTPUT | Remove DEFAULT_WORKSPACE prefix in SARIF-files, for example 'DEFAULT_WORKSPACE/src/main' would be 'src/main' etc. | `true`                     |
-| SARIF_REPORTER_FILE_NAME                | File name for SARIF report output file                                                                            | `mega-linter-report.sarif` |
+| SARIF_REPORTER_FILE_NAME                | File name for SARIF report output file                                                                            | `megalinter-report.sarif` |
 | SARIF_REPORTER_LINTERS                  | List of linter keys that will output SARIF (if not set, all SARIF compliant linters will output SARIF)            | `[]`                       |


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Minor documentation correction on default SARIF_REPORTER_FILE_NAME
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
