### PR TITLE
Retrieve SARIF errors and warnings correctly

### DIFF
--- a/megalinter/Linter.py
+++ b/megalinter/Linter.py
@@ -1472,7 +1472,7 @@ class Linter:
         if self.output_sarif is True:
             return self.get_sarif_result_count(stdout, "warning")
         # Get number with a single regex.
-        if self.cli_lint_warnings_count == "regex_number":
+        elif self.cli_lint_warnings_count == "regex_number":
             reg = self.get_regex(self.cli_lint_warnings_regex)
             m = re.search(reg, utils.normalize_log_string(stdout))
             if m:

--- a/megalinter/utilstest.py
+++ b/megalinter/utilstest.py
@@ -598,7 +598,7 @@ def test_linter_report_sarif(linter, test_self):
         len(sarif_content["runs"]) > 0,
         f"Empty runs list in {tmp_sarif_file_name}",
     )
-    # Check number of errors is ok
+    # Check number of errors and warnings is ok
     for linter in mega_linter.linters:
         if (
             linter.output_sarif is True
@@ -615,6 +615,14 @@ def test_linter_report_sarif(linter, test_self):
                 + f" ({linter.total_number_errors})\n"
                 + f"SARIF:{str(sarif_content)}",
             )
+
+            if linter.cli_lint_warnings_count is not None:
+                test_self.assertTrue(
+                    linter.total_number_warnings > 1,
+                    f"Missing multiple sarif warnings in {linter.name}"
+                    + f" ({linter.total_number_warnings})\n"
+                    + f"SARIF:{str(sarif_content)}",
+                )
 
 
 def assert_is_skipped(skipped_item, output, test_self):


### PR DESCRIPTION
With @nvuillam's [request](https://github.com/oxsecurity/megalinter/pull/4556#issuecomment-2676709760) I have:
* Return the number of warnings (which it didn't do)
* Correct the calculation of counting the errors or warnings according to: https://github.com/microsoft/sarif-tutorials/blob/main/docs/2-Basics.md#results
* Share in a single function this logic