### PR TITLE
Update plugins.md to add raw link to JSON schema

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -47,7 +47,7 @@ PLUGINS:
 You can implement your own descriptors and load them as plugins during MegaLinter runtime
 
 - Descriptor format is exactly the same than [MegaLinter embedded ones](https://github.com/oxsecurity/megalinter/tree/main/megalinter/descriptors) ([see json schema documentation](https://megalinter.io/json-schemas/descriptor.html))
-- Plugins descriptor files must be named **\*\*.megalinter-descriptor.yml** and respect [MegaLinter Json Schema](https://github.com/oxsecurity/megalinter/blob/main/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json)
+- Plugins descriptor files must be named **\*\*.megalinter-descriptor.yml** and respect [MegaLinter Json Schema](https://github.com/oxsecurity/megalinter/blob/main/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json) ([raw](https://raw.githubusercontent.com/oxsecurity/megalinter/refs/heads/main/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json))
 - Plugins must be hosted in a url containing **\*\*/mega-linter-plugin-\*\*/**
 - File URLs must conform to the same directory and file naming criteria as defined above.
 


### PR DESCRIPTION
This adds a link to the "raw" version of the JSON schema for descriptors.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. this adds a link labeled`(raw)` after the reference to the JSON schema for linter descriptors.  While working on validating a plugin, I attempted to use `v8r` with the URL mentioned on the plugins.md page only to be met with the error `Unexpected token '<', "` which confused me as there was no `<` in my plugin descriptor.  I eventually realized that the link on the plugins page points to the JSON schema file in the repo, not raw version that I could pass to `v8r -s https://....` .  Rather than change the existing link, I added a new link with the `(raw)` title after it.  I'm pretty sure there are more attractive ways to accomplish the same thing, so I'm very open to feedback, modifications, etc..

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the CHANGELOG: I didn't because it's just a small addition to a page on the site, not MegaLinter itself
- [ ] If documentation is needed: same, just a small update to the site

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
