### PR TITLE
Downgrade mkdocs-glightbox to 0.3.2

### DIFF
--- a/.config/python/dev/requirements.txt
+++ b/.config/python/dev/requirements.txt
@@ -14,7 +14,7 @@ markdown==3.7
 mdx_truly_sane_lists==1.3
 mike==2.1.3
 mkdocs==1.6.1
-mkdocs-glightbox==0.4.0
+mkdocs-glightbox==0.3.2
 mkdocs-material==9.6.8
 multiprocessing_logging==0.3.4
 pychalk==2.0.1


### PR DESCRIPTION
Downgrade `mkdocs-glightbox` to 0.3.2, had inadvertently updated to 0.4.0 and caused the build command to freeze.

Related: https://github.com/blueswen/mkdocs-glightbox/issues/56