### PR TITLE
Syft: Add SBOM file by default in report folder + remove useless debug statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Media
 
 - Linters enhancements
+  - [syft](https://megalinter.io/latest/descriptors/repository_syft/): Add SBOM file by default in report folder + remove useless debug statement
 
 - Fixes
   - Use npm to install pyright

--- a/megalinter/linters/SyftLinter.py
+++ b/megalinter/linters/SyftLinter.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 
-from megalinter import Linter
+from megalinter import Linter, utils
 from megalinter.constants import (
     DEFAULT_SARIF_SCHEMA_URI,
     DEFAULT_SARIF_VERSION,
@@ -16,6 +16,27 @@ from megalinter.constants import (
 
 
 class SyftLinter(Linter):
+
+    # Provide additional details in text reporter logs
+    # Add SBOM output file
+    # noinspection PyMethodMayBeStatic
+    def complete_text_reporter_report(self, reporter_self):
+        # Collect detected words from logs
+        if self.stdout is None or not utils.can_write_report_files(self.master):
+            return []
+        output_file_extension = ".json" if self.stdout.startswith("{") else ".txt"
+        sbom_output_file = (
+            reporter_self.report_folder
+            + os.path.sep
+            + "SBOM-syft"
+            + output_file_extension
+        )
+        # Save SBOM output file
+        os.makedirs(os.path.dirname(sbom_output_file), exist_ok=True)
+        with open(sbom_output_file, "w", encoding="utf-8") as outfile:
+            outfile.write(self.stdout)
+        return []
+
     # Get syft json output and build SARIF output from it
     def manage_sarif_output(self, _return_stdout):
         if self.can_output_sarif is True and self.output_sarif is True:
@@ -23,8 +44,6 @@ class SyftLinter(Linter):
             if os.path.isfile(json_output_file):
                 with open(json_output_file, "r", encoding="utf-8") as json_file:
                     json_file_str = json_file.read()
-                    if logging.getLogger().isEnabledFor(logging.DEBUG):
-                        logging.debug("SYFT initial output file: " + json_file_str)
                     syft_result_sbom = json.loads(json_file_str)
                 sarif_obj = {
                     "$schema": DEFAULT_SARIF_SCHEMA_URI,


### PR DESCRIPTION
Fixes https://github.com/oxsecurity/megalinter/issues/4288
