### PR TITLE
Initial Renovate automerge configuration

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -590,6 +590,7 @@
         "autoloader",
         "automagically",
         "automerge",
+        "automerges",
         "autopep",
         "autoplay",
         "await-thenable",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Flavors
 
 - CI
+  - Initial Renovate automerge configuration, by @echoix in <https://github.com/oxsecurity/megalinter/pull/5057>
 
 - mega-linter-runner
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,9 @@
     'preview:dockerVersions',
     'group:unitTestNonMajor',
     ':enableVulnerabilityAlerts',
+    ':automergePr', // Still raise a PR for automerges
+    ':automergeDigest', // enable for PRs updating digests
+    ':automergePatch', // enable for lock files, patch and pin
   ],
   vulnerabilityAlerts: {
     enabled: true,

--- a/renovate.json5
+++ b/renovate.json5
@@ -15,7 +15,7 @@
     ':enableVulnerabilityAlerts',
     ':automergePr', // Still raise a PR for automerges
     ':automergeDigest', // enable for PRs updating digests
-    ':automergePatch', // enable for lock files, patch and pin
+    ':automergePatch' // enable for lock files, patch and pin
   ],
   vulnerabilityAlerts: {
     enabled: true,


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

This PR starts the configuration needed for enabling automerge with renovate.

For now, it won’t work as is, for example, because of the way the CODEOWNERS file is written, and the old branch protection settings.
But, it is still useful to start learning on how it works, what Renovate would consider ready to automerge. We will still need to place approvals for now.

Later on, we will need to adapt the repo’s config to use rulesets, and define our restrictions and approval settings there. After that, the CODEOWNERS file would be kinda useless.

Automerge doesn’t apply to all PRs. We configure for what of the Renovate PRs we want, for now, lock file maintenance, pin, digest and patch updates. Other non-renovate PRs aren’t affected. On GitHub, it uses the platform’s automerge functionality.

PRs should be merged with squash-merge, since it is our default merge method (if not the only one allowed). The renovate config for automergeStrategy is left to « auto ». https://docs.renovatebot.com/configuration-options/#automergestrategy

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
