### PR TITLE
build-command: Unshallow pull or full pull before committing changes

### DIFF
--- a/.github/workflows/build-command.yml
+++ b/.github/workflows/build-command.yml
@@ -81,7 +81,7 @@ jobs:
             > Running script `./build.sh`
       - name: Run build script
         run: ./build.sh
-      - run: git pull
+      - run: git pull --unshallow || git pull
       - uses: stefanzweifel/git-auto-commit-action@v5
         id: auto-commit-action
         with:


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Pulling before committing ends up needing to pull all branches and all commits. Unshallow usually "reverts" a clone with a fetch-depth, but maybe can be affected if --single-branch was used. I'm not sure if it is used, but if so, unshallow would be faster (not needing to get the gh pages branch).

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
