### PR TITLE
Fix crash when the markdown table summary is empty

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -111,6 +111,8 @@ CVE-2024-21538
 # other
 CVE-2024-47535
 CVE-2024-12797
+# https://avd.aquasec.com/nvd/cve-2025-46569 : Linters in MegaLinter do not run servers.
+CVE-2025-46569
 # Dockerfile
 DS001
 DS002

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Linters enhancements
 
 - Fixes
+  - Fix crash when the markdown table summary is empty
 
 - Reporters
 

--- a/megalinter/utils_reporter.py
+++ b/megalinter/utils_reporter.py
@@ -91,7 +91,6 @@ def build_markdown_summary(reporter_self, action_run_url=""):
                 table_line += [str(round(linter.elapsed_time_s, 2)) + "s"]
             table_data_raw += [table_line]
     # Build markdown table
-    table_data_raw.pop(0)
     writer = MarkdownTableWriter(
         headers=table_header,
         column_styles=table_column_styles,


### PR DESCRIPTION
Fixes https://github.com/oxsecurity/megalinter/issues/5358
