### PR TITLE
chore(docs): display hash as plain text in markdown

### DIFF
--- a/.automation/build.py
+++ b/.automation/build.py
@@ -990,7 +990,7 @@ def generate_descriptor_documentation(descriptor):
     ]
     # Title
     descriptor_md += [
-        f"# {descriptor.get('descriptor_label', descriptor.get('descriptor_id'))}",
+        f"# {descriptor.get('descriptor_label', descriptor.get('descriptor_id')).replace('#', '\\#')}",
         "",
     ]
     # List of linters


### PR DESCRIPTION
<!-- display hash as plain text in markdown -->
Discussion: [hash in C# csharp not built in docs](https://github.com/oxsecurity/megalinter/discussions/5410)
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

This change ensures that any hash # character in the descriptor_label or descriptor_id will be treated as a literal character in Markdown output, preventing it from being interpreted.

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
