### PR TITLE
Enhances Markdown Reporter with GITHUB_STEP_SUMMARY support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Reporters
   - New default display for Pull Request comments, with expandable sections containing the first 1000 lines of the output log. Former display remains available by defining `REPORTERS_MARKDOWN_SUMMARY_TYPE=table`
+  - Markdown reporter: Write a file for Github integration if GITHUB_STEP_SUMMARY is set
 
 - Doc
   - Update documentation in all megalinter descriptor files to improve accuracy and consistency

--- a/docs/reporters/MarkdownSummaryReporter.md
+++ b/docs/reporters/MarkdownSummaryReporter.md
@@ -7,7 +7,9 @@ description: Generates a summary of SAST results in Markdown within a file named
 
 Generates a summary of SAST results in Markdown within a file named **megalinter-report.md**, located in the report folder.
 
-This reporter **is deactivated by default**.
+If GITHUB_STEP_SUMMARY is set, the related file will also be written.
+
+This reporter **is deactivated by default**, except if env variable GITHUB_STEP_SUMMARY is found.
 
 ![Screenshot](../assets/images/MarkdownSummaryReporter_1.png)
 

--- a/megalinter/reporters/MarkdownSummaryReporter.py
+++ b/megalinter/reporters/MarkdownSummaryReporter.py
@@ -20,6 +20,7 @@ class MarkdownSummaryReporter(Reporter):
         elif (
             config.get(self.master.request_id, "MARKDOWN_SUMMARY_REPORTER", "false")
             == "true"
+            or "GITHUB_STEP_SUMMARY" in os.environ
         ):
             self.is_active = True
         else:
@@ -37,8 +38,16 @@ class MarkdownSummaryReporter(Reporter):
         if os.path.isfile(summary_file_name):
             # Remove from previous run
             os.remove(summary_file_name)
-        with open(summary_file_name, "w", encoding="utf-8") as sarif_file:
-            sarif_file.write(summary)
+        with open(summary_file_name, "w", encoding="utf-8") as summary_file:
+            summary_file.write(summary)
+        # if GITHUB_STEP_SUMMARY is set, append to it
+        if "GITHUB_STEP_SUMMARY" in os.environ:
+            with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary_file:
+                summary_file.write(summary)
         logging.info(
             f"[MARKDOWN_SUMMARY Reporter] Generated {self.name} report: {summary_file_name}"
         )
+        if "GITHUB_STEP_SUMMARY" in os.environ:
+            logging.info(
+            f"[MARKDOWN_SUMMARY Reporter] Also appended to GITHUB_STEP_SUMMARY: {os.environ['GITHUB_STEP_SUMMARY']}"
+            )

--- a/megalinter/reporters/MarkdownSummaryReporter.py
+++ b/megalinter/reporters/MarkdownSummaryReporter.py
@@ -42,12 +42,14 @@ class MarkdownSummaryReporter(Reporter):
             summary_file.write(summary)
         # if GITHUB_STEP_SUMMARY is set, append to it
         if "GITHUB_STEP_SUMMARY" in os.environ:
-            with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary_file:
+            with open(
+                os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8"
+            ) as summary_file:
                 summary_file.write(summary)
         logging.info(
             f"[MARKDOWN_SUMMARY Reporter] Generated {self.name} report: {summary_file_name}"
         )
         if "GITHUB_STEP_SUMMARY" in os.environ:
             logging.info(
-            f"[MARKDOWN_SUMMARY Reporter] Also appended to GITHUB_STEP_SUMMARY: {os.environ['GITHUB_STEP_SUMMARY']}"
+                f"[MARKDOWN_SUMMARY Reporter] Also appended to GITHUB_STEP_SUMMARY: {os.environ['GITHUB_STEP_SUMMARY']}"
             )


### PR DESCRIPTION
Extends the Markdown reporter to write a report file compatible with Github integration by appending the report to the GITHUB_STEP_SUMMARY environment variable, if set.

This change allows for seamless integration with GitHub's step summary feature, providing a more convenient way to view linting results directly within the GitHub Actions workflow.

Fixes https://github.com/oxsecurity/megalinter/issues/5682