### PR TITLE
Improves markdown summary reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Reporters
   - New default display for Pull Request comments, with expandable sections containing the first 1000 lines of the output log. Former display remains available by defining `REPORTERS_MARKDOWN_SUMMARY_TYPE=table`
-  - Markdown reporter: Write a file for Github integration if GITHUB_STEP_SUMMARY is set
+  - Markdown summary reporter:
+    - Write a file for Github integration if GITHUB_STEP_SUMMARY is set
+    - Truncate less linter output lines
 
 - Doc
   - Update documentation in all megalinter descriptor files to improve accuracy and consistency

--- a/megalinter/reporters/MarkdownSummaryReporter.py
+++ b/megalinter/reporters/MarkdownSummaryReporter.py
@@ -27,7 +27,7 @@ class MarkdownSummaryReporter(Reporter):
             self.is_active = False
 
     def produce_report(self):
-        summary = build_markdown_summary(self)
+        summary = build_markdown_summary(self, action_run_url="", max_total_chars=800000)
 
         # Write output file
         summary_file_name = f"{self.report_folder}{os.path.sep}" + config.get(

--- a/megalinter/reporters/MarkdownSummaryReporter.py
+++ b/megalinter/reporters/MarkdownSummaryReporter.py
@@ -27,7 +27,9 @@ class MarkdownSummaryReporter(Reporter):
             self.is_active = False
 
     def produce_report(self):
-        summary = build_markdown_summary(self, action_run_url="", max_total_chars=800000)
+        summary = build_markdown_summary(
+            self, action_run_url="", max_total_chars=800000
+        )
 
         # Write output file
         summary_file_name = f"{self.report_folder}{os.path.sep}" + config.get(

--- a/megalinter/utils_reporter.py
+++ b/megalinter/utils_reporter.py
@@ -20,12 +20,12 @@ from pytablewriter.style import Style
 from redis import Redis
 
 
-def build_markdown_summary(reporter_self, action_run_url=""):
+def build_markdown_summary(reporter_self, action_run_url="", max_total_chars = 40000):
     markdown_summary_type = config.get(
         reporter_self.master.request_id, "REPORTERS_MARKDOWN_SUMMARY_TYPE", "table"
     )
     if markdown_summary_type == "sections":
-        return build_markdown_summary_sections(reporter_self, action_run_url)
+        return build_markdown_summary_sections(reporter_self, action_run_url, max_total_chars)
     else:
         return build_markdown_summary_table(reporter_self, action_run_url)
 
@@ -79,7 +79,7 @@ def build_markdown_summary_table(reporter_self, action_run_url=""):
     return p_r_msg
 
 
-def build_markdown_summary_sections(reporter_self, action_run_url=""):
+def build_markdown_summary_sections(reporter_self, action_run_url="", max_total_chars = 40000):
     """Build markdown summary using HTML sections with summary/details tags for each linter"""
 
     # Build complete message using helper functions
@@ -121,7 +121,6 @@ def build_markdown_summary_sections(reporter_self, action_run_url=""):
     linters_with_issues.sort(key=sort_linters_by_icon_severity)
 
     # Calculate available space per linter based on total linters with issues
-    max_total_chars = 40000
     total_linters_with_issues = len(linters_with_issues)
     max_chars_per_linter = max_total_chars // max(total_linters_with_issues, 1)
 

--- a/megalinter/utils_reporter.py
+++ b/megalinter/utils_reporter.py
@@ -20,12 +20,14 @@ from pytablewriter.style import Style
 from redis import Redis
 
 
-def build_markdown_summary(reporter_self, action_run_url="", max_total_chars = 40000):
+def build_markdown_summary(reporter_self, action_run_url="", max_total_chars=40000):
     markdown_summary_type = config.get(
         reporter_self.master.request_id, "REPORTERS_MARKDOWN_SUMMARY_TYPE", "table"
     )
     if markdown_summary_type == "sections":
-        return build_markdown_summary_sections(reporter_self, action_run_url, max_total_chars)
+        return build_markdown_summary_sections(
+            reporter_self, action_run_url, max_total_chars
+        )
     else:
         return build_markdown_summary_table(reporter_self, action_run_url)
 
@@ -79,7 +81,9 @@ def build_markdown_summary_table(reporter_self, action_run_url=""):
     return p_r_msg
 
 
-def build_markdown_summary_sections(reporter_self, action_run_url="", max_total_chars = 40000):
+def build_markdown_summary_sections(
+    reporter_self, action_run_url="", max_total_chars=40000
+):
     """Build markdown summary using HTML sections with summary/details tags for each linter"""
 
     # Build complete message using helper functions


### PR DESCRIPTION
Truncates the linter output in markdown summary reports to avoid exceeding the maximum allowed length.

This change also updates the markdown summary reporter to write a file for GitHub integration when GITHUB_STEP_SUMMARY is set.
