### PR TITLE
PHP-CS-Fixer is able to run on unofficial supported versions (like php 8.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Media
 
 - Linters enhancements
+  - PHP-CS-Fixer is able to run on PHP 8.4 without error (change default configuration) by @llaville
 
 - Fixes
 

--- a/TEMPLATES/.php-cs-fixer.dist.php
+++ b/TEMPLATES/.php-cs-fixer.dist.php
@@ -5,6 +5,9 @@ $finder = (new PhpCsFixer\Finder())
 ;
 
 return (new PhpCsFixer\Config())
+    // allow to run on unsupported PHP Versions
+    // {@link https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/README.md#supported-php-versions}
+    ->setUnsupportedPhpVersionAllowed(true)
     // use default @link https://www.php-fig.org/per/coding-style/
     ->setRules([
         '@PER-CS' => true,

--- a/TEMPLATES/.php-cs-fixer.dist.php
+++ b/TEMPLATES/.php-cs-fixer.dist.php
@@ -5,8 +5,10 @@ $finder = (new PhpCsFixer\Finder())
 ;
 
 return (new PhpCsFixer\Config())
+    // use default @link https://www.php-fig.org/per/coding-style/
     ->setRules([
         '@PER-CS' => true,
     ])
+    // default source code to scan
     ->setFinder($finder)
 ;


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes https://github.com/oxsecurity/megalinter/pull/5701

MUST BE applied first before re-run PR#5701

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Apply config on default TEMPLATE

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
