### PR TITLE
Install `iconv` PHP 8.4 extension

### DIFF
--- a/flavors/cupcake/Dockerfile
+++ b/flavors/cupcake/Dockerfile
@@ -349,6 +349,7 @@ RUN apk -U --no-cache upgrade \
                 php84-openssl \
                 php84-common \
                 php84-simplexml \
+                php84-iconv \
                 dpkg \
                 py3-pyflakes \
                 cppcheck \

--- a/flavors/php/Dockerfile
+++ b/flavors/php/Dockerfile
@@ -237,6 +237,7 @@ RUN apk -U --no-cache upgrade \
                 php84-openssl \
                 php84-common \
                 php84-simplexml \
+                php84-iconv \
                 dpkg \
                 py3-pyflakes \
                 openjdk17 \

--- a/linters/php_phpcsfixer/Dockerfile
+++ b/linters/php_phpcsfixer/Dockerfile
@@ -87,6 +87,7 @@ RUN apk -U --no-cache upgrade \
                 php84-openssl \
                 php84-common \
                 php84-simplexml \
+                php84-iconv \
                 dpkg \
     && git config --global core.autocrlf true
 #APK__END

--- a/megalinter/descriptors/php.megalinter-descriptor.yml
+++ b/megalinter/descriptors/php.megalinter-descriptor.yml
@@ -20,6 +20,7 @@ install:
     - php84-openssl
     - php84-common
     - php84-simplexml
+    - php84-iconv
     - dpkg
   dockerfile:
     - RUN update-alternatives --install /usr/bin/php php /usr/bin/php84 110


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes PR #5701

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

Found following problem during PR #5701 build

```
Problem
    - Root composer.json requires friendsofphp/php-cs-fixer v3.76.0 -> satisfiable by friendsofphp/php-cs-fixer[v3.76.0].
    - friendsofphp/php-cs-fixer v3.76.0 requires symfony/polyfill-mbstring ^1.32 -> satisfiable by symfony/polyfill-mbstring[v1.32.0].
    - symfony/polyfill-mbstring v1.32.0 requires ext-iconv * -> it is missing from your system. Install or enable PHP's iconv extension

```
## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
