### PR TITLE
build-command: Remove pulling before committing

### DIFF
--- a/.github/workflows/build-command.yml
+++ b/.github/workflows/build-command.yml
@@ -81,7 +81,6 @@ jobs:
             > Running script `./build.sh`
       - name: Run build script
         run: ./build.sh
-      - run: git pull --unshallow || git pull
       - uses: stefanzweifel/git-auto-commit-action@v6
         id: auto-commit-action
         with:


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

I think that pulling isn’t needed anymore since the v6 of https://github.com/stefanzweifel/git-auto-commit-action.

It takes two minutes for this step to run otherwise.

I can really try it out correctly, and my plan is to re-add it if it doesn’t work. But it needs to be in the default branch to try it out correctly.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
