### PR TITLE
When linter is docker based, force `--platform=linux/amd64` so it works when running locally on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - [hadolint](https://megalinter.io/latest/descriptors/docker_hadolint/): Extend DOCKERFILE_HADOLINT_FILE_NAMES_REGEX to include the `purpose.Dockerfile` convention eg service.Dockerfile.
 
 - Fixes
+  - When linter is docker based, force `--platform=linux/amd64` so it works when running locally on Mac
 
 - Reporters
   - New default display for Pull Request comments, with expandable sections containing the first 1000 lines of the output log. Former display remains available by defining `REPORTERS_MARKDOWN_SUMMARY_TYPE=table`

--- a/megalinter/Linter.py
+++ b/megalinter/Linter.py
@@ -1335,7 +1335,7 @@ class Linter:
     def manage_docker_command(self, command):
         if self.cli_docker_image is None:
             return command
-        docker_command = ["docker", "run", "--rm"]
+        docker_command = ["docker", "run", "--platform=linux/amd64", "--rm"]
         if hasattr(self, "workspace"):
             volume_root = config.get(self.request_id, "MEGALINTER_VOLUME_ROOT", "")
             if volume_root != "":


### PR DESCRIPTION
Fixes https://github.com/oxsecurity/megalinter/issues/6049