### PR TITLE
Adding supported filetypes to ruff and ruff-format linters

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -115,6 +115,7 @@
         "imple",
         "iname",
         "inimal",
+        "ipynb",
         "is-arrayish",
         "isaacs",
         "johnnymorganz",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Fixes
   - When linter is docker based, force `--platform=linux/amd64` so it works when running locally on Mac
+  - Added checking of `*.pyi` and `*.ipynb` files to the `ruff` and `ruff-format` linters
 
 - Reporters
   - New default display for Pull Request comments, with expandable sections containing the first 1000 lines of the output log. Former display remains available by defining `REPORTERS_MARKDOWN_SUMMARY_TYPE=table`

--- a/megalinter/descriptors/python.megalinter-descriptor.yml
+++ b/megalinter/descriptors/python.megalinter-descriptor.yml
@@ -517,6 +517,10 @@ linters:
   - linter_name: ruff
     name: PYTHON_RUFF
     can_output_sarif: true
+    file_extensions:
+      - ".py"
+      - ".pyi"
+      - ".ipynb"
     linter_text: |
       **Ruff** is an extremely fast Python linter and code formatter written in Rust that aims to be 10-100x faster than existing tools while providing comprehensive functionality behind a single interface.
 
@@ -575,6 +579,10 @@ linters:
     class: RuffFormatLinter
     name: PYTHON_RUFF_FORMAT
     is_formatter: true
+    file_extensions:
+      - ".py"
+      - ".pyi"
+      - ".ipynb"
     activation_rules:
       - type: variable
         variable: PYTHON_DEFAULT_STYLE


### PR DESCRIPTION


Fixes #5979

## Proposed Changes

The ruff tool supports *.py, *.pyi, and *.ipynb. This PR adds the last two file types to the ruff and ruff-format linters to allow these files to be checked in `list_of_files` mode.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
