### PR TITLE
Allow to override correctly `PHP_*_CLI_EXECUTABLE` and use local version instead of embedded version provided by MegaLinter v9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -762,7 +762,7 @@ RUN wget --tries=5 https://www.lua.org/ftp/lua-5.3.5.tar.gz -O - -q | tar -xzf -
 # PHP installation
     && update-alternatives --install /usr/bin/php php /usr/bin/php84 110
 # Managed with COPY --from=composer/composer:2-bin /composer /usr/bin/composer
-ENV PATH="/root/.composer/vendor/bin:${PATH}"
+ENV PATH="/tmp/lint/vendor/bin:/root/.composer/vendor/bin:${PATH}"
 #
 # POWERSHELL installation
 # Next line commented because already managed by another linter

--- a/flavors/cupcake/Dockerfile
+++ b/flavors/cupcake/Dockerfile
@@ -598,7 +598,7 @@ ENV PATH="$JAVA_HOME/bin:${PATH}"
 # PHP installation
 RUN update-alternatives --install /usr/bin/php php /usr/bin/php84 110
 # Managed with COPY --from=composer/composer:2-bin /composer /usr/bin/composer
-ENV PATH="/root/.composer/vendor/bin:${PATH}"
+ENV PATH="/tmp/lint/vendor/bin:/root/.composer/vendor/bin:${PATH}"
 #
 # TYPESCRIPT installation
 #

--- a/flavors/php/Dockerfile
+++ b/flavors/php/Dockerfile
@@ -388,7 +388,7 @@ ENV PATH="$JAVA_HOME/bin:${PATH}"
 # PHP installation
 RUN update-alternatives --install /usr/bin/php php /usr/bin/php84 110
 # Managed with COPY --from=composer/composer:2-bin /composer /usr/bin/composer
-ENV PATH="/root/.composer/vendor/bin:${PATH}"
+ENV PATH="/tmp/lint/vendor/bin:/root/.composer/vendor/bin:${PATH}"
 #
 # actionlint installation
 # Managed with COPY --link --from=actionlint /usr/local/bin/actionlint /usr/bin/actionlint

--- a/linters/php_phpcs/Dockerfile
+++ b/linters/php_phpcs/Dockerfile
@@ -168,7 +168,7 @@ COPY --from=composer/composer:2-bin /composer /usr/bin/composer
 # PHP installation
 RUN update-alternatives --install /usr/bin/php php /usr/bin/php84 110
 # Managed with COPY --from=composer/composer:2-bin /composer /usr/bin/composer
-ENV PATH="/root/.composer/vendor/bin:${PATH}"
+ENV PATH="/tmp/lint/vendor/bin:/root/.composer/vendor/bin:${PATH}"
 #
 # phpcs installation
 RUN --mount=type=secret,id=GITHUB_TOKEN GITHUB_AUTH_TOKEN="$(cat /run/secrets/GITHUB_TOKEN)" && export GITHUB_AUTH_TOKEN && composer global require squizlabs/php_codesniffer:${PHP_SQUIZLABS_PHP_CODESNIFFER_VERSION} bartlett/sarif-php-converters:${PHP_BARTLETT_SARIF_PHP_CONVERTERS_VERSION}

--- a/linters/php_phpcsfixer/Dockerfile
+++ b/linters/php_phpcsfixer/Dockerfile
@@ -166,7 +166,7 @@ COPY --from=composer/composer:2-bin /composer /usr/bin/composer
 # PHP installation
 RUN update-alternatives --install /usr/bin/php php /usr/bin/php84 110
 # Managed with COPY --from=composer/composer:2-bin /composer /usr/bin/composer
-ENV PATH="/root/.composer/vendor/bin:${PATH}"
+ENV PATH="/tmp/lint/vendor/bin:/root/.composer/vendor/bin:${PATH}"
 #
 # php-cs-fixer installation
 RUN --mount=type=secret,id=GITHUB_TOKEN GITHUB_AUTH_TOKEN="$(cat /run/secrets/GITHUB_TOKEN)" && export GITHUB_AUTH_TOKEN && composer global require friendsofphp/php-cs-fixer:${PHP_FRIENDSOFPHP_PHP_CS_FIXER_VERSION} --with-all-dependencies

--- a/linters/php_phplint/Dockerfile
+++ b/linters/php_phplint/Dockerfile
@@ -168,7 +168,7 @@ COPY --from=composer/composer:2-bin /composer /usr/bin/composer
 # PHP installation
 RUN update-alternatives --install /usr/bin/php php /usr/bin/php84 110
 # Managed with COPY --from=composer/composer:2-bin /composer /usr/bin/composer
-ENV PATH="/root/.composer/vendor/bin:${PATH}"
+ENV PATH="/tmp/lint/vendor/bin:/root/.composer/vendor/bin:${PATH}"
 #
 # phplint installation
 RUN --mount=type=secret,id=GITHUB_TOKEN GITHUB_AUTH_TOKEN="$(cat /run/secrets/GITHUB_TOKEN)" && export GITHUB_AUTH_TOKEN && composer global require overtrue/phplint:${PHP_OVERTRUE_PHPLINT_VERSION} bartlett/sarif-php-converters:${PHP_BARTLETT_SARIF_PHP_CONVERTERS_VERSION}

--- a/linters/php_phpstan/Dockerfile
+++ b/linters/php_phpstan/Dockerfile
@@ -170,7 +170,7 @@ COPY --from=composer/composer:2-bin /composer /usr/bin/composer
 # PHP installation
 RUN update-alternatives --install /usr/bin/php php /usr/bin/php84 110
 # Managed with COPY --from=composer/composer:2-bin /composer /usr/bin/composer
-ENV PATH="/root/.composer/vendor/bin:${PATH}"
+ENV PATH="/tmp/lint/vendor/bin:/root/.composer/vendor/bin:${PATH}"
 #
 # phpstan installation
 RUN --mount=type=secret,id=GITHUB_TOKEN GITHUB_AUTH_TOKEN="$(cat /run/secrets/GITHUB_TOKEN)" && export GITHUB_AUTH_TOKEN && composer config --global allow-plugins.phpstan/extension-installer true && composer global require phpstan/phpstan:${PHP_PHPSTAN_PHPSTAN_VERSION} phpstan/extension-installer:${PHP_PHPSTAN_EXTENSION_INSTALLER_VERSION} bartlett/sarif-php-converters:${PHP_BARTLETT_SARIF_PHP_CONVERTERS_VERSION}

--- a/linters/php_psalm/Dockerfile
+++ b/linters/php_psalm/Dockerfile
@@ -166,7 +166,7 @@ COPY --from=composer/composer:2-bin /composer /usr/bin/composer
 # PHP installation
 RUN update-alternatives --install /usr/bin/php php /usr/bin/php84 110
 # Managed with COPY --from=composer/composer:2-bin /composer /usr/bin/composer
-ENV PATH="/root/.composer/vendor/bin:${PATH}"
+ENV PATH="/tmp/lint/vendor/bin:/root/.composer/vendor/bin:${PATH}"
 #
 # psalm installation
 RUN --mount=type=secret,id=GITHUB_TOKEN GITHUB_AUTH_TOKEN="$(cat /run/secrets/GITHUB_TOKEN)" && export GITHUB_AUTH_TOKEN && composer global require vimeo/psalm:${PHP_VIMEO_PSALM_VERSION}

--- a/megalinter/descriptors/php.megalinter-descriptor.yml
+++ b/megalinter/descriptors/php.megalinter-descriptor.yml
@@ -25,7 +25,7 @@ install:
   dockerfile:
     - RUN update-alternatives --install /usr/bin/php php /usr/bin/php84 110
     - COPY --from=composer/composer:2-bin /composer /usr/bin/composer
-    - ENV PATH="/root/.composer/vendor/bin:${PATH}"
+    - ENV PATH="/tmp/lint/vendor/bin:/root/.composer/vendor/bin:${PATH}"
 linters:
   # PHPCS
   - linter_name: phpcs


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #6223

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. add `/tmp/lint/vendor/bin` in head of PATH to resolve locally vendor binary

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
