### PR TITLE
Hides regex compilation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Fixes
   - [#6544](https://github.com/oxsecurity/megalinter/issues/6544): Add GITHUB_TOKEN in docker build command for custom flavor
+  - Hide warning when compiling a regex
 
 - Reporters
 

--- a/megalinter/utils.py
+++ b/megalinter/utils.py
@@ -7,6 +7,7 @@ import os
 import re
 import tempfile
 import urllib.parse
+import warnings
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, Optional, Pattern, Sequence
@@ -640,7 +641,9 @@ def keep_only_valid_regex_patterns(patterns, fail=False):
         # First, attempt to fix the pattern
         fixed_pattern = fix_regex_pattern(pattern)
         try:
-            re.compile(fixed_pattern)  # Check if the pattern is valid
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", FutureWarning)
+                re.compile(fixed_pattern)  # Check if the pattern is valid
             # Skip if pattern has nested quantifiers (ReDoS risk)
             if nested_quantifier_regex.search(fixed_pattern):
                 logging.debug(


### PR DESCRIPTION
Suppresses a FutureWarning related to regex compilation to prevent unnecessary noise in the logs. This improves the user experience by reducing irrelevant warnings.

Fixes https://github.com/oxsecurity/megalinter/issues/6650