### PR TITLE
Update slash-command-dispatch version to 5.0.1

### DIFF
--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -42,7 +42,7 @@ jobs:
           GET_PR_OUTPUTS: ${{ toJson(steps.get-pr.outputs) }}
         run: echo "$GET_PR_OUTPUTS"
       - name: Slash Command Dispatch PR
-        uses: peter-evans/slash-command-dispatch@v5
+        uses: peter-evans/slash-command-dispatch@v5.0.1
         id: scd
         if: success()
         with:


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

It seems that even if the tag for v5 matches v5.0.1, the v5.0.0 is downloaded, and doesn’t find the workflow command to start.
<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update GitHub Actions workflow to use `peter-evans/slash-command-dispatch@v5.0.1` instead of `@v5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8689a9fcae6a00fc939cc51b64ea73742e8cd62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->