### PR TITLE
Add missing Dockerfile patterns to Renovate Dockerfile manager

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -116,7 +116,7 @@
   ],
   dockerfile: {
     managerFilePatterns: [
-      '/^.automation/test/Dockerfile-megalinter-custom$/'
+      '/^\\.automation/test/Dockerfile-megalinter-custom$/'
     ]
   }
 }


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

That file was not kept updated

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Renovate Dockerfile manager pattern to manage `.automation/test/Dockerfile-megalinter-custom`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2ebbb3961c06d98138ce44f87b0ae26f9c85f48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->