### PR TITLE
Remove rumdl test condition

### DIFF
--- a/megalinter/utilstest.py
+++ b/megalinter/utilstest.py
@@ -613,7 +613,7 @@ def test_linter_report_sarif(linter, test_self):
             ]
         ):
             # https://github.com/gitleaks/gitleaks/issues/1858
-            if linter.name != "REPOSITORY_GITLEAKS": # does not report errors
+            if linter.name != "REPOSITORY_GITLEAKS":  # does not report errors
                 test_self.assertTrue(
                     linter.total_number_errors > 1,
                     f"Missing multiple sarif errors in {linter.name}"


### PR DESCRIPTION
Starting with version 0.0.200, they have correctly mapped the `level` field from SARIF:

https://github.com/rvben/rumdl/commit/6aed1c948127258d25de17cb8afc534833d29655

https://github.com/rvben/rumdl/commit/763ae9777a51369e5f108b77b8ace749012d5dd7