### PR TITLE
feat(linters/spectral): change cli_lint_mode to list_of_files

### DIFF
--- a/megalinter/descriptors/api.megalinter-descriptor.yml
+++ b/megalinter/descriptors/api.megalinter-descriptor.yml
@@ -37,6 +37,7 @@ linters:
     linter_rules_configuration_url: https://docs.stoplight.io/docs/spectral/9ffa04e052cc1-spectral-cli#using-a-ruleset-file
     linter_spdx_license: Apache-2.0
     config_file_name: .spectral.yaml
+    cli_lint_mode: list_of_files
     cli_config_arg_name: "-r"
     cli_lint_extra_args:
       - "lint"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Spectral configuration to adjust how files are linted.
> 
> - In `megalinter/descriptors/api.megalinter-descriptor.yml`, set Spectral `cli_lint_mode` to `list_of_files`, switching MegaLinter to pass an explicit list of files to `spectral lint` (per-file linting)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 098684a0d33c821d9a2f7694425ad56175a5e8f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->