### PR TITLE
Avoid duplicate jobs "Mirror docker image" + allow to skip linters build

### DIFF
--- a/.github/workflows/deploy-BETA-linters.yml
+++ b/.github/workflows/deploy-BETA-linters.yml
@@ -41,6 +41,7 @@ concurrency:
 jobs:
   get-linters-matrix:
     name: Get Linters Matrix
+    if: ${{ vars.BETA_LINTERS_ENABLED != 'false' }}
     runs-on: ubuntu-latest
     outputs:
       linters: ${{ steps.set-matrix.outputs.linters }}
@@ -73,6 +74,7 @@ jobs:
            github.repository == 'oxsecurity/megalinter'
         && !contains(github.event.head_commit.message, 'skip deploy')
         && !contains(github.event.head_commit.message, 'Release MegaLinter v')
+        && vars.BETA_LINTERS_ENABLED != 'false'
       )
     ##################
     # Load all steps #

--- a/.github/workflows/deploy-DEV-linters.yml
+++ b/.github/workflows/deploy-DEV-linters.yml
@@ -92,6 +92,7 @@ jobs:
       (github.event_name == 'push' && github.repository == 'oxsecurity/megalinter')
       )
       && !contains(github.event.head_commit.message, 'skip deploy')
+      && !contains(github.event.head_commit.message, 'skip linters')
 
     ##################
     # Load all steps #

--- a/.github/workflows/mirror-docker-image.yml
+++ b/.github/workflows/mirror-docker-image.yml
@@ -14,6 +14,10 @@ on:
         required: false
         default: 'true'
 
+concurrency:
+  group: mirror-docker-image-${{ github.event.inputs.target-image }}
+  cancel-in-progress: true
+
 jobs:
 
   copy-to-docker-hub-alpha:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - CI
   - Free more space on GitHub Actions runners to avoid build failures
   - Ignore .isorted files in secretlint to avoid scanning transient files created by other linters
+  - Avoid duplicate jobs "Mirror docker image"
+  - Allow to skip linters build using `skip linters` in latest commit text
+  - Allow to disable build & push of standalone linters docker images using variable `BETA_LINTERS_ENABLED=false`
 
 - mega-linter-runner
   - If variables are defined in a local .env file, send their values to docker/podman run command (can be useful for secret variables)


### PR DESCRIPTION
  - Avoid duplicate jobs "Mirror docker image"
  - Allow to skip linters build using `skip linters` in latest commit text
  - Allow to disable build & push of standalone linters docker images using variable `BETA_LINTERS_ENABLED=false`