### PR TITLE
Handles GitHub API 500 errors gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Display in the console reporter the working directory from which the commands are executed by @bdovaz
   - Update WebHook reporter so it can send more events for a better integration with UI
   - When truncating long comments in markdown reports, keep the end of the text instead of the beginning (which usually contains less useful information)
+  - In case GitHub Api returns 500, do not make the whole MegaLinter fail, display a warning instead
 
 - Doc
   - JSON Schema: add default values for file extensions and file names variables + improve descriptions

--- a/megalinter/reporters/GithubCommentReporter.py
+++ b/megalinter/reporters/GithubCommentReporter.py
@@ -118,11 +118,17 @@ class GithubCommentReporter(Reporter):
                     logging.warning(f"Could not fetch PR#{pr_id}: {e}")
             if pr_list is None or len(pr_list) == 0:
                 # If not found with GITHUB_REF, try to find PR from commit
-                commit = repo.get_commit(sha=sha)
-                pr_list = commit.get_pulls()
-                if pr_list.totalCount == 0:
-                    logging.info(
-                        "[GitHub Comment Reporter] No pull request has been found, so no comment has been posted"
+                try:
+                    commit = repo.get_commit(sha=sha)
+                    pr_list = commit.get_pulls()
+                    if pr_list.totalCount == 0:
+                        logging.info(
+                            "[GitHub Comment Reporter] No pull request has been found, so no comment has been posted"
+                        )
+                        return
+                except Exception as e:
+                    logging.warning(
+                        f"[GitHub Comment Reporter] Unable to fetch pull requests for commit {sha}: {e}"
                     )
                     return
             for pr in pr_list:


### PR DESCRIPTION
Prevents MegaLinter from failing entirely when the GitHub API returns a 500 error. Instead, it logs a warning, allowing the process to continue.

Also attempts to retrieve pull requests associated with a commit and handles potential exceptions during the process.
