### PR TITLE
docs(vale): mention community style packages in linter description

### DIFF
--- a/megalinter/descriptors/spell.megalinter-descriptor.yml
+++ b/megalinter/descriptors/spell.megalinter-descriptor.yml
@@ -146,6 +146,8 @@ linters:
       - **Custom Rule Creation**: Powerful rule engine allows you to create and share custom style rules tailored to your organization
       - **Industry-Tested**: Trusted by thousands of writers, editors, and developers worldwide across different industries
 
+      Beyond the built-in style guides, the community maintains additional Vale packages for specialized use cases such as [inclusive language](https://vale.sh/hub/) and [speciesist language](https://github.com/Open-Paws/vale-speciesism) checks. These can be installed via `vale sync` and added to your `.vale.ini`.
+
       To be active within MegaLinter, you need to [initialize a .vale.ini configuration file](https://vale.sh/docs/vale-cli/structure/) at the root of your repository.
       MegaLinter analyze markdown and restructuredText files by default, you can change that using SPELL_VALE_FILE_EXTENSIONS variable.
     linter_url: https://vale.sh/


### PR DESCRIPTION
## Summary

- Adds a note to the Vale `linter_text` in the spell descriptor mentioning community-maintained Vale style packages
- Specifically references inclusive language and [speciesist language](https://github.com/Open-Paws/vale-speciesism) checks available via `vale sync`

Closes #7262

## Context

Per discussion in #7262, MegaLinter's Vale integration is the right place to surface community style packages. This is a small docs-only change to the descriptor — no code or behavior changes.

## Test plan

- [ ] Verify generated docs reflect the updated `linter_text`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that updates the Vale linter descriptor text; no runtime behavior or configuration semantics are modified.
> 
> **Overview**
> Updates the `SPELL_VALE` descriptor’s `linter_text` to mention community-maintained Vale style packages (e.g., inclusive language and speciesist language rules) and notes they can be installed via `vale sync` and referenced from `.vale.ini`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b544f4b44d874b4c0ce23751b32ce1f0f00aed00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->