### PR TITLE
csharp(roslynator): convert roslynator JSON/XML to SARIF and include …

### DIFF
--- a/megalinter/linters/RoslynatorLinter.py
+++ b/megalinter/linters/RoslynatorLinter.py
@@ -1,23 +1,313 @@
 #!/usr/bin/env python3
 """
-Use roslynator to lint CSharp files
+Use roslynator to lint CSharp files and convert its JSON/XML report to SARIF
+so MegaLinter can consume diagnostics from roslynator reports.
 """
 
+import json
 import logging
+import os
+from xml.etree import ElementTree as ET
 
-from megalinter import Linter
+from megalinter import Linter, utils
 
 
 class RoslynatorLinter(Linter):
     def process_linter(self, file=None):
-        command = f"dotnet restore {file}"
+        # Ensure project restore is attempted (keeps legacy behavior)
+        if file is not None:
+            command = f"dotnet restore {file}"
+            logging.debug(f"[{self.linter_name}] command: {str(command)}")
+            return_code, return_output = self.execute_lint_command(command)
+            logging.debug(
+                f"[{self.linter_name}] restore result: {str(return_code)} {return_output}"
+            )
 
-        logging.debug(f"[{self.linter_name}] command: {str(command)}")
+        # Let base class run the configured linter command (descriptor driven)
+        result = super().process_linter(file)
 
-        return_code, return_output = self.execute_lint_command(command)
+        # After the linter run, try to find roslynator JSON or XML reports
+        try:
+            report_files = []
+            # Common places: report_folder, workspace root
+            candidates = []
+            if hasattr(self, "report_folder") and self.report_folder:
+                candidates.append(self.report_folder)
+            if hasattr(self, "workspace") and self.workspace:
+                candidates.append(self.workspace)
 
-        logging.debug(
-            f"[{self.linter_name}] result: {str(return_code)} {return_output}"
-        )
+            for base in candidates:
+                try:
+                    for f in os.listdir(base):
+                        lf = f.lower()
+                        if "roslynator" in lf and (
+                            lf.endswith(".json") or lf.endswith(".xml")
+                        ):
+                            report_files.append(os.path.join(base, f))
+                except Exception:
+                    continue
 
-        return super().process_linter(file)
+            # Also scan report_folder subdir
+            if hasattr(self, "report_folder") and self.report_folder:
+                for root, _, files in os.walk(self.report_folder):
+                    for f in files:
+                        lf = f.lower()
+                        if "roslynator" in lf and (
+                            lf.endswith(".json") or lf.endswith(".xml")
+                        ):
+                            report_files.append(os.path.join(root, f))
+
+            # If any report found, convert the first one to SARIF
+            if len(report_files) > 0:
+                report = report_files[0]
+                logging.info(f"[{self.linter_name}] Found roslynator report: {report}")
+                sarif_obj = self._convert_report_to_sarif(report)
+                if sarif_obj is not None:
+                    # Ensure sarif_output_file path exists (fallback if not set)
+                    if self.sarif_output_file is None:
+                        self.sarif_output_file = os.path.join(
+                            self.report_folder or ".", "sarif", f"{self.name}.sarif"
+                        )
+                        os.makedirs(
+                            os.path.dirname(self.sarif_output_file), exist_ok=True
+                        )
+
+                    with open(self.sarif_output_file, "w", encoding="utf-8") as fh:
+                        json.dump(sarif_obj, fh, indent=2, sort_keys=True)
+                    logging.info(
+                        f"[{self.linter_name}] Wrote SARIF: {self.sarif_output_file}"
+                    )
+
+        except Exception as e:
+            logging.exception(
+                f"[{self.linter_name}] Error while converting roslynator report: {e}"
+            )
+
+        return result
+
+    def _convert_report_to_sarif(self, report_path):
+        """Try to parse roslynator JSON or XML report and build a minimal SARIF object."""
+        try:
+            if report_path.lower().endswith(".json"):
+                with open(report_path, "r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+                return self._json_to_sarif(data)
+            elif report_path.lower().endswith(".xml"):
+                tree = ET.parse(report_path)
+                root = tree.getroot()
+                return self._xml_to_sarif(root)
+        except Exception as e:
+            logging.exception(
+                f"[{self.linter_name}] Failed to parse report {report_path}: {e}"
+            )
+        return None
+
+    def _json_to_sarif(self, data):
+        # Best-effort mapping from roslynator JSON to SARIF
+        diagnostics = []
+        if isinstance(data, dict):
+            # common candidates
+            if "diagnostics" in data and isinstance(data["diagnostics"], list):
+                diagnostics = data["diagnostics"]
+            elif "items" in data and isinstance(data["items"], list):
+                diagnostics = data["items"]
+            else:
+                # maybe top-level is a list
+                for v in data.values():
+                    if isinstance(v, list):
+                        diagnostics = v
+                        break
+        elif isinstance(data, list):
+            diagnostics = data
+
+        results = []
+        rules = {}
+        for diag in diagnostics:
+            try:
+                rule_id = (
+                    diag.get("id") or diag.get("ruleId") or diag.get("diagnosticId")
+                )
+                message = (
+                    diag.get("message")
+                    or diag.get("messageText")
+                    or diag.get("title")
+                    or str(diag)
+                )
+                file_path = diag.get("file") or diag.get("filePath") or diag.get("path")
+                line = diag.get("line") or diag.get("startLine") or None
+
+                if rule_id:
+                    rules.setdefault(
+                        rule_id, {"id": rule_id, "shortDescription": {"text": rule_id}}
+                    )
+
+                location = None
+                if file_path:
+                    region = {"startLine": int(line) if line is not None else 1}
+                    location = {
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": file_path},
+                            "region": region,
+                        }
+                    }
+
+                res = {"ruleId": rule_id or "roslynator", "message": {"text": message}}
+                if location:
+                    res["locations"] = [location]
+
+                results.append(res)
+            except Exception:
+                continue
+
+        sarif = {
+            "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {
+                        "driver": {
+                            "name": "roslynator",
+                            "version": self.get_linter_version(),
+                            "informationUri": getattr(
+                                self,
+                                "linter_url",
+                                "https://github.com/dotnet/Roslynator",
+                            ),
+                            "rules": list(rules.values()),
+                        }
+                    },
+                    "results": results,
+                }
+            ],
+        }
+        return sarif
+
+    def _xml_to_sarif(self, root):
+        # Best-effort mapping from XML structure to SARIF. Try to find diagnostic elements.
+        diagnostics = []
+        for diag in root.iter():
+            if diag.tag.lower().endswith("diagnostic") or diag.tag.lower().endswith(
+                "issue"
+            ):
+                diagnostics.append(diag)
+
+        results = []
+        rules = {}
+        for diag in diagnostics:
+            try:
+                rule_id = (
+                    diag.findtext("id") or diag.findtext("ruleId") or diag.get("id")
+                )
+                message = (
+                    diag.findtext("message")
+                    or diag.findtext("messageText")
+                    or ET.tostring(diag, encoding="unicode")
+                )
+                file_path = diag.findtext("file") or diag.findtext("path") or None
+                line = diag.findtext("line") or diag.findtext("startLine") or None
+
+                if rule_id:
+                    rules.setdefault(
+                        rule_id, {"id": rule_id, "shortDescription": {"text": rule_id}}
+                    )
+
+                location = None
+                if file_path:
+                    region = {"startLine": int(line) if line is not None else 1}
+                    location = {
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": file_path},
+                            "region": region,
+                        }
+                    }
+
+                res = {"ruleId": rule_id or "roslynator", "message": {"text": message}}
+                if location:
+                    res["locations"] = [location]
+
+                results.append(res)
+            except Exception:
+                continue
+
+        sarif = {
+            "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {
+                        "driver": {
+                            "name": "roslynator",
+                            "version": self.get_linter_version(),
+                            "informationUri": getattr(
+                                self,
+                                "linter_url",
+                                "https://github.com/dotnet/Roslynator",
+                            ),
+                            "rules": list(rules.values()),
+                        }
+                    },
+                    "results": results,
+                }
+            ],
+        }
+        return sarif
+
+    # Provide original roslynator report content in the standard TextReporter
+    # This method is called by reporters to append extra human-readable lines
+    def complete_text_reporter_report(self, reporter_self):
+        if self.stdout is None or not utils.can_write_report_files(self.master):
+            return []
+
+        # Find the same report files as in process_linter
+        report_files = []
+        candidates = []
+        if hasattr(self, "report_folder") and self.report_folder:
+            candidates.append(self.report_folder)
+        if hasattr(self, "workspace") and self.workspace:
+            candidates.append(self.workspace)
+
+        for base in candidates:
+            try:
+                for f in os.listdir(base):
+                    lf = f.lower()
+                    if "roslynator" in lf and (lf.endswith(".json") or lf.endswith(".xml")):
+                        report_files.append(os.path.join(base, f))
+            except Exception:
+                continue
+
+        if hasattr(self, "report_folder") and self.report_folder:
+            for root, _, files in os.walk(self.report_folder):
+                for f in files:
+                    lf = f.lower()
+                    if "roslynator" in lf and (lf.endswith(".json") or lf.endswith(".xml")):
+                        report_files.append(os.path.join(root, f))
+
+        if len(report_files) == 0:
+            return []
+
+        # Use the first found report
+        report_path = report_files[0]
+        try:
+            with open(report_path, "r", encoding="utf-8") as fh:
+                raw = fh.read()
+        except Exception:
+            return []
+
+        additional_report = [
+            "\n--- Roslynator original report ---",
+            f"Source: {utils.normalize_log_string(report_path)}",
+        ]
+
+        try:
+            if report_path.lower().endswith(".json"):
+                parsed = json.loads(raw)
+                pretty = json.dumps(parsed, indent=2, ensure_ascii=False)
+                additional_report += pretty.splitlines()
+            else:
+                # XML: show raw (or pretty if feasible)
+                additional_report += raw.splitlines()
+        except Exception:
+            additional_report += raw.splitlines()
+
+        additional_report += ["--- End Roslynator report ---\n"]
+        return additional_report

--- a/tmp/test_roslynator_minimal.py
+++ b/tmp/test_roslynator_minimal.py
@@ -1,0 +1,133 @@
+import json
+import os
+import sys
+import types
+import importlib.util
+
+
+# Create a lightweight dummy 'megalinter' module so we can import the Roslynator linter
+# without pulling the full project dependencies (yaml, etc.).
+megalinter_mod = types.ModuleType("megalinter")
+
+
+class DummyLinter:
+    def __init__(self, params=None, linter_config=None):
+        self.request_id = params.get("request_id") if params else None
+        self.report_folder = None
+        self.workspace = None
+        self.sarif_output_file = None
+        self.name = None
+        self.linter_url = "https://github.com/dotnet/Roslynator"
+
+    def get_linter_version(self):
+        return "0.0.0"
+
+    def execute_lint_command(self, cmd):
+        return (0, "")
+
+    def process_linter(self, file=None):
+        return None
+
+
+megalinter_mod.Linter = DummyLinter
+
+# Minimal dummy utils used by RoslynatorLinter during tests
+dummy_utils = types.ModuleType("megalinter.utils")
+
+def _can_write_report_files(master):
+    return True
+
+def _normalize_log_string(s):
+    return s
+
+dummy_utils.can_write_report_files = _can_write_report_files
+dummy_utils.normalize_log_string = _normalize_log_string
+
+megalinter_mod.utils = dummy_utils
+
+# Inject into sys.modules so subsequent imports find it
+sys.modules["megalinter"] = megalinter_mod
+
+# Load RoslynatorLinter by file so it uses our dummy megalinter module
+rl_path = os.path.join(os.path.dirname(__file__), os.pardir, "megalinter", "linters", "RoslynatorLinter.py")
+rl_path = os.path.normpath(rl_path)
+spec = importlib.util.spec_from_file_location("roslynator_module", rl_path)
+ros_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ros_mod)
+
+RoslynatorLinter = getattr(ros_mod, "RoslynatorLinter")
+
+
+def main():
+    tmpdir = "tmp_test_roslynator"
+    os.makedirs(tmpdir, exist_ok=True)
+
+    json_report = os.path.join(tmpdir, "roslynator_report.json")
+    xml_report = os.path.join(tmpdir, "roslynator_report.xml")
+
+    # sample JSON report
+    sample_json = {
+        "diagnostics": [
+            {"id": "R001", "message": "Example issue", "file": "src/foo.cs", "line": 10}
+        ]
+    }
+    with open(json_report, "w", encoding="utf-8") as fh:
+        json.dump(sample_json, fh)
+
+    # sample XML report
+    sample_xml = """<?xml version='1.0'?>
+<reports>
+  <diagnostic>
+    <id>R002</id>
+    <message>XML issue</message>
+    <file>src/bar.cs</file>
+    <line>20</line>
+  </diagnostic>
+</reports>
+"""
+    with open(xml_report, "w", encoding="utf-8") as fh:
+        fh.write(sample_xml)
+
+    # Instantiate linter using dummy Linter base
+    linter = RoslynatorLinter(params={"request_id": "test"}, linter_config={})
+    linter.report_folder = tmpdir
+    linter.workspace = tmpdir
+    linter.name = "CSHARP_ROSLYNATOR"
+    # Provide minimal runtime attributes expected by reporter helper
+    linter.stdout = ""
+    linter.master = types.SimpleNamespace(report_folder=tmpdir, request_id="test")
+
+    print("Testing JSON report conversion:")
+    sarif_json = linter._convert_report_to_sarif(json_report)
+    print(json.dumps(sarif_json, indent=2, ensure_ascii=False))
+
+    print("\nTesting XML report conversion:")
+    sarif_xml = linter._convert_report_to_sarif(xml_report)
+    print(json.dumps(sarif_xml, indent=2, ensure_ascii=False))
+
+    return linter
+
+
+if __name__ == "__main__":
+    # Run main flow and get linter instance
+    linter = main()
+
+    # Simulate reporter_self for text reporter augmentation
+    class DummyReporter:
+        def __init__(self, report_folder, master):
+            self.report_folder = report_folder
+            self.master = master
+
+    class DummyMaster:
+        def __init__(self):
+            self.report_folder = "tmp_test_roslynator"
+            self.request_id = "test"
+            self.config_file_name = "dummy"
+
+    reporter = DummyReporter(report_folder="tmp_test_roslynator", master=DummyMaster())
+    print("\nText reporter additional lines:")
+    lines = linter.complete_text_reporter_report(reporter)
+    for line in lines:
+        print(line)
+
+    sys.exit(0)

--- a/tmp_test_roslynator/roslynator_report.json
+++ b/tmp_test_roslynator/roslynator_report.json
@@ -1,0 +1,1 @@
+{"diagnostics": [{"id": "R001", "message": "Example issue", "file": "src/foo.cs", "line": 10}]}

--- a/tmp_test_roslynator/roslynator_report.xml
+++ b/tmp_test_roslynator/roslynator_report.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0'?>
+<reports>
+  <diagnostic>
+    <id>R002</id>
+    <message>XML issue</message>
+    <file>src/bar.cs</file>
+    <line>20</line>
+  </diagnostic>
+</reports>


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Convert Roslynator JSON/XML reports into SARIF and write the SARIF to the configured `sarif_output_file` (so MegaLinter can consume diagnostics).
2. Append the original Roslynator JSON/XML content into the standard TextReporter output for human-readable inspection.
3. Add a small isolated test script (`tmp/test_roslynator_minimal.py`) used for local validation of conversion and reporter output.

## Files changed / highlights

- `megalinter/linters/RoslynatorLinter.py` — parse Roslynator JSON/XML, produce a minimal SARIF file, and add `complete_text_reporter_report` to include the raw report in the TextReporter output.
- `tmp/test_roslynator_minimal.py` — isolated test script used to validate conversion and reporter output (for reviewer/local validation).

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
