### PR TITLE
Remove deprecated exclude_mail lychee configuration

### DIFF
--- a/.github/linters/lychee.toml
+++ b/.github/linters/lychee.toml
@@ -55,8 +55,5 @@ exclude_link_local = true
 # Exclude loopback IP address range and localhost from checking.
 exclude_loopback = true
 
-# Exclude all mail addresses from checking.
-exclude_mail = true
-
 # Exclude these filesystem paths from getting checked.
 exclude_path = ["node_modules", "site", "docs", ".venv", "CHANGELOG.md", "megalinter/descriptors/schemas", ".automation/generated", ".automation/test"]

--- a/docs/descriptors/lua_selene.md
+++ b/docs/descriptors/lua_selene.md
@@ -9,7 +9,7 @@ description: How to use selene (configure, ignore files, ignore errors, help & v
 
 _This linter has been disabled in this version_
 
-_Disabled reason: https://github.com/Kampfkarren/selene/issues/662_
+_Disabled reason: <https://github.com/Kampfkarren/selene/issues/662>_
 
 **Selene** is a blazing-fast modern Lua linter written in Rust that provides comprehensive static analysis for Lua code. It offers extensive configurability and can be tailored to specific Lua environments like Roblox, World of Warcraft addons, or standard Lua.
 

--- a/docs/descriptors/repository_gitleaks.md
+++ b/docs/descriptors/repository_gitleaks.md
@@ -34,18 +34,18 @@ If MegaLinter with gitleaks runs against a PR on a platform not listed above, an
 
 You can still choose to scan only PR commits in your CI/CD platform by setting the following MegaLinter environment variables:
 
-  - `PULL_REQUEST=true`\*
-  - `REPOSITORY_GITLEAKS_PR_COMMITS_SCAN: true`
-  - `REPOSITORY_GITLEAKS_PR_SOURCE_SHA` with last commit sha from your PR and `REPOSITORY_GITLEAKS_PR_TARGET_SHA` commit sha from your target branch (for example, `main` if you do PR to main branch)
+- `PULL_REQUEST=true`\*
+- `REPOSITORY_GITLEAKS_PR_COMMITS_SCAN: true`
+- `REPOSITORY_GITLEAKS_PR_SOURCE_SHA` with last commit sha from your PR and `REPOSITORY_GITLEAKS_PR_TARGET_SHA` commit sha from your target branch (for example, `main` if you do PR to main branch)
 
     Example commands:
 
-      - Source commit SHA:
+  - Source commit SHA:
         ```bash
         git rev-list -n 1 refs/remotes/origin/<source_branch>
         ```
 
-      - Target commit SHA:
+  - Target commit SHA:
         ```bash
         git rev-parse refs/remotes/origin/<target_branch>
         ```

--- a/docs/descriptors/repository_kics.md
+++ b/docs/descriptors/repository_kics.md
@@ -15,7 +15,7 @@ description: How to use kics (configure, ignore files, ignore errors, help & ver
 
 _This linter has been disabled in this version_
 
-_Disabled reason: Supply chain compromise - https://socket.dev/blog/checkmarx-supply-chain-compromise_
+_Disabled reason: Supply chain compromise - <https://socket.dev/blog/checkmarx-supply-chain-compromise>_
 
 **KICS** (Keeping Infrastructure as Code Secure) is a comprehensive open-source security scanner that identifies security vulnerabilities, compliance issues, and infrastructure misconfigurations in Infrastructure as Code files. It serves as a critical tool for preventing security risks before deployment to production environments.
 

--- a/docs/descriptors/repository_trivy.md
+++ b/docs/descriptors/repository_trivy.md
@@ -15,7 +15,7 @@ description: How to use trivy (configure, ignore files, ignore errors, help & ve
 
 _This linter has been disabled in this version_
 
-_Disabled reason: https://github.com/aquasecurity/trivy/discussions/10425_
+_Disabled reason: <https://github.com/aquasecurity/trivy/discussions/10425>_
 
 **Trivy** is a comprehensive security scanner that detects vulnerabilities, misconfigurations, secrets, and license issues in container images, filesystems, and git repositories. It serves as an all-in-one security solution for modern development workflows.
 

--- a/docs/descriptors/repository_trivy_sbom.md
+++ b/docs/descriptors/repository_trivy_sbom.md
@@ -15,7 +15,7 @@ description: How to use trivy-sbom (configure, ignore files, ignore errors, help
 
 _This linter has been disabled in this version_
 
-_Disabled reason: https://github.com/aquasecurity/trivy/discussions/10425_
+_Disabled reason: <https://github.com/aquasecurity/trivy/discussions/10425>_
 
 **Trivy SBOM** is a specialized component of Trivy that generates comprehensive Software Bill of Materials (SBOM) documents for enhanced supply chain security and compliance. It provides detailed inventory management for software components and dependencies.
 


### PR DESCRIPTION
Context: https://github.com/lycheeverse/lychee/releases/tag/lychee-v0.19.0

It caused errors:

<img width="1433" height="360" alt="image" src="https://github.com/user-attachments/assets/16668a58-cb85-4217-be20-25388583c483" />

