### PR TITLE
fix: exclude REPORT_OUTPUT_FOLDER when set to an absolute workspace path (#7845)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Linters enhancements
 
 - Fixes
+  - Exclude `REPORT_OUTPUT_FOLDER` from linting when configured as an absolute path inside the workspace (e.g. `/tmp/lint/megalinter-reports`), fixing #7845.
 
 - Reporters
 

--- a/docs/descriptors/repository_gitleaks.md
+++ b/docs/descriptors/repository_gitleaks.md
@@ -40,12 +40,12 @@ You can still choose to scan only PR commits in your CI/CD platform by setting t
 
     Example commands:
 
-    - Source commit SHA:
+  - Source commit SHA:
         ```bash
         git rev-list -n 1 refs/remotes/origin/<source_branch>
         ```
 
-    - Target commit SHA:
+  - Target commit SHA:
         ```bash
         git rev-parse refs/remotes/origin/<target_branch>
         ```

--- a/megalinter/MegaLinter.py
+++ b/megalinter/MegaLinter.py
@@ -902,12 +902,36 @@ class Megalinter:
                 all_files += [diff_line]
         return all_files
 
+    def _normalize_excluded_directories(self, excluded_directories):
+        # Convert absolute paths located inside the workspace into
+        # workspace-relative paths so they match the values produced by
+        # os.walk(). Workspace-relative entries are kept unchanged; absolute
+        # paths outside the workspace are dropped (they can never match).
+        workspace_abs = os.path.abspath(self.workspace)
+        normalized = set()
+        for excluded_dir in excluded_directories:
+            if not excluded_dir:
+                continue
+            if os.path.isabs(excluded_dir):
+                try:
+                    rel = os.path.relpath(excluded_dir, workspace_abs)
+                except ValueError:
+                    continue
+                if rel == "." or rel.startswith(".."):
+                    continue
+                normalized.add(rel.replace("\\", "/"))
+            else:
+                normalized.add(excluded_dir)
+        return normalized
+
     def list_files_all(self):
         # List all files under workspace root directory
         logging.info(
             "Listing all files in directory [" + self.workspace + "], then filter with:"
         )
-        excluded_directories = utils.get_excluded_directories(self.request_id)
+        excluded_directories = self._normalize_excluded_directories(
+            utils.get_excluded_directories(self.request_id)
+        )
         all_files = []
         for dirpath, dirnames, filenames in os.walk(
             self.workspace, topdown=True, followlinks=False

--- a/megalinter/descriptors/repository.megalinter-descriptor.yml
+++ b/megalinter/descriptors/repository.megalinter-descriptor.yml
@@ -285,12 +285,12 @@ linters:
 
           Example commands:
 
-          - Source commit SHA:
+        - Source commit SHA:
               ```bash
               git rev-list -n 1 refs/remotes/origin/<source_branch>
               ```
 
-          - Target commit SHA:
+        - Target commit SHA:
               ```bash
               git rev-parse refs/remotes/origin/<target_branch>
               ```

--- a/megalinter/tests/test_megalinter/mega_linter_files_test.py
+++ b/megalinter/tests/test_megalinter/mega_linter_files_test.py
@@ -52,6 +52,40 @@ class MegaLinterFilesTest(unittest.TestCase):
             self.assertNotIn("excluded/should_skip.txt", files)
             self.assertNotIn("keep/nested_excluded/skip_me.txt", files)
 
+    def test_list_files_all_skips_absolute_excluded_directory_inside_workspace(self):
+        # Regression test for issue #7845: an absolute path inside the
+        # workspace (e.g. REPORT_OUTPUT_FOLDER=/tmp/lint/megalinter-reports)
+        # must be pruned from os.walk() the same as a relative entry.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with open(os.path.join(tmp_dir, "root.txt"), "w", encoding="utf-8"):
+                pass
+
+            report_dir = os.path.join(tmp_dir, "megalinter-reports")
+            os.makedirs(os.path.join(report_dir, "updated_sources"), exist_ok=True)
+            with open(
+                os.path.join(report_dir, "updated_sources", "test.sh"),
+                "w",
+                encoding="utf-8",
+            ):
+                pass
+
+            excluded = {report_dir}
+
+            ml = Megalinter.__new__(Megalinter)
+            ml.workspace = tmp_dir
+            ml.request_id = "test"
+
+            with patch(
+                "megalinter.utils.get_excluded_directories", return_value=excluded
+            ):
+                files = ml.list_files_all()
+
+            self.assertIn("root.txt", files)
+            self.assertNotIn(
+                "megalinter-reports/updated_sources/test.sh",
+                [f.replace(os.sep, "/") for f in files],
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

When `REPORT_OUTPUT_FOLDER` is set to an absolute path inside the workspace (e.g. `/tmp/lint/megalinter-reports`, as `mega-linter-runner` mounts the workspace at `/tmp/lint`), the report folder was not pruned from `Megalinter.list_files_all()`. After a first run, files generated under that folder (e.g. `megalinter-reports/updated_sources/*`) leaked into the candidate file list on the next run and got linted.

Root cause: `utils.get_excluded_directories()` returns the configured value unchanged, while `list_files_all()` compares against the workspace-relative directory names produced by `os.walk()`. Absolute paths therefore never matched.

This PR normalizes excluded directories to workspace-relative paths before pruning. Workspace-relative entries are kept unchanged; absolute paths outside the workspace are dropped (they can never match). `list_git_ignored_files()` is unchanged — Git canonicalizes absolute pathspecs itself, as noted in the issue.

## Changes

- `megalinter/MegaLinter.py`: add `_normalize_excluded_directories()` helper and use it in `list_files_all()`.
- `megalinter/tests/test_megalinter/mega_linter_files_test.py`: regression test for the absolute-path case.
- `CHANGELOG.md`: Fixes entry.

## Test plan

- [ ] New unit test passes locally.
- [ ] Reproduce per the issue: run `mega-linter-runner` twice with `REPORT_OUTPUT_FOLDER=/tmp/lint/megalinter-reports` and confirm that `megalinter-reports/updated_sources/test.sh` is no longer in the second run's `shfmt` command.
- [ ] Confirm relative-path behavior is unchanged (default `megalinter-reports` still excluded).

Fixes https://github.com/oxsecurity/megalinter/issues/7845