### PR TITLE
Update python version in devcontainer image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:3-3.12-trixie
+FROM mcr.microsoft.com/devcontainers/python:3-3.14-trixie
 
 # renovate: datasource=npm depName=markdown-table-formatter
 ARG NPM_MARKDOWN_TABLE_FORMATTER_VERSION=1.7.0


### PR DESCRIPTION
We use Python 3.14 everywhere: https://github.com/search?q=repo%3Aoxsecurity%2Fmegalinter%203.14&type=code