### PR TITLE
Bump idna to >=3.15 to address security vulnerability GHSA-65pc-fj4g-8rjx

### DIFF
--- a/.config/python/dev/requirements.txt
+++ b/.config/python/dev/requirements.txt
@@ -6,6 +6,7 @@ commentjson==0.9.0
 fastapi==0.136.1
 gitpython==3.1.50
 giturlparse==0.14.0
+idna==3.15
 importlib-metadata==9.0.0
 json-schema-for-humans==1.5.1
 jsonpickle==4.1.1

--- a/.cspell.json
+++ b/.cspell.json
@@ -120,6 +120,7 @@
         "has-tostringtag",
         "hiqr",
         "humanwhocodes",
+        "idna",
         "iisisrael",
         "ilrsD",
         "imple",

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,7 +27,7 @@ jobs:
     if: "github.event_name == 'schedule'"
     steps:
       - name: Mark issue stale
-        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity.\nIt will be closed in 14 days if no further activity occurs.\nThank you for your contributions.\n\nIf you think this issue should stay open, please remove the `O: stale 🤖` label or comment on the issue."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Fixes
   - Exclude `REPORT_OUTPUT_FOLDER` from linting when configured as an absolute path inside the workspace (e.g. `/tmp/lint/megalinter-reports`), fixing #7845.
   - Fix command injection in Roslynator linter (`DOTNET_ROSLYNATOR`) where a crafted `.csproj` filename could break out of `dotnet restore` arguments and execute arbitrary shell commands. The command is now invoked via argv list instead of a shell string. Reported by Francesco Sabiu.
+  - Bump transitive `idna` to `>=3.15` to address [GHSA-65pc-fj4g-8rjx](https://github.com/advisories/GHSA-65pc-fj4g-8rjx) (DoS via crafted IDN). Pinned explicitly in `pyproject.toml`, `.config/python/dev/requirements.txt`, and `server/requirements.txt`.
 
 - Reporters
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
   "commentjson",
   "gitpython",
+  "idna>=3.15",
   "importlib-metadata>=3.10; python_version < '3.9'",
   "jsonpickle",
   "langchain-core~=1.4.0",

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,6 +1,7 @@
 aiofiles==25.1.0
 gitpython==3.1.50
 fastapi==0.136.1
+idna==3.15
 h11==0.16.0
 python-multipart==0.0.29
 pygments==2.20.0

--- a/uv.lock
+++ b/uv.lock
@@ -1276,6 +1276,7 @@ source = { editable = "." }
 dependencies = [
     { name = "commentjson" },
     { name = "gitpython" },
+    { name = "idna" },
     { name = "jsonpickle" },
     { name = "langchain-anthropic" },
     { name = "langchain-community" },
@@ -1315,6 +1316,7 @@ huggingface = [
 requires-dist = [
     { name = "commentjson" },
     { name = "gitpython" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "importlib-metadata", marker = "python_full_version < '3.9'", specifier = ">=3.10" },
     { name = "jsonpickle" },
     { name = "langchain-anthropic", specifier = "~=1.4.0" },


### PR DESCRIPTION
 ## Summary

  Pin `idna>=3.15` explicitly to address [GHSA-65pc-fj4g-8rjx](https://github.com/advisories/GHSA-65pc-fj4g-8rjx) (DoS via crafted IDN), surfaced by `REPOSITORY_OSV_SCANNER` on recent PR runs.

  `idna` was pulled transitively via `requests`/`urllib3`. The OSV scanner resolved 3.9.0 from `.config/python/dev/requirements.txt` and `server/requirements.txt`, both of which had no explicit pin.

  ## Changes

  - `pyproject.toml` — `idna>=3.15` added to `[project.dependencies]`
  - `.config/python/dev/requirements.txt` — `idna==3.15`
  - `server/requirements.txt` — `idna==3.15`
  - `uv.lock` — refreshed via `uv lock` (idna 3.15 was already resolved, this just records the explicit constraint)

  ## Notes

  - `idna 3.15` is the latest stable on PyPI as of this PR.
  - This is the smallest change that satisfies OSV's "vulnerabilities that can be fixed" check.

  ## Test plan

  - [ ] CI passes (OSV scanner should no longer report idna)
  - [ ] No new dependency conflicts in `uv lock`
