### PR TITLE
fix(descriptors): restore missing examples in dart descriptor

### DIFF
--- a/megalinter/descriptors/dart.megalinter-descriptor.yml
+++ b/megalinter/descriptors/dart.megalinter-descriptor.yml
@@ -79,6 +79,8 @@ linters:
     cli_help_extra_args:
       - "analyze"
     version_extract_regex: "(?<=Dart SDK version: )(\\d+)\\.(\\d+)\\.(\\d+)"
+    examples:
+      - "dart analyze --fatal-infos --fatal-warnings myfile.dart"
     common_linter_errors:
       - identifier: DART_DARTANALYZER_ERROR_MISSING_PUBSPEC
         regex: 'Could not find a file named "pubspec.yaml"'


### PR DESCRIPTION
## Summary

- PR #7907 (common_linter_errors) accidentally replaced the `examples` block in `dart.megalinter-descriptor.yml` with `common_linter_errors` instead of adding the new field alongside.
- `examples` is a required property in `megalinter-descriptor.jsonschema.json`, so `validate_descriptors()` now fails in the [Auto-Update Linters workflow](https://github.com/oxsecurity/megalinter/actions/runs/26374790102/job/77633105839):

```
ERROR dart.megalinter-descriptor.yml is not compliant with JSON schema
reason: 'examples' is a required property
```

This restores the original `examples` entry.

## Test plan

- [x] Local validation: `jsonschema.validate(dart_descriptor, schema)` passes
- [ ] CI: Auto-Update Linters workflow validates descriptors successfully