### PR TITLE
Prevent FromAsCasing warning in Dockerfiles

### DIFF
--- a/Dockerfile-quick
+++ b/Dockerfile-quick
@@ -10,7 +10,7 @@
 ##################
 ARG GITHUB_TOKEN
 ARG MEGALINTER_BASE_IMAGE=ghcr.io/oxsecurity/megalinter:beta
-FROM $MEGALINTER_BASE_IMAGE as base
+FROM $MEGALINTER_BASE_IMAGE AS base
 
 ##################
 # Build wheel for megalinter python package

--- a/docs/descriptor-schema.md
+++ b/docs/descriptor-schema.md
@@ -163,7 +163,7 @@ _Descriptor definition for mega-linter_
 						 - _Will be automatically integrated in generated Dockerfile_
 						 - Type: `array`
 						 - Example values: 
-							 1. `FROM accurics/terrascan:d182f1c as terrascan`
+							 1. `FROM accurics/terrascan:d182f1c AS terrascan`
 							 2. `COPY --from=terrascan /go/bin/terrascan /usr/bin/`
 							 3. `RUN terrascan init`
 							 - **_Items_**

--- a/docs/json-schemas/descriptor.html
+++ b/docs/json-schemas/descriptor.html
@@ -5252,7 +5252,7 @@
 <div class="badge badge-secondary">Examples:</div>
 <br/><button class="btn btn-light example-show collapsed" data-toggle="collapse" data-target="#linters_items_install_ex1" aria-controls="linters_items_install_ex1"></button><div id="linters_items_install_ex1" class="collapse jumbotron examples"><div class="highlight"><pre><span></span><span class="p">{</span>
 <span class="w">    </span><span class="s2">&quot;dockerfile&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span>
-<span class="w">        </span><span class="s2">&quot;FROM accurics/terrascan:latest as terrascan&quot;</span><span class="p">,</span>
+<span class="w">        </span><span class="s2">&quot;FROM accurics/terrascan:latest AS terrascan&quot;</span><span class="p">,</span>
 <span class="w">        </span><span class="s2">&quot;COPY --from=terrascan /go/bin/terrascan /usr/bin/&quot;</span><span class="p">,</span>
 <span class="w">        </span><span class="s2">&quot;RUN terrascan init&quot;</span>
 <span class="w">    </span><span class="p">]</span>
@@ -5594,7 +5594,7 @@
     </div><br/>
 <div class="badge badge-secondary">Example:</div>
 <br/><div id="linters_items_install_dockerfile_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">[</span>
-<span class="w">    </span><span class="s2">&quot;FROM accurics/terrascan:latest as terrascan&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;FROM accurics/terrascan:latest AS terrascan&quot;</span><span class="p">,</span>
 <span class="w">    </span><span class="s2">&quot;COPY --from=terrascan /go/bin/terrascan /usr/bin/&quot;</span><span class="p">,</span>
 <span class="w">    </span><span class="s2">&quot;RUN terrascan init&quot;</span>
 <span class="p">]</span>
@@ -8136,7 +8136,7 @@ These special installation steps replace the instructions in the <a href="#linte
 <div class="badge badge-secondary">Examples:</div>
 <br/><button class="btn btn-light example-show collapsed" data-toggle="collapse" data-target="#linters_items_supported_platforms_install_override_items_install_ex1" aria-controls="linters_items_supported_platforms_install_override_items_install_ex1"></button><div id="linters_items_supported_platforms_install_override_items_install_ex1" class="collapse jumbotron examples"><div class="highlight"><pre><span></span><span class="p">{</span>
 <span class="w">    </span><span class="s2">&quot;dockerfile&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span>
-<span class="w">        </span><span class="s2">&quot;FROM accurics/terrascan:latest as terrascan&quot;</span><span class="p">,</span>
+<span class="w">        </span><span class="s2">&quot;FROM accurics/terrascan:latest AS terrascan&quot;</span><span class="p">,</span>
 <span class="w">        </span><span class="s2">&quot;COPY --from=terrascan /go/bin/terrascan /usr/bin/&quot;</span><span class="p">,</span>
 <span class="w">        </span><span class="s2">&quot;RUN terrascan init&quot;</span>
 <span class="w">    </span><span class="p">]</span>
@@ -8604,7 +8604,7 @@ These special installation steps replace the instructions in the <a href="#linte
     </div><br/>
 <div class="badge badge-secondary">Example:</div>
 <br/><div id="linters_items_supported_platforms_install_override_items_install_dockerfile_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">[</span>
-<span class="w">    </span><span class="s2">&quot;FROM accurics/terrascan:latest as terrascan&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;FROM accurics/terrascan:latest AS terrascan&quot;</span><span class="p">,</span>
 <span class="w">    </span><span class="s2">&quot;COPY --from=terrascan /go/bin/terrascan /usr/bin/&quot;</span><span class="p">,</span>
 <span class="w">    </span><span class="s2">&quot;RUN terrascan init&quot;</span>
 <span class="p">]</span>

--- a/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json
@@ -1048,7 +1048,7 @@
             "examples": [
               {
                 "dockerfile": [
-                  "FROM accurics/terrascan:latest as terrascan",
+                  "FROM accurics/terrascan:latest AS terrascan",
                   "COPY --from=terrascan /go/bin/terrascan /usr/bin/",
                   "RUN terrascan init"
                 ]
@@ -1102,7 +1102,7 @@
                 "description": "Will be automatically integrated in generated Dockerfile",
                 "examples": [
                   [
-                    "FROM accurics/terrascan:latest as terrascan",
+                    "FROM accurics/terrascan:latest AS terrascan",
                     "COPY --from=terrascan /go/bin/terrascan /usr/bin/",
                     "RUN terrascan init"
                   ]

--- a/server/Dockerfile-dev
+++ b/server/Dockerfile-dev
@@ -1,5 +1,5 @@
-FROM hadolint/hadolint:v2.14.0-alpine as hadolint
-FROM trufflesecurity/trufflehog:latest as trufflehog
+FROM hadolint/hadolint:v2.14.0-alpine AS hadolint
+FROM trufflesecurity/trufflehog:latest AS trufflehog
 
 ##################
 # Build wheel for megalinter python package


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

## Fixes

I saw some `FromAsCasing` warnings in the logs

The warnings stem from using 'FROM ... as ' and not 'FROM ... AS ' in Dockerfiles.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Replace 'FROM ... as '  with 'FROM ... AS ' througout the project

## Readiness Checklist

### Author/Contributor

- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
  - This change is too small to warrant a changelog entry.
- [x] If documentation is needed for this change, has that been included in this pull request
  - Not applicable for this change.

### Reviewing Maintainer

- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
