### PR TITLE
(automation) scan DEV image tar directly in Trivy

### DIFF
--- a/.github/workflows/deploy-DEV.yml
+++ b/.github/workflows/deploy-DEV.yml
@@ -384,11 +384,6 @@ jobs:
       security-events: write
     timeout-minutes: 30
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          persist-credentials: false
-
       - name: Free Disk space
         shell: bash
         run: |
@@ -405,20 +400,12 @@ jobs:
           name: megalinter-image
           path: /tmp
 
-      - name: Load Docker image
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker load -i /tmp/megalinter-image.tar
-          rm -f /tmp/megalinter-image.tar
-          docker image ls
-
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           # renovate: datasource=github-releases depName=aquasecurity/trivy
           version: "v0.71.0"
-          image-ref: "${{ needs.build.outputs.image-tag }}"
+          input: /tmp/megalinter-image.tar
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

## Fixes

Fixes a `no space left on device` failure in the `Build & Deploy - DEV` workflow, for example:

```text
2026-06-15T23:51:18Z	FATAL	Fatal error	run error: 
  image scan error: scan error: scan failed: failed analysis: analyze error: pipeline error: 
  failed to analyze layer (sha256:40e063a0ff62e03b7accfdf883dc91bb2bc0f93cf687a70ff8db19d6cec9e4da): 
  unable to get uncompressed layer sha256:40e063a0ff62e03b7accfdf883dc91bb2bc0f93cf687a70ff8db19d6cec9e4da: 
  failed to get the layer (sha256:40e063a0ff62e03b7accfdf883dc91bb2bc0f93cf687a70ff8db19d6cec9e4da):
  unable to populate: unable to open: 
  failed to copy the image: 
  write /tmp/trivy-2645/docker-export-1773176353: no space left on device
Error: Process completed with exit code 1.
```

Reference run:
[runs/27580168103/job/81541450897?pr=8090](https://github.com/oxsecurity/megalinter/actions/runs/27580168103/job/81541450897?pr=8090)

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. In the `trivy` job of `deploy-DEV.yml`, scan the downloaded image tar directly instead of loading it into Docker first.
2. This removes an extra image copy in the scan job and lowers peak disk usage.
3. The change is intentionally limited to the DEV workflow, where the image already arrives as a tar artifact.

## Readiness Checklist

### Author/Contributor

- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
  - This change is too small to warrant a changelog entry.
- [x] If documentation is needed for this change, has that been included in this pull request
  - Not applicable for this change.

### Reviewing Maintainer

- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
