### PR TITLE
fix: Explain why linters are skipped by activation rules (#8017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Core
   - New linter descriptor property `common_linter_errors`: declare known non-lint failure patterns (config issue, remote service down, missing credentials…) and the guidance message shown to users, directly in YAML — no custom Python class needed.
+  - Skipped-linters summary now explains why a linter was skipped by an activation rule, including the variable to set to activate it (e.g. `MARKDOWN_RUMDL: MARKDOWN_DEFAULT_STYLE=markdownlint (set MARKDOWN_DEFAULT_STYLE=rumdl to activate)`), fixing [#8017](https://github.com/oxsecurity/megalinter/issues/8017).
 
 - New linters
 

--- a/megalinter/Linter.py
+++ b/megalinter/Linter.py
@@ -72,6 +72,7 @@ class Linter:
         self.test_format_fix_file_extensions = []
         self.test_format_fix_regex_exclude = None
         self.activation_rules = []
+        self.activation_skip_reason = None
         self.test_variables = {}
         # Array of strings defining file extensions. Ex: ['.js','.cjs', '']
         self.file_extensions = []
@@ -451,7 +452,9 @@ class Linter:
             strategies["VALIDATE"] = True
         # check activation rules
         if self.is_active is True and len(self.activation_rules) > 0:
-            self.is_active = utils.check_activation_rules(self.activation_rules, self)
+            self.is_active, self.activation_skip_reason = utils.check_activation_rules(
+                self.activation_rules, self
+            )
 
         strategiesUsed = format(
             ", ".join("{0}".format(k) for k, v in strategies.items() if v)

--- a/megalinter/MegaLinter.py
+++ b/megalinter/MegaLinter.py
@@ -689,6 +689,7 @@ class Megalinter:
             all_linters = linter_factory.list_all_linters(linter_init_params)
 
         skipped_linters = []
+        activation_skip_reasons = {}
         # Remove inactive, disabled or skipped linters
         skip_cli_lint_modes = config.get_list(
             self.request_id, "SKIP_CLI_LINT_MODES", []
@@ -707,6 +708,8 @@ class Megalinter:
                 or linter.cli_lint_mode in skip_cli_lint_modes
             ):
                 skipped_linters += [linter.name]
+                if linter.activation_skip_reason is not None:
+                    activation_skip_reasons[linter.name] = linter.activation_skip_reason
                 if linter.disabled is True:
                     disabled_reason = (
                         linter.disabled_reason
@@ -731,6 +734,15 @@ class Megalinter:
         if len(skipped_linters) > 0 and show_skipped_linters:
             skipped_linters.sort()
             logging.info("Skipped linters: " + ", ".join(skipped_linters))
+            if len(activation_skip_reasons) > 0:
+                reasons_lines = "\n".join(
+                    f"- {name}: {activation_skip_reasons[name]}"
+                    for name in sorted(activation_skip_reasons.keys())
+                )
+                logging.info(
+                    "Some linters were skipped due to activation rules:\n"
+                    + reasons_lines
+                )
         # Sort linters by language and linter_name
         self.linters = sorted(
             self.linters, key=lambda lamb: (lamb.processing_order, lamb.descriptor_id)

--- a/megalinter/utils.py
+++ b/megalinter/utils.py
@@ -292,6 +292,7 @@ def list_active_reporters_for_scope(scope, reporter_init_params):
 
 def check_activation_rules(activation_rules, linter):
     active = False
+    reason = None
     for rule in activation_rules:
         if rule["type"] == "variable":
             value = config.get(
@@ -301,8 +302,12 @@ def check_activation_rules(activation_rules, linter):
                 active = True
             else:
                 active = False
+                reason = (
+                    f"{rule['variable']}={value} "
+                    f"(set {rule['variable']}={rule['expected_value']} to activate)"
+                )
                 break
-    return active
+    return active, reason
 
 
 def file_contains(file_name: str, regex_object: Optional[Pattern[str]]) -> bool:


### PR DESCRIPTION
The skipped linters summary now provides detailed reasons when a linter is inactive due to its activation rules not being met. This includes the variable and expected value required to activate the linter, improving user understanding and troubleshooting.

Fixes https://github.com/oxsecurity/megalinter/issues/8017