### PR TITLE
fix: Treat osv-scanner exit code 128 as success when no package sources found (#7917)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Linters enhancements
 
 - Fixes
+  - `REPOSITORY_OSV_SCANNER`: exit code 128 ("No package sources found") is now treated as a clean pass instead of a failure — osv-scanner returns this code when the repo contains no lockfiles/manifests/SBOMs, which is not a vulnerability finding (#7917).
   - Fix intermittent `ansible-lint` `load-failure[not-found]` error on `github_conf/branch_protection_rules.json` caused by a race condition with `checkov` running in parallel. Checkov's transient GitHub-conf directory is now written to a hidden path (`.megalinter_github_conf`) that project-mode linters skip, eliminating the conflict (#8092).
   - Complete the Alpine 3.24 upgrade across the whole image and fix how alpine version is detected.
   - Exclude `REPORT_OUTPUT_FOLDER` from linting when configured as an absolute path inside the workspace (e.g. `/tmp/lint/megalinter-reports`), fixing #7845.

--- a/megalinter/descriptors/repository.megalinter-descriptor.yml
+++ b/megalinter/descriptors/repository.megalinter-descriptor.yml
@@ -626,7 +626,8 @@ linters:
         - linux/arm64
 
   # OSV-SCANNER
-  - linter_name: osv-scanner
+  - class: OsvScannerLinter
+    linter_name: osv-scanner
     name: REPOSITORY_OSV_SCANNER
     can_output_sarif: false # disabled until it works !
     descriptor_flavors:
@@ -680,7 +681,7 @@ linters:
                 DISABLE_ERRORS_LINTERS:
                   - REPOSITORY_OSV_SCANNER
       - identifier: REPOSITORY_OSV_SCANNER_ERROR_NO_PACKAGE_SOURCES
-        regex: "no package sources found"
+        regex: "(?i)no package sources found"
         message: |-
           osv-scanner found no lockfiles, manifests, or SBOMs to scan in the repository.
           This is a configuration/scope issue, not a vulnerability finding.

--- a/megalinter/linters/OsvScannerLinter.py
+++ b/megalinter/linters/OsvScannerLinter.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""
+Use OsvScanner to check for dependency vulnerabilities.
+Treat exit code 128 ("No package sources found") as a clean pass —
+osv-scanner upstream declined to add a --no-fail-if-no-package flag
+(https://github.com/google/osv-scanner/issues/348), so we handle it here.
+"""
+
+import logging
+
+from megalinter import Linter
+
+
+class OsvScannerLinter(Linter):
+
+    def execute_lint_command(self, command):
+        return_code, return_output = super().execute_lint_command(command)
+        if return_code == 128 and "no package sources found" in return_output.lower():
+            logging.info(
+                "[osv-scanner] No package sources found (exit 128) — "
+                "treating as success (nothing to scan)"
+            )
+            return 0, return_output
+        return return_code, return_output


### PR DESCRIPTION
osv-scanner returns exit code 128 when no lockfiles, manifests, or SBOMs are present in the repository. This indicates a configuration/scope issue, not a vulnerability finding.

As the upstream project declined to add a `--no-fail-if-no-package` flag, MegaLinter now explicitly handles this exit code for `REPOSITORY_OSV_SCANNER`, converting it to a successful pass to prevent false failures.

Fixes https://github.com/oxsecurity/megalinter/issues/7917
