### PR TITLE
fix(py314): avoid deprecated positional re.sub count and flags

### DIFF
--- a/.automation/build.py
+++ b/.automation/build.py
@@ -2564,7 +2564,7 @@ def replace_in_file(file_path, start, end, content, add_new_line=True):
         # Get text between markdown-headers tag
         header_content = header_matches[0]
         content = re.sub(
-            r"<!-- markdown-headers\n.*?\n-->", "", content, 1, re.MULTILINE | re.DOTALL
+            r"<!-- markdown-headers\n.*?\n-->", "", content, count=1, flags=re.MULTILINE | re.DOTALL
         )[1:]
     # Replace the target string
     if add_new_line is True:
@@ -2572,7 +2572,7 @@ def replace_in_file(file_path, start, end, content, add_new_line=True):
     else:
         replacement = f"{start}{content}{end}"
     regex = rf"{start}([\s\S]*?){end}"
-    file_content = re.sub(regex, replacement, file_content, 1, re.DOTALL)
+    file_content = re.sub(regex, replacement, file_content, count=1, flags=re.DOTALL)
     # Add / replace header if necessary
     if header_content is not None:
         existing_header_matches = re.findall(
@@ -2587,8 +2587,8 @@ def replace_in_file(file_path, start, end, content, add_new_line=True):
                 r"---\n.*?\n---",
                 header_content,
                 file_content,
-                1,
-                re.MULTILINE | re.DOTALL,
+                count=1,
+                flags=re.MULTILINE | re.DOTALL,
             )
         else:
             file_content = header_content + "\n" + file_content
@@ -2975,7 +2975,7 @@ def move_to_file(file_path, start, end, target_file, keep_in_source=False):
     else:
         bracket_content = ""
     if keep_in_source is False:
-        file_content = re.sub(regex, replacement, file_content, 1, re.DOTALL)
+        file_content = re.sub(regex, replacement, file_content, count=1, flags=re.DOTALL)
     # Write the file out again
     Path(file_path).write_text(file_content, encoding="utf-8")
     logging.info("Updated " + file_path + " between " + start + " and " + end)

--- a/megalinter/utilstest.py
+++ b/megalinter/utilstest.py
@@ -414,7 +414,7 @@ def test_get_linter_version(linter, test_self):
                 )
                 versions_block = f"{start}{versions_text}{end}"
                 changelog_content = re.sub(
-                    regex, versions_block, changelog_content, re.DOTALL
+                    regex, versions_block, changelog_content, flags=re.DOTALL
                 )
                 with open(changelog_file, "w", encoding="utf-8") as md_file:
                     md_file.write(changelog_content)


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes:

During 'make megalinter-build' on Python 3.14.4 this warning popped up early:

- `'count' is passed as positional argument`

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Use named arguments for `count` and `flag` in calls to `re.sub()`

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
