### PR TITLE
fix(runtime): preserve entrypoint args after user switch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -478,6 +478,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 icu-libs \
                 openjdk21 \
                 lua5.3 \

--- a/flavors/c_cpp/Dockerfile
+++ b/flavors/c_cpp/Dockerfile
@@ -256,6 +256,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
                 py3-pyflakes \
                 cppcheck \

--- a/flavors/ci_light/Dockerfile
+++ b/flavors/ci_light/Dockerfile
@@ -165,6 +165,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk17 \
                 libxml2-dev \
                 libxml2-utils \

--- a/flavors/cupcake/Dockerfile
+++ b/flavors/cupcake/Dockerfile
@@ -380,6 +380,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
                 gnupg \
                 php84 \

--- a/flavors/documentation/Dockerfile
+++ b/flavors/documentation/Dockerfile
@@ -254,6 +254,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
                 py3-pyflakes \
                 openjdk17 \

--- a/flavors/dotnet/Dockerfile
+++ b/flavors/dotnet/Dockerfile
@@ -282,6 +282,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 icu-libs \
                 openjdk21 \
                 py3-pyflakes \

--- a/flavors/dotnetweb/Dockerfile
+++ b/flavors/dotnetweb/Dockerfile
@@ -318,6 +318,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 icu-libs \
                 openjdk21 \
                 py3-pyflakes \

--- a/flavors/formatters/Dockerfile
+++ b/flavors/formatters/Dockerfile
@@ -138,6 +138,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 icu-libs \
                 npm \
                 nodejs-current \

--- a/flavors/go/Dockerfile
+++ b/flavors/go/Dockerfile
@@ -270,6 +270,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
                 py3-pyflakes \
                 openjdk17 \

--- a/flavors/java/Dockerfile
+++ b/flavors/java/Dockerfile
@@ -266,6 +266,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
                 py3-pyflakes \
                 openjdk17 \

--- a/flavors/javascript/Dockerfile
+++ b/flavors/javascript/Dockerfile
@@ -294,6 +294,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
                 py3-pyflakes \
                 openjdk17 \

--- a/flavors/php/Dockerfile
+++ b/flavors/php/Dockerfile
@@ -268,6 +268,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
                 gnupg \
                 php84 \

--- a/flavors/python/Dockerfile
+++ b/flavors/python/Dockerfile
@@ -286,6 +286,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
                 py3-pyflakes \
                 cppcheck \

--- a/flavors/ruby/Dockerfile
+++ b/flavors/ruby/Dockerfile
@@ -266,6 +266,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
                 py3-pyflakes \
                 openjdk17 \

--- a/flavors/rust/Dockerfile
+++ b/flavors/rust/Dockerfile
@@ -256,6 +256,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
                 py3-pyflakes \
                 openjdk17 \

--- a/flavors/salesforce/Dockerfile
+++ b/flavors/salesforce/Dockerfile
@@ -266,6 +266,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
                 coreutils \
                 py3-pyflakes \

--- a/flavors/security/Dockerfile
+++ b/flavors/security/Dockerfile
@@ -188,6 +188,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 helm \
                 npm \
                 nodejs-current \

--- a/flavors/swift/Dockerfile
+++ b/flavors/swift/Dockerfile
@@ -256,6 +256,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
                 py3-pyflakes \
                 openjdk17 \

--- a/flavors/terraform/Dockerfile
+++ b/flavors/terraform/Dockerfile
@@ -268,6 +268,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
                 py3-pyflakes \
                 openjdk17 \

--- a/linters/action_actionlint/Dockerfile
+++ b/linters/action_actionlint/Dockerfile
@@ -88,6 +88,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 py3-pyflakes \
     && git config --global core.autocrlf true
 #APK__END

--- a/linters/action_zizmor/Dockerfile
+++ b/linters/action_zizmor/Dockerfile
@@ -89,6 +89,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/ansible_ansible_lint/Dockerfile
+++ b/linters/ansible_ansible_lint/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/arm_arm_ttk/Dockerfile
+++ b/linters/arm_arm_ttk/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 icu-libs \
     && git config --global core.autocrlf true
 #APK__END

--- a/linters/bash_exec/Dockerfile
+++ b/linters/bash_exec/Dockerfile
@@ -80,6 +80,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/bash_shellcheck/Dockerfile
+++ b/linters/bash_shellcheck/Dockerfile
@@ -92,6 +92,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/bash_shfmt/Dockerfile
+++ b/linters/bash_shfmt/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/bicep_bicep_linter/Dockerfile
+++ b/linters/bicep_bicep_linter/Dockerfile
@@ -84,6 +84,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 icu-libs \
     && git config --global core.autocrlf true
 #APK__END

--- a/linters/c_clang_format/Dockerfile
+++ b/linters/c_clang_format/Dockerfile
@@ -80,6 +80,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 cmd:clang-format \
     && git config --global core.autocrlf true
 #APK__END

--- a/linters/c_cppcheck/Dockerfile
+++ b/linters/c_cppcheck/Dockerfile
@@ -80,6 +80,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 cppcheck \
     && git config --global core.autocrlf true
 #APK__END

--- a/linters/c_cpplint/Dockerfile
+++ b/linters/c_cpplint/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/clojure_clj_kondo/Dockerfile
+++ b/linters/clojure_clj_kondo/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/clojure_cljstyle/Dockerfile
+++ b/linters/clojure_cljstyle/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/cloudformation_cfn_lint/Dockerfile
+++ b/linters/cloudformation_cfn_lint/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/coffee_coffeelint/Dockerfile
+++ b/linters/coffee_coffeelint/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/copypaste_jscpd/Dockerfile
+++ b/linters/copypaste_jscpd/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/cpp_clang_format/Dockerfile
+++ b/linters/cpp_clang_format/Dockerfile
@@ -80,6 +80,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 cmd:clang-format \
     && git config --global core.autocrlf true
 #APK__END

--- a/linters/cpp_cppcheck/Dockerfile
+++ b/linters/cpp_cppcheck/Dockerfile
@@ -80,6 +80,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 cppcheck \
     && git config --global core.autocrlf true
 #APK__END

--- a/linters/cpp_cpplint/Dockerfile
+++ b/linters/cpp_cpplint/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/csharp_csharpier/Dockerfile
+++ b/linters/csharp_csharpier/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/csharp_dotnet_format/Dockerfile
+++ b/linters/csharp_dotnet_format/Dockerfile
@@ -80,6 +80,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/csharp_roslynator/Dockerfile
+++ b/linters/csharp_roslynator/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/css_stylelint/Dockerfile
+++ b/linters/css_stylelint/Dockerfile
@@ -94,6 +94,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/dart_dartanalyzer/Dockerfile
+++ b/linters/dart_dartanalyzer/Dockerfile
@@ -84,6 +84,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/dockerfile_hadolint/Dockerfile
+++ b/linters/dockerfile_hadolint/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/editorconfig_editorconfig_checker/Dockerfile
+++ b/linters/editorconfig_editorconfig_checker/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/env_dotenv_linter/Dockerfile
+++ b/linters/env_dotenv_linter/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/gherkin_gherkin_lint/Dockerfile
+++ b/linters/gherkin_gherkin_lint/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/go_golangci_lint/Dockerfile
+++ b/linters/go_golangci_lint/Dockerfile
@@ -84,6 +84,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/go_revive/Dockerfile
+++ b/linters/go_revive/Dockerfile
@@ -93,6 +93,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/graphql_graphql_schema_linter/Dockerfile
+++ b/linters/graphql_graphql_schema_linter/Dockerfile
@@ -84,6 +84,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/groovy_npm_groovy_lint/Dockerfile
+++ b/linters/groovy_npm_groovy_lint/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk17 \
                 npm \
                 nodejs-current \

--- a/linters/html_djlint/Dockerfile
+++ b/linters/html_djlint/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/html_htmlhint/Dockerfile
+++ b/linters/html_htmlhint/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/java_checkstyle/Dockerfile
+++ b/linters/java_checkstyle/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
     && git config --global core.autocrlf true
 #APK__END

--- a/linters/java_pmd/Dockerfile
+++ b/linters/java_pmd/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
     && git config --global core.autocrlf true
 #APK__END

--- a/linters/javascript_es/Dockerfile
+++ b/linters/javascript_es/Dockerfile
@@ -100,6 +100,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/javascript_prettier/Dockerfile
+++ b/linters/javascript_prettier/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/javascript_standard/Dockerfile
+++ b/linters/javascript_standard/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/json_jsonlint/Dockerfile
+++ b/linters/json_jsonlint/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/json_npm_package_json_lint/Dockerfile
+++ b/linters/json_npm_package_json_lint/Dockerfile
@@ -84,6 +84,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/json_prettier/Dockerfile
+++ b/linters/json_prettier/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/json_v8r/Dockerfile
+++ b/linters/json_v8r/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/jsx_eslint/Dockerfile
+++ b/linters/jsx_eslint/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/kotlin_detekt/Dockerfile
+++ b/linters/kotlin_detekt/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
     && git config --global core.autocrlf true
 #APK__END

--- a/linters/kotlin_ktlint/Dockerfile
+++ b/linters/kotlin_ktlint/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
     && git config --global core.autocrlf true
 #APK__END

--- a/linters/kubernetes_helm/Dockerfile
+++ b/linters/kubernetes_helm/Dockerfile
@@ -80,6 +80,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 helm \
     && git config --global core.autocrlf true
 #APK__END

--- a/linters/kubernetes_kubeconform/Dockerfile
+++ b/linters/kubernetes_kubeconform/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/kubernetes_kubescape/Dockerfile
+++ b/linters/kubernetes_kubescape/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/latex_chktex/Dockerfile
+++ b/linters/latex_chktex/Dockerfile
@@ -80,6 +80,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/lua_luacheck/Dockerfile
+++ b/linters/lua_luacheck/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 lua5.3 \
                 lua5.3-dev \
                 readline-dev \

--- a/linters/lua_stylua/Dockerfile
+++ b/linters/lua_stylua/Dockerfile
@@ -98,6 +98,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 lua5.3 \
                 lua5.3-dev \
                 readline-dev \

--- a/linters/markdown_markdown_table_formatter/Dockerfile
+++ b/linters/markdown_markdown_table_formatter/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/markdown_markdownlint/Dockerfile
+++ b/linters/markdown_markdownlint/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/markdown_rumdl/Dockerfile
+++ b/linters/markdown_rumdl/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/perl_perlcritic/Dockerfile
+++ b/linters/perl_perlcritic/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 perl \
                 perl-dev \
     && git config --global core.autocrlf true

--- a/linters/php_phpcs/Dockerfile
+++ b/linters/php_phpcs/Dockerfile
@@ -84,6 +84,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 gnupg \
                 php84 \
                 php84-phar \

--- a/linters/php_phpcsfixer/Dockerfile
+++ b/linters/php_phpcsfixer/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 gnupg \
                 php84 \
                 php84-phar \

--- a/linters/php_phplint/Dockerfile
+++ b/linters/php_phplint/Dockerfile
@@ -84,6 +84,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 gnupg \
                 php84 \
                 php84-phar \

--- a/linters/php_phpstan/Dockerfile
+++ b/linters/php_phpstan/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 gnupg \
                 php84 \
                 php84-phar \

--- a/linters/php_psalm/Dockerfile
+++ b/linters/php_psalm/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 gnupg \
                 php84 \
                 php84-phar \

--- a/linters/powershell_powershell/Dockerfile
+++ b/linters/powershell_powershell/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 icu-libs \
     && git config --global core.autocrlf true
 #APK__END

--- a/linters/powershell_powershell_formatter/Dockerfile
+++ b/linters/powershell_powershell_formatter/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 icu-libs \
     && git config --global core.autocrlf true
 #APK__END

--- a/linters/protobuf_protolint/Dockerfile
+++ b/linters/protobuf_protolint/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/python_bandit/Dockerfile
+++ b/linters/python_bandit/Dockerfile
@@ -88,6 +88,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/python_black/Dockerfile
+++ b/linters/python_black/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/python_flake8/Dockerfile
+++ b/linters/python_flake8/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/python_isort/Dockerfile
+++ b/linters/python_isort/Dockerfile
@@ -88,6 +88,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/python_mypy/Dockerfile
+++ b/linters/python_mypy/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/python_nbqa_mypy/Dockerfile
+++ b/linters/python_nbqa_mypy/Dockerfile
@@ -88,6 +88,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/python_pylint/Dockerfile
+++ b/linters/python_pylint/Dockerfile
@@ -88,6 +88,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/python_pyright/Dockerfile
+++ b/linters/python_pyright/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/python_ruff/Dockerfile
+++ b/linters/python_ruff/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/python_ruff_format/Dockerfile
+++ b/linters/python_ruff_format/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/r_lintr/Dockerfile
+++ b/linters/r_lintr/Dockerfile
@@ -80,6 +80,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 g++ \
                 libcurl \
                 libgcc \

--- a/linters/raku_raku/Dockerfile
+++ b/linters/raku_raku/Dockerfile
@@ -84,6 +84,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/repository_betterleaks/Dockerfile
+++ b/linters/repository_betterleaks/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/repository_checkov/Dockerfile
+++ b/linters/repository_checkov/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/repository_devskim/Dockerfile
+++ b/linters/repository_devskim/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/repository_dustilock/Dockerfile
+++ b/linters/repository_dustilock/Dockerfile
@@ -88,6 +88,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/repository_git_diff/Dockerfile
+++ b/linters/repository_git_diff/Dockerfile
@@ -80,6 +80,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/repository_gitleaks/Dockerfile
+++ b/linters/repository_gitleaks/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/repository_grype/Dockerfile
+++ b/linters/repository_grype/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/repository_kingfisher/Dockerfile
+++ b/linters/repository_kingfisher/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/repository_ls_lint/Dockerfile
+++ b/linters/repository_ls_lint/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/repository_osv_scanner/Dockerfile
+++ b/linters/repository_osv_scanner/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/repository_secretlint/Dockerfile
+++ b/linters/repository_secretlint/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/repository_semgrep/Dockerfile
+++ b/linters/repository_semgrep/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/repository_syft/Dockerfile
+++ b/linters/repository_syft/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/repository_trivy/Dockerfile
+++ b/linters/repository_trivy/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/repository_trivy_sbom/Dockerfile
+++ b/linters/repository_trivy_sbom/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/repository_trufflehog/Dockerfile
+++ b/linters/repository_trufflehog/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/robotframework_robocop/Dockerfile
+++ b/linters/robotframework_robocop/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/rst_rst_lint/Dockerfile
+++ b/linters/rst_rst_lint/Dockerfile
@@ -88,6 +88,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/rst_rstcheck/Dockerfile
+++ b/linters/rst_rstcheck/Dockerfile
@@ -88,6 +88,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/rst_rstfmt/Dockerfile
+++ b/linters/rst_rstfmt/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/ruby_rubocop/Dockerfile
+++ b/linters/ruby_rubocop/Dockerfile
@@ -92,6 +92,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 ruby \
                 ruby-dev \
                 ruby-bundler \

--- a/linters/rust_clippy/Dockerfile
+++ b/linters/rust_clippy/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/salesforce_code_analyzer_apex/Dockerfile
+++ b/linters/salesforce_code_analyzer_apex/Dockerfile
@@ -88,6 +88,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 coreutils \
                 openjdk21 \
                 npm \

--- a/linters/salesforce_code_analyzer_aura/Dockerfile
+++ b/linters/salesforce_code_analyzer_aura/Dockerfile
@@ -88,6 +88,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 coreutils \
                 openjdk21 \
                 npm \

--- a/linters/salesforce_code_analyzer_lwc/Dockerfile
+++ b/linters/salesforce_code_analyzer_lwc/Dockerfile
@@ -88,6 +88,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 coreutils \
                 openjdk21 \
                 npm \

--- a/linters/scala_scalafix/Dockerfile
+++ b/linters/scala_scalafix/Dockerfile
@@ -84,6 +84,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 openjdk21 \
     && git config --global core.autocrlf true
 #APK__END

--- a/linters/snakemake_lint/Dockerfile
+++ b/linters/snakemake_lint/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/snakemake_snakefmt/Dockerfile
+++ b/linters/snakemake_snakefmt/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/spell_codespell/Dockerfile
+++ b/linters/spell_codespell/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/spell_cspell/Dockerfile
+++ b/linters/spell_cspell/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/spell_lychee/Dockerfile
+++ b/linters/spell_lychee/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/spell_proselint/Dockerfile
+++ b/linters/spell_proselint/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/spell_vale/Dockerfile
+++ b/linters/spell_vale/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/sql_sqlfluff/Dockerfile
+++ b/linters/sql_sqlfluff/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/sql_tsqllint/Dockerfile
+++ b/linters/sql_tsqllint/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/swift_swiftlint/Dockerfile
+++ b/linters/swift_swiftlint/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 unzip \
     && git config --global core.autocrlf true
 #APK__END

--- a/linters/tekton_tekton_lint/Dockerfile
+++ b/linters/tekton_tekton_lint/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/terraform_terraform_fmt/Dockerfile
+++ b/linters/terraform_terraform_fmt/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/terraform_terragrunt/Dockerfile
+++ b/linters/terraform_terragrunt/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/terraform_terrascan/Dockerfile
+++ b/linters/terraform_terrascan/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/terraform_tflint/Dockerfile
+++ b/linters/terraform_tflint/Dockerfile
@@ -83,6 +83,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/tsx_eslint/Dockerfile
+++ b/linters/tsx_eslint/Dockerfile
@@ -102,6 +102,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/typescript_es/Dockerfile
+++ b/linters/typescript_es/Dockerfile
@@ -108,6 +108,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/typescript_prettier/Dockerfile
+++ b/linters/typescript_prettier/Dockerfile
@@ -84,6 +84,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/typescript_standard/Dockerfile
+++ b/linters/typescript_standard/Dockerfile
@@ -84,6 +84,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/vbdotnet_dotnet_format/Dockerfile
+++ b/linters/vbdotnet_dotnet_format/Dockerfile
@@ -80,6 +80,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/linters/xml_xmllint/Dockerfile
+++ b/linters/xml_xmllint/Dockerfile
@@ -80,6 +80,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 libxml2-dev \
                 libxml2-utils \
                 libgcc \

--- a/linters/yaml_prettier/Dockerfile
+++ b/linters/yaml_prettier/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/yaml_v8r/Dockerfile
+++ b/linters/yaml_v8r/Dockerfile
@@ -82,6 +82,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
                 npm \
                 nodejs-current \
                 yarn \

--- a/linters/yaml_yamllint/Dockerfile
+++ b/linters/yaml_yamllint/Dockerfile
@@ -86,6 +86,7 @@ RUN apk -U --no-cache upgrade \
                 make \
                 musl-dev \
                 openssh \
+                su-exec \
     && git config --global core.autocrlf true
 #APK__END
 

--- a/megalinter/constants.py
+++ b/megalinter/constants.py
@@ -49,6 +49,8 @@ DEFAULT_DOCKERFILE_APK_PACKAGES = [
     "make",
     "musl-dev",
     "openssh",
+    # su-exec for user switch in entrypoint
+    "su-exec",
 ]
 
 DEFAULT_DOCKERFILE_NPM_ARGS: list[str] = []

--- a/sh/setup-runtime-user.sh
+++ b/sh/setup-runtime-user.sh
@@ -58,4 +58,4 @@ export HOME="${MEGALINTER_RUNTIME_HOME}"
 export USER="${MEGALINTER_RUNTIME_USER}"
 export MEGALINTER_USER_SWITCHED=true
 
-exec su -p "${MEGALINTER_RUNTIME_USER}" -s /bin/bash -c 'exec /entrypoint.sh "$@"' bash "$@"
+exec su-exec "${MEGALINTER_RUNTIME_UID}:${MEGALINTER_RUNTIME_GID}" /entrypoint.sh "$@"


### PR DESCRIPTION
fix(runtime): preserve entrypoint args after user switch

- install su-exec in the image
- use it in setup-runtime-user instead of su
- keep extra entrypoint arguments intact in the non-root startup path
- remove unused args in action.yml (arguments to entrypoint.sh)

Why:

The extra args in `action.yml` (from 2021) were passed as arguments to the `entrypoint.sh`.
They were always ignored but now caused an error with the previous `su` command for the user-switch.
With the new user-switch with `su-exec` such arguments to entrypoint.sh would be properly handled.

Alternative:

Without su-exec this would also work:
`exec su -p -s /bin/sh "${MEGALINTER_RUNTIME_USER}" -c 'exec /entrypoint.sh "$@"' -- "$@"`
But su-exec is tiny (≈20 kB) and is the dedicated tool for user switching on Alpine.

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
