### PR TITLE
chore(renovate): pin js-yaml below v5 (ESM-only breaks runner)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -35,6 +35,16 @@
   ],
   packageRules: [
     {
+      // js-yaml v5+ is ESM-only (dropped CommonJS). yeoman-environment loads the
+      // mega-linter-runner custom-flavor generator via require(), which cannot
+      // synchronously require() a pure-ESM js-yaml and fails with
+      // ERR_REQUIRE_ESM_RACE_CONDITION. Keep js-yaml on the v4 line (dual CJS/ESM).
+      matchPackageNames: [
+        'js-yaml',
+      ],
+      allowedVersions: '<5',
+    },
+    {
       matchPackageNames: [
         'uv',
         'astral-sh/uv',


### PR DESCRIPTION
## What

Add a Renovate `packageRule` capping `js-yaml` to `<5`.

## Why

js-yaml v5 dropped CommonJS support and is **pure ESM**. `yeoman-environment` loads the `mega-linter-runner` custom-flavor generator (`generators/mega-linter-custom-flavor/index.js`) via `require()`, which cannot synchronously `require()` a pure-ESM `js-yaml` — it throws `ERR_REQUIRE_ESM_RACE_CONDITION`.

This surfaced in the renovate bump PR #8208 (`js-yaml` 4.1.0 → 5.2.0), which failed the **Test MegaLinter runner** job with 5 failing tests in `custom-flavor-generator.test.js`, all tracing back to that error.

The v4 line ships both CJS and ESM, so capping below v5 keeps the runner working. PR #8208 should be closed.