### PR TITLE
chore: stop Dependabot updating intentional test fixtures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,23 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
 
+  # Skip npm test fixtures: files under .automation/test intentionally ship
+  # outdated / vulnerable dependencies so MegaLinter's own security scanners
+  # (grype, osv-scanner, syft, trivy...) have something to flag. Ignoring every
+  # dependency in these directories stops Dependabot from opening version AND
+  # security update PRs that would defeat the purpose of the fixtures (e.g. the
+  # recurring "bump the npm_and_yarn group across .../repository_*/bad" PRs).
+  # `exclude-paths` is not used here because it does not suppress security
+  # update PRs (see dependabot/dependabot-core#14408); an `ignore` wildcard is
+  # the only lever that also covers security updates.
+  - package-ecosystem: "npm"
+    directories:
+      - "/.automation/test/**"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+
   # Maintain dependencies for ruby with bundler
   - package-ecosystem: "bundler"
     directory: "/"


### PR DESCRIPTION
## Problem

Dependabot keeps opening PRs that upgrade dependencies inside `.automation/test/**` fixtures — for example [#8346](https://github.com/oxsecurity/megalinter/pull/8346) ("bump the npm_and_yarn group across `repository_grype/bad`, `repository_osv_scanner/bad`, `repository_syft`").

Those files **intentionally** ship outdated / vulnerable dependencies so MegaLinter's own security scanners (grype, osv-scanner, syft, trivy, devskim…) have something to detect. Upgrading them:

- defeats the purpose of the fixtures, and
- makes their linter tests (e.g. `repository_osv_scanner_test::test_failure`) go green when they must fail.

## Fix

Add an `npm` update block scoped to `/.automation/test/**` that ignores every dependency:

```yaml
- package-ecosystem: "npm"
  directories:
    - "/.automation/test/**"
  schedule:
    interval: "weekly"
  ignore:
    - dependency-name: "*"
```

### Why `ignore: "*"` and not `exclude-paths`

`exclude-paths` (GA Aug 2025) only suppresses **version** update PRs — it has no effect on **security** update PRs, which is what #8346 is (`dependabot/npm_and_yarn/...` branch, driven by a vulnerability alert). See [dependabot/dependabot-core#14408](https://github.com/dependabot/dependabot-core/issues/14408). An `ignore` wildcard in a directory-scoped block is the documented lever that Dependabot honours for **both** version and security updates.

The glob covers every current npm fixture (grype, osv-scanner, syft, trivy…) and any future ones, so this shouldn't need revisiting per-directory. The existing `/mega-linter-runner` npm block is untouched, so real dependency updates keep flowing there.

If other ecosystems' fixtures (pip, bundler, go…) start generating the same noise, the same `ignore: "*"` pattern can be added for them.