### PR TITLE
Fix flaky config tests: add timeout + retry to remote config fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Fixes
 
+  - Make remote configuration loading resilient to transient network failures by adding a request timeout and bounded retries with backoff when fetching `MEGALINTER_CONFIG` and `EXTENDS` files over HTTP (fixes intermittent `config_test` failures caused by `raw.githubusercontent.com` CDN cache lag)
   - Disable `TERRAFORM_TERRASCAN` (upstream repo archived by Tenable, unmaintained) and `SQL_TSQLLINT` (no upstream release since 2024-09), as both ship unpatched CVEs with no prospect of a fixed release
   - Fix `SARIF_TO_HUMAN` producing empty linter logs when the bundled `sarif-fmt` binary crashes by building it from source on Alpine and falling back to raw SARIF on conversion failure (#8294)
   - Keep the Docker Pulls badge in `docs/index.md` in sync by having `docker_stats.py` also update the hardcoded badge total in `.automation/build.py`

--- a/megalinter/config.py
+++ b/megalinter/config.py
@@ -5,6 +5,7 @@ import os
 import re
 import shlex
 import tempfile
+import time
 
 import requests
 import yaml
@@ -30,6 +31,40 @@ DEFAULT_SECURED_ENV_VARIABLES = (
     "(SFDX_CLIENT_KEY_.*)",
     "(^|_)(SLACK|DISCORD|TEAMS|WEBHOOK)_URL($|_)",
 )
+
+
+# Fetch a remote config file with a request timeout and bounded retries.
+# Remote configs live on raw.githubusercontent.com, whose CDN edge cache can
+# lag behind a fresh push (transient 404) and occasionally returns 5xx; a bare
+# requests.get with no timeout/retry turns any such blip into a hard failure.
+# Retries cover network exceptions and every non-200; the last response is
+# returned so callers keep their own specific status-code error messages.
+def http_get_with_retry(url, headers=None, retries=3, timeout=30, backoff_base=2):
+    last_response = None
+    last_error = None
+    for attempt in range(retries):
+        try:
+            last_response = requests.get(
+                url, allow_redirects=True, headers=headers or {}, timeout=timeout
+            )
+            if last_response.status_code == 200:
+                return last_response
+            last_error = f"HTTP {last_response.status_code}"
+        except requests.RequestException as e:
+            last_response = None
+            last_error = str(e)
+        if attempt < retries - 1:
+            delay = backoff_base**attempt
+            logging.warning(
+                f"[config] Attempt {attempt + 1}/{retries} to fetch {url} failed "
+                f"({last_error}); retrying in {delay}s"
+            )
+            time.sleep(delay)
+    if last_response is not None:
+        return last_response
+    raise RuntimeError(
+        f"Unable to retrieve {url} after {retries} attempts: {last_error}"
+    )
 
 
 def init_config(request_id, workspace=None, params=None):
@@ -71,7 +106,7 @@ def init_config(request_id, workspace=None, params=None):
                 + os.path.sep
                 + config_file_name.rsplit("/", 1)[-1]
             )
-            r = requests.get(config_file_name, allow_redirects=True)
+            r = http_get_with_retry(config_file_name)
             if r.status_code != 200:
                 raise RuntimeError(f"Unable to retrieve config file {config_file_name}")
             with open(config_file, "wb") as f:
@@ -144,7 +179,7 @@ def combine_config(workspace, config, combined_config, config_source):
             ):
                 github_token = os.environ["GITHUB_TOKEN"]
                 headers["Authorization"] = f"token {github_token}"
-            r = requests.get(extends_item, allow_redirects=True, headers=headers)
+            r = http_get_with_retry(extends_item, headers=headers)
             assert (
                 r.status_code == 200
             ), f"Unable to retrieve EXTENDS config file {extends_item}"


### PR DESCRIPTION
## Problem

The CI test suite intermittently fails on `config_test::test_remote_config_success`, `test_remote_config_extends_success`, `test_remote_config_extends_success_2`, etc. These tests fetch a config from `raw.githubusercontent.com` (by branch name) and depend on the network.

Root cause: in `megalinter/config.py`, both remote fetches used a bare `requests.get(...)` with **no timeout and no retry**:

- `MEGALINTER_CONFIG` remote fetch (was line ~74)
- `EXTENDS` remote fetch (was line ~147)

So a hung connection blocks indefinitely, and a single transient blip — DNS hiccup, GitHub 5xx, or a `raw.githubusercontent.com` CDN edge cache that hasn't caught up to a fresh push yet (common right after a bot rebase/push, when the "Run Test Cases" job starts soon after the build) — is a hard failure. Because all these tests hit the same host, they fail together as a block, which matches the observed pattern.

## Fix

Add an `http_get_with_retry` helper (30s timeout, 3 attempts, exponential backoff) and use it at both fetch sites. It retries on network exceptions and on any non-200 (including transient CDN-lag 404s), and returns the last response so each caller keeps its own specific error message — preserving the `test_remote_config_error` / `test_remote_config_extends_error` assertions.

This is a genuine production robustness improvement for anyone using remote/`EXTENDS` configs, not just a test fix.

## Verification

Unit-tested the helper's behavior with mocked `requests.get`:

- 200 on first try → single call, returns immediately
- persistent non-200 → 3 attempts, returns last response (caller raises its own error)
- transient 404 then 200 → recovers
- persistent network exception → raises `RuntimeError` naming the URL
- `timeout=30` is passed through

Full flaky-test context: this is one of three independent flaky tests surfaced while investigating a Renovate PR; the other two (`csharp_csharpier::test_format_fix`, `repository_osv_scanner::test_failure`) have separate root causes (dotnet/MSBuild contention and an over-broad exit-code mask, respectively) and are tracked separately.