### PR TITLE
Honor ADDITIONAL_EXCLUDED_DIRECTORIES in changed-files mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Keep the Docker Pulls badge in `docs/index.md` in sync by having `docker_stats.py` also update the hardcoded badge total in `.automation/build.py`
   - Fix outdated links in `docs/descriptors/repository_kingfisher.md`
   - Fix `LINTER_RULES_PATH` not being used to resolve config files for linters using `active_only_if_file_found` (e.g. `REPOSITORY_LS_LINT`, `SPELL_PROSELINT`, `SPELL_VALE`), fixes [#8416](https://github.com/oxsecurity/megalinter/issues/8416)
+  - Honor `EXCLUDED_DIRECTORIES` and `ADDITIONAL_EXCLUDED_DIRECTORIES` in changed-files mode (`VALIDATE_ALL_CODEBASE: false`), so files inside excluded directories are pruned from the `git diff` file list the same way they are during full-codebase validation ([#8360](https://github.com/oxsecurity/megalinter/issues/8360))
 
 - Reporters
 

--- a/megalinter/MegaLinter.py
+++ b/megalinter/MegaLinter.py
@@ -932,13 +932,40 @@ class Megalinter:
             logging.warning("Using fallback without merge-base...")
             diff = repo.git.diff(default_branch_remote, name_only=True)
         logging.info(f"Modified files:\n{diff}")
+        # Prune files located inside excluded directories so that
+        # EXCLUDED_DIRECTORIES / ADDITIONAL_EXCLUDED_DIRECTORIES behave the
+        # same in changed-files mode as in full-codebase mode (see #8360).
+        excluded_directories = self._normalize_excluded_directories(
+            utils.get_excluded_directories(self.request_id)
+        )
         all_files = list()
         for diff_line in diff.splitlines():
+            if self._is_in_excluded_directory(diff_line, excluded_directories):
+                continue
             if os.path.isfile(
                 self.workspace + os.path.sep + diff_line
             ) and not os.path.islink(self.workspace + os.path.sep + diff_line):
                 all_files += [diff_line]
         return all_files
+
+    def _is_excluded_dir(self, rel_dir_path, excluded_directories):
+        # Single source of truth for directory-exclusion matching, shared by
+        # full-codebase (os.walk) and changed-files (git diff) modes: a
+        # directory matches by its basename at any nesting level, or by its
+        # workspace-relative path.
+        rel_dir_path = rel_dir_path.replace("\\", "/")
+        basename = rel_dir_path.rsplit("/", 1)[-1]
+        return basename in excluded_directories or rel_dir_path in excluded_directories
+
+    def _is_in_excluded_directory(self, rel_file, excluded_directories):
+        # Return True when any ancestor directory of rel_file is excluded.
+        parts = rel_file.replace("\\", "/").split("/")[:-1]
+        progressive = ""
+        for part in parts:
+            progressive = f"{progressive}/{part}" if progressive else part
+            if self._is_excluded_dir(progressive, excluded_directories):
+                return True
+        return False
 
     def _normalize_excluded_directories(self, excluded_directories):
         # Convert absolute paths located inside the workspace into
@@ -982,11 +1009,14 @@ class Megalinter:
             dirnames[:] = [
                 d
                 for d in dirnames
-                if d not in excluded_directories
-                and os.path.join(rel_dirpath, d).replace(".\\", "").replace("./", "")
-                not in excluded_directories
+                if not self._is_excluded_dir(
+                    os.path.join(rel_dirpath, d).replace(".\\", "").replace("./", ""),
+                    excluded_directories,
+                )
             ]
-            if rel_dirpath != "." and rel_dirpath in excluded_directories:
+            if rel_dirpath != "." and self._is_excluded_dir(
+                rel_dirpath, excluded_directories
+            ):
                 continue
             all_files += [
                 os.path.relpath(os.path.join(dirpath, file), self.workspace)

--- a/megalinter/tests/test_megalinter/mega_linter_files_test.py
+++ b/megalinter/tests/test_megalinter/mega_linter_files_test.py
@@ -4,8 +4,9 @@
 import os
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+from megalinter import config
 from megalinter.MegaLinter import Megalinter
 
 
@@ -36,6 +37,17 @@ class MegaLinterFilesTest(unittest.TestCase):
             ):
                 pass
 
+            # "excluded_backup" shares a prefix with the excluded "excluded"
+            # directory but is a distinct name; it must be kept. Guards against
+            # regressing exact-segment matching into prefix/substring matching.
+            os.makedirs(os.path.join(tmp_dir, "excluded_backup"), exist_ok=True)
+            with open(
+                os.path.join(tmp_dir, "excluded_backup", "keep.txt"),
+                "w",
+                encoding="utf-8",
+            ):
+                pass
+
             excluded = {"excluded", "keep/nested_excluded"}
 
             ml = Megalinter.__new__(Megalinter)
@@ -49,6 +61,7 @@ class MegaLinterFilesTest(unittest.TestCase):
 
             self.assertIn("root.txt", files)
             self.assertIn("keep/keep.txt", files)
+            self.assertIn("excluded_backup/keep.txt", files)
             self.assertNotIn("excluded/should_skip.txt", files)
             self.assertNotIn("keep/nested_excluded/skip_me.txt", files)
 
@@ -85,6 +98,70 @@ class MegaLinterFilesTest(unittest.TestCase):
                 "megalinter-reports/updated_sources/test.sh",
                 [f.replace(os.sep, "/") for f in files],
             )
+
+    def test_list_files_git_diff_skips_excluded_directories(self):
+        # Regression test for issue #8360: files inside excluded directories
+        # must be pruned in changed-files mode (VALIDATE_ALL_CODEBASE=false),
+        # the same way they are in full-codebase mode (list_files_all).
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Files referenced by the mocked git diff must exist on disk
+            # because list_files_git_diff() keeps only real, non-symlink files.
+            for rel_path in [
+                "README.md",
+                "src/app.py",
+                "excluded_backup/keep.py",
+                "excluded/skip.py",
+                "pkg/excluded/deep.py",
+                "keep/nested_excluded/skip.py",
+            ]:
+                abs_path = os.path.join(tmp_dir, rel_path)
+                os.makedirs(os.path.dirname(abs_path) or tmp_dir, exist_ok=True)
+                with open(abs_path, "w", encoding="utf-8"):
+                    pass
+
+            # "excluded" matches by basename at any nesting level;
+            # "keep/nested_excluded" matches by workspace-relative path.
+            excluded = {"excluded", "keep/nested_excluded"}
+            diff_output = (
+                "README.md\n"
+                "src/app.py\n"
+                "excluded_backup/keep.py\n"
+                "excluded/skip.py\n"
+                "pkg/excluded/deep.py\n"
+                "keep/nested_excluded/skip.py\n"
+            )
+
+            ml = Megalinter.__new__(Megalinter)
+            ml.workspace = tmp_dir
+            ml.github_workspace = tmp_dir
+            ml.request_id = "test"
+            ml.has_git_extraheader = False
+
+            config.set_config(ml.request_id, {})
+            self.addCleanup(config.delete, ml.request_id)
+
+            head_ref = MagicMock()
+            head_ref.name = "origin/HEAD"
+            mock_repo = MagicMock()
+            mock_repo.refs = [head_ref]
+            mock_repo.git.diff.return_value = diff_output
+
+            with (
+                patch("megalinter.MegaLinter.git.Repo", return_value=mock_repo),
+                patch(
+                    "megalinter.utils.get_excluded_directories", return_value=excluded
+                ),
+            ):
+                files = ml.list_files_git_diff()
+
+            # Root-level file has no ancestor directory, so it is never excluded
+            self.assertIn("README.md", files)
+            self.assertIn("src/app.py", files)
+            # Prefix of an excluded name must not be pruned (exact-segment match)
+            self.assertIn("excluded_backup/keep.py", files)
+            self.assertNotIn("excluded/skip.py", files)
+            self.assertNotIn("pkg/excluded/deep.py", files)
+            self.assertNotIn("keep/nested_excluded/skip.py", files)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In changed-files mode (VALIDATE_ALL_CODEBASE: false), the file list was
built straight from `git diff --name-only` without consulting the excluded
directories, so files under EXCLUDED_DIRECTORIES / ADDITIONAL_EXCLUDED_
DIRECTORIES were still linted. Full-codebase mode prunes them during the
os.walk traversal, creating inconsistent behavior between the two paths.

Prune diff files whose ancestor directory is excluded so both modes behave
identically. The matching rule (a directory matches by its basename at any
nesting level, or by its workspace-relative path) is consolidated into a
single `_is_excluded_dir()` predicate reused by both the git-diff pruning
and the full-codebase os.walk traversal, so the two modes cannot drift.

Closes #8360

Assisted-by: Claude Opus 4.8
