### PR TITLE
docs: Fix links to kingfisher docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Disable `TERRAFORM_TERRASCAN` (upstream repo archived by Tenable, unmaintained) and `SQL_TSQLLINT` (no upstream release since 2024-09), as both ship unpatched CVEs with no prospect of a fixed release
   - Fix `SARIF_TO_HUMAN` producing empty linter logs when the bundled `sarif-fmt` binary crashes by building it from source on Alpine and falling back to raw SARIF on conversion failure (#8294)
   - Keep the Docker Pulls badge in `docs/index.md` in sync by having `docker_stats.py` also update the hardcoded badge total in `.automation/build.py`
+  - Fix outdated links in `docs/descriptors/repository_kingfisher.md`
 
 - Reporters
 

--- a/megalinter/descriptors/repository.megalinter-descriptor.yml
+++ b/megalinter/descriptors/repository.megalinter-descriptor.yml
@@ -1294,8 +1294,8 @@ linters:
     linter_url: https://github.com/mongodb/kingfisher
     linter_repo: https://github.com/mongodb/kingfisher
     linter_spdx_license: Apache-2.0
-    linter_rules_url: https://github.com/mongodb/kingfisher/tree/main/data/rules
-    linter_rules_inline_disable_url: https://github.com/mongodb/kingfisher?tab=readme-ov-file#inline-ignore-directives
+    linter_rules_url: https://mongodb.github.io/kingfisher/rules/builtin-rules
+    linter_rules_inline_disable_url: https://github.com/mongodb/kingfisher#filtering-and-suppression
     test_folder: repository_kingfisher
     cli_lint_mode: project
     cli_lint_extra_args:

--- a/megalinter/descriptors/repository.megalinter-descriptor.yml
+++ b/megalinter/descriptors/repository.megalinter-descriptor.yml
@@ -1295,7 +1295,7 @@ linters:
     linter_repo: https://github.com/mongodb/kingfisher
     linter_spdx_license: Apache-2.0
     linter_rules_url: https://mongodb.github.io/kingfisher/rules/builtin-rules
-    linter_rules_inline_disable_url: https://github.com/mongodb/kingfisher#filtering-and-suppression
+    linter_rules_inline_disable_url: https://mongodb.github.io/kingfisher/usage/advanced/?h=inline#inline-ignore-directives
     test_folder: repository_kingfisher
     cli_lint_mode: project
     cli_lint_extra_args:


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes outdated links in `docs/descriptors/repository_kingfisher.md`

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Update two of the links in `docs/descriptors/repository_kingfisher.md` which no longer resolve.

I considered pressing `y` while viewing the referenced Markdown file and using the resulting GitHub URL pinned to a specific commit (i.e. <https://github.com/mongodb/kingfisher/tree/8fa4f142bcd32664ac0feb16fc8aabc67637660d#filtering-and-suppression>) but I'm not sure if those types of links are discouraged in the docs of open source projects. On the one hand, using a GitHub URL pinned to a specific commit ensures the documentation link never becomes broken again. On the other hand, it risks pointing MegaLinter users to documentation that (in the future) has become outdated and is no longer providing accurate information about kingfisher.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
