### PR TITLE
Write Checkov GitHub-config scan dir under the report folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Fixes
 
+  - Write `REPOSITORY_CHECKOV`'s transient GitHub-config scan directory (`branch_protection_rules.json` and similar) to a hidden `.checkov-github-conf` subfolder of the MegaLinter report folder instead of the repository root, so the artifact stays out of the linted tree (gitignored, excluded from file discovery, and skipped by project-mode linters), extending the earlier ansible-lint race-condition fix (#8092)
   - Make remote configuration loading resilient to transient network failures by adding a request timeout and bounded retries with backoff when fetching `MEGALINTER_CONFIG` and `EXTENDS` files over HTTP (fixes intermittent `config_test` failures caused by `raw.githubusercontent.com` CDN cache lag)
   - Disable `TERRAFORM_TERRASCAN` (upstream repo archived by Tenable, unmaintained) and `SQL_TSQLLINT` (no upstream release since 2024-09), as both ship unpatched CVEs with no prospect of a fixed release
   - Fix `SARIF_TO_HUMAN` producing empty linter logs when the bundled `sarif-fmt` binary crashes by building it from source on Alpine and falling back to raw SARIF on conversion failure (#8294)

--- a/megalinter/linters/CheckovLinter.py
+++ b/megalinter/linters/CheckovLinter.py
@@ -3,17 +3,30 @@
 Use Checkov to lint Infrastructure as Code
 """
 
+import os
+
 import megalinter.utils as utils
 from megalinter import Linter, config
 
 
 class CheckovLinter(Linter):
     def before_lint_files(self):
-        # Redirect Checkov's transient github_conf/ to a hidden dir to prevent ansible-lint race condition (issue #8092)
+        # Redirect Checkov's transient github_conf/ out of the linted tree to
+        # avoid an ansible-lint race condition (issue #8092). Prefer a hidden
+        # subfolder of the MegaLinter report folder: it is gitignored,
+        # auto-created and excluded from file discovery, while the leading dot
+        # keeps project-mode linters (which walk the tree themselves) from
+        # descending into it. Checkov joins CKV_GITHUB_CONF_DIR_NAME with the
+        # current working directory, so an absolute path lands there verbatim.
+        # Fall back to a hidden dir at the workspace root when reports are off.
         if self._cached_subprocess_env is not None:
-            self._cached_subprocess_env["CKV_GITHUB_CONF_DIR_NAME"] = (
-                ".megalinter_github_conf"
-            )
+            if self.report_folder not in ("", "none", "false"):
+                github_conf_dir = os.path.abspath(
+                    os.path.join(self.report_folder, ".checkov-github-conf")
+                )
+            else:
+                github_conf_dir = ".megalinter_github_conf"
+            self._cached_subprocess_env["CKV_GITHUB_CONF_DIR_NAME"] = github_conf_dir
 
     def build_lint_command(self, file=None) -> list:
         if (


### PR DESCRIPTION
## Proposed Changes

Checkov's `github_configuration` framework writes a transient directory (`branch_protection_rules.json` and similar files fetched from the GitHub API) that, until now, landed in the **repository root** being linted — leaving `.megalinter_github_conf/` behind in the workspace after every run.

This changes `CheckovLinter.before_lint_files()` to point `CKV_GITHUB_CONF_DIR_NAME` at a hidden `.checkov-github-conf` subfolder of the MegaLinter **report folder** instead:

- **Out of the linted tree** — the report folder is gitignored and already in the default `EXCLUDED_DIRECTORIES`, so the artifact no longer shows up in `git status` or gets picked up by file discovery.
- **Leading dot preserved** — project-mode linters (which walk the tree themselves) skip dot-directories, so this keeps the property that fixed the original ansible-lint race condition (#8092).
- **Absolute path** — Checkov joins `CKV_GITHUB_CONF_DIR_NAME` with `os.getcwd()`, so passing an absolute path lands the files there verbatim.
- **Fallback** — when reports are disabled (`report_folder` is empty / `none` / `false`), it falls back to the previous workspace-root hidden dir.

This extends the earlier #8092 fix (which merely hid the directory at the workspace root) so the scan artifact no longer sits inside the repository being linted at all.

## Readiness Checklist

### Author/Contributor

- [x] Add entry to the CHANGELOG listing the change
- [x] If documentation is needed for this change, has that been included in this pull request (no doc change needed — internal behavior only)

### Reviewing Maintainer

- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`