### PR TITLE
Fix: LINTER_RULES_PATH config resolution for active_only_if_file_found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Fix `SARIF_TO_HUMAN` producing empty linter logs when the bundled `sarif-fmt` binary crashes by building it from source on Alpine and falling back to raw SARIF on conversion failure (#8294)
   - Keep the Docker Pulls badge in `docs/index.md` in sync by having `docker_stats.py` also update the hardcoded badge total in `.automation/build.py`
   - Fix outdated links in `docs/descriptors/repository_kingfisher.md`
+  - Fix `LINTER_RULES_PATH` not being used to resolve config files for linters using `active_only_if_file_found` (e.g. `REPOSITORY_LS_LINT`, `SPELL_PROSELINT`, `SPELL_VALE`), fixes [#8416](https://github.com/oxsecurity/megalinter/issues/8416)
 
 - Reporters
 

--- a/megalinter/Linter.py
+++ b/megalinter/Linter.py
@@ -345,6 +345,12 @@ class Linter:
                     if os.path.isfile(f"{self.workspace}{os.path.sep}{file_to_check}"):
                         found_file = f"{self.workspace}{os.path.sep}{file_to_check}"
                     elif os.path.isfile(
+                        self.linter_rules_path + os.path.sep + file_to_check
+                    ):
+                        found_file = (
+                            self.linter_rules_path + os.path.sep + file_to_check
+                        )
+                    elif os.path.isfile(
                         f"{self.workspace}{os.path.sep}{self.linter_rules_path}{os.path.sep}{file_to_check}"
                     ):
                         found_file = (

--- a/megalinter/tests/test_megalinter/mega_linter_1_test.py
+++ b/megalinter/tests/test_megalinter/mega_linter_1_test.py
@@ -5,11 +5,12 @@ Unit tests for Megalinter class
 """
 
 import os
+import tempfile
 import unittest
 import uuid
 
 import megalinter
-from megalinter import config, utilstest
+from megalinter import config, linter_factory, utilstest, utils
 from megalinter.constants import DEFAULT_DOCKER_WORKSPACE_DIR, ML_REPO
 
 
@@ -185,6 +186,89 @@ class mega_linter_1_test(unittest.TestCase):
         self.assertIn("Linted [JAVASCRIPT] files", output)
         self.assertIn("Using [eslint", output)
         self.assertIn(".eslintrc-custom.yml", output)
+
+    def test_linter_rules_path_resolves_active_only_if_file_found(self):
+        self.before_start()
+        with tempfile.TemporaryDirectory() as tmp_workspace:
+            rules_dir = (
+                tmp_workspace + os.path.sep + ".github" + os.path.sep + "linters"
+            )
+            os.makedirs(rules_dir, exist_ok=True)
+            # Create config files for linters using active_only_if_file_found
+            with open(
+                rules_dir + os.path.sep + "ls-lint.yaml", "w", encoding="utf-8"
+            ) as f:
+                f.write("ls:\n  .js: regex:...[a-z]+\n")
+            with open(
+                rules_dir + os.path.sep + "proselint.json", "w", encoding="utf-8"
+            ) as f:
+                f.write('{"checks": {"airlinese": false}}\n')
+            with open(
+                rules_dir + os.path.sep + "vale.ini", "w", encoding="utf-8"
+            ) as f:
+                f.write("StylesPath = styles\n")
+
+            # Set custom config file names
+            config.set_value(
+                self.request_id, "REPOSITORY_LS_LINT_CONFIG_FILE", "ls-lint.yaml"
+            )
+            config.set_value(
+                self.request_id, "SPELL_PROSELINT_CONFIG_FILE", "proselint.json"
+            )
+            config.set_value(
+                self.request_id, "SPELL_VALE_CONFIG_FILE", "vale.ini"
+            )
+
+            linter_rules_path = rules_dir
+            default_rules_location = utils.get_default_rules_location()
+            base_params = {
+                "default_linter_activation": True,
+                "enable_descriptors": [],
+                "enable_linters": [],
+                "disable_descriptors": [],
+                "disable_linters": [],
+                "disable_errors_linters": [],
+                "github_workspace": tmp_workspace,
+                "workspace": tmp_workspace,
+                "linter_rules_path": linter_rules_path,
+                "default_rules_location": default_rules_location,
+                "post_linter_status": True,
+                "request_id": self.request_id,
+            }
+
+            ls_lint = linter_factory.build_linter(
+                "REPOSITORY", "ls-lint", base_params
+            )
+            self.assertTrue(
+                ls_lint.is_active,
+                "REPOSITORY_LS_LINT should be active when config exists under LINTER_RULES_PATH",
+            )
+            self.assertEqual(
+                ls_lint.config_file,
+                linter_rules_path + os.path.sep + "ls-lint.yaml",
+            )
+
+            proselint = linter_factory.build_linter(
+                "SPELL", "proselint", base_params
+            )
+            self.assertTrue(
+                proselint.is_active,
+                "SPELL_PROSELINT should be active when config exists under LINTER_RULES_PATH",
+            )
+            self.assertEqual(
+                proselint.config_file,
+                linter_rules_path + os.path.sep + "proselint.json",
+            )
+
+            vale = linter_factory.build_linter("SPELL", "vale", base_params)
+            self.assertTrue(
+                vale.is_active,
+                "SPELL_VALE should be active when config exists under LINTER_RULES_PATH",
+            )
+            self.assertEqual(
+                vale.config_file,
+                linter_rules_path + os.path.sep + "vale.ini",
+            )
 
     def test_override_linter_rules_path_remote(self):
         self.before_start()

--- a/megalinter/tests/test_megalinter/mega_linter_1_test.py
+++ b/megalinter/tests/test_megalinter/mega_linter_1_test.py
@@ -10,7 +10,7 @@ import unittest
 import uuid
 
 import megalinter
-from megalinter import config, linter_factory, utilstest, utils
+from megalinter import config, linter_factory, utils, utilstest
 from megalinter.constants import DEFAULT_DOCKER_WORKSPACE_DIR, ML_REPO
 
 
@@ -203,9 +203,7 @@ class mega_linter_1_test(unittest.TestCase):
                 rules_dir + os.path.sep + "proselint.json", "w", encoding="utf-8"
             ) as f:
                 f.write('{"checks": {"airlinese": false}}\n')
-            with open(
-                rules_dir + os.path.sep + "vale.ini", "w", encoding="utf-8"
-            ) as f:
+            with open(rules_dir + os.path.sep + "vale.ini", "w", encoding="utf-8") as f:
                 f.write("StylesPath = styles\n")
 
             # Set custom config file names
@@ -215,9 +213,7 @@ class mega_linter_1_test(unittest.TestCase):
             config.set_value(
                 self.request_id, "SPELL_PROSELINT_CONFIG_FILE", "proselint.json"
             )
-            config.set_value(
-                self.request_id, "SPELL_VALE_CONFIG_FILE", "vale.ini"
-            )
+            config.set_value(self.request_id, "SPELL_VALE_CONFIG_FILE", "vale.ini")
 
             linter_rules_path = rules_dir
             default_rules_location = utils.get_default_rules_location()
@@ -236,9 +232,7 @@ class mega_linter_1_test(unittest.TestCase):
                 "request_id": self.request_id,
             }
 
-            ls_lint = linter_factory.build_linter(
-                "REPOSITORY", "ls-lint", base_params
-            )
+            ls_lint = linter_factory.build_linter("REPOSITORY", "ls-lint", base_params)
             self.assertTrue(
                 ls_lint.is_active,
                 "REPOSITORY_LS_LINT should be active when config exists under LINTER_RULES_PATH",
@@ -248,9 +242,7 @@ class mega_linter_1_test(unittest.TestCase):
                 linter_rules_path + os.path.sep + "ls-lint.yaml",
             )
 
-            proselint = linter_factory.build_linter(
-                "SPELL", "proselint", base_params
-            )
+            proselint = linter_factory.build_linter("SPELL", "proselint", base_params)
             self.assertTrue(
                 proselint.is_active,
                 "SPELL_PROSELINT should be active when config exists under LINTER_RULES_PATH",


### PR DESCRIPTION
Linters such as `REPOSITORY_LS_LINT`, `SPELL_PROSELINT`, and `SPELL_VALE` rely on finding a specific configuration file to become active. Previously, the `LINTER_RULES_PATH` was not correctly checked for these files, preventing activation or use of custom configurations. This update ensures that the path specified by `LINTER_RULES_PATH` is correctly searched. Fixes #8416.

Fixes https://github.com/oxsecurity/megalinter/issues/8416