### PR TITLE
Allow FILTER_REGEX_INCLUDE and FILTER_REGEX_EXCLUDE to be arrays

### DIFF
--- a/.automation/build.py
+++ b/.automation/build.py
@@ -1201,7 +1201,8 @@ def generate_descriptor_documentation(descriptor):
                         f"{descriptor.get('descriptor_id')}: "
                         "Custom regex including filter: only files matching this regex will be linted"
                     ),
-                    "type": "string",
+                    "type": ["string", "array"],
+                    "items": {"type": "string"},
                     "title": f"Including regex filter for {descriptor.get('descriptor_id')} descriptor",
                     "x-doc-key": "config-filtering",
                 },
@@ -1214,7 +1215,8 @@ def generate_descriptor_documentation(descriptor):
                         f"{descriptor.get('descriptor_id')}: "
                         "Custom regex excluding filter: files matching this regex will NOT be linted"
                     ),
-                    "type": "string",
+                    "type": ["string", "array"],
+                    "items": {"type": "string"},
                     "title": f"Excluding regex filter for {descriptor.get('descriptor_id')} descriptor",
                     "x-doc-key": "config-filtering",
                 },
@@ -1625,7 +1627,8 @@ def process_type(linters_by_type, type1, type_label, linters_tables_md):
                             if "project" in linter.supported_cli_lint_modes
                             else ""
                         ),
-                        "type": "string",
+                        "type": ["string", "array"],
+                        "items": {"type": "string"},
                         "title": f"{title_prefix}{linter.name}: Including Regex",
                         "x-doc-key": "config-filtering",
                     },
@@ -1642,7 +1645,8 @@ def process_type(linters_by_type, type1, type_label, linters_tables_md):
                             if "project" in linter.supported_cli_lint_modes
                             else ""
                         ),
-                        "type": "string",
+                        "type": ["string", "array"],
+                        "items": {"type": "string"},
                         "title": f"{title_prefix}{linter.name}: Excluding Regex",
                         "x-doc-key": "config-filtering",
                     },

--- a/.automation/test/mega-linter-config-test/local_extends_filter_regex_append/base.local.mega-linter.yml
+++ b/.automation/test/mega-linter-config-test/local_extends_filter_regex_append/base.local.mega-linter.yml
@@ -1,0 +1,4 @@
+FILTER_REGEX_INCLUDE:
+  - "(src)"
+FILTER_REGEX_EXCLUDE:
+  - "(base_excluded)"

--- a/.automation/test/mega-linter-config-test/local_extends_filter_regex_append/local.mega-linter.yml
+++ b/.automation/test/mega-linter-config-test/local_extends_filter_regex_append/local.mega-linter.yml
@@ -1,0 +1,8 @@
+EXTENDS: base.local.mega-linter.yml
+CONFIG_PROPERTIES_TO_APPEND:
+  - FILTER_REGEX_INCLUDE
+  - FILTER_REGEX_EXCLUDE
+FILTER_REGEX_INCLUDE:
+  - "(lib)"
+FILTER_REGEX_EXCLUDE:
+  - "(local_excluded)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Core
 
+  - Allow `FILTER_REGEX_INCLUDE` and `FILTER_REGEX_EXCLUDE` (global, per-descriptor and per-linter) to be defined as a list of regexes combined with a logical OR, so filter regexes can be appended across `EXTENDS` configs via `CONFIG_PROPERTIES_TO_APPEND`; single-string values remain fully supported, fixes [#8361](https://github.com/oxsecurity/megalinter/issues/8361)
   - Add `ENABLE_DISABLE_LINTERS_PRIORITY` variable to let `DISABLE_LINTERS` override `ENABLE_LINTERS` when a linter is in both lists (e.g. to trim an inherited `ENABLE_LINTERS` list via `EXTENDS`), fixes [#8296](https://github.com/oxsecurity/megalinter/issues/8296)
   - Add `supported_cli_lint_modes` descriptor property to declare which CLI lint modes (`file`, `list_of_files`, `project`) each linter supports, generate `success`/`failure` tests for every supported mode, and reject a `<LINTER>_CLI_LINT_MODE` override targeting an unsupported mode with an explicit error, fixes [#7120](https://github.com/oxsecurity/megalinter/issues/7120)
 

--- a/megalinter/MegaLinter.py
+++ b/megalinter/MegaLinter.py
@@ -834,9 +834,15 @@ class Megalinter:
                 "- File names (regex): " + ", ".join(sorted(self.file_names_regex))
             )
         if self.filter_regex_include is not None:
-            logging.info("- Including regex: " + self.filter_regex_include)
+            logging.info(
+                "- Including regex: "
+                + ", ".join(utils.normalize_regex_filter(self.filter_regex_include))
+            )
         if self.filter_regex_exclude is not None:
-            logging.info("- Excluding regex: " + self.filter_regex_exclude)
+            logging.info(
+                "- Excluding regex: "
+                + ", ".join(utils.normalize_regex_filter(self.filter_regex_exclude))
+            )
 
         # List git ignored files if necessary
         ignored_files = []

--- a/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
@@ -8788,25 +8788,45 @@
     },
     "FILTER_REGEX_EXCLUDE": {
       "$id": "#/properties/FILTER_REGEX_EXCLUDE",
-      "description": "Regular expression defining which files will be excluded from linting",
+      "description": "Regular expression(s) defining which files will be excluded from linting. Can be a single regex string or a list of regexes combined with a logical OR",
       "examples": [
         "(\\.automation/test|docs/javascripts|docs/overrides|flavors|clj-kondo|TEMPLATES)",
-        "(src/test)"
+        "(src/test)",
+        [
+          "(src/test)",
+          "(docs/overrides)"
+        ]
       ],
+      "items": {
+        "type": "string"
+      },
       "title": "Excluding regex filter",
-      "type": "string",
+      "type": [
+        "string",
+        "array"
+      ],
       "x-category": "GENERAL",
       "x-order": 200020,
       "x-section": "SCOPE"
     },
     "FILTER_REGEX_INCLUDE": {
       "$id": "#/properties/FILTER_REGEX_INCLUDE",
-      "description": "Regular expression defining which files will be processed by linters",
+      "description": "Regular expression(s) defining which files will be processed by linters. Can be a single regex string or a list of regexes combined with a logical OR",
       "examples": [
-        "(src/)"
+        "(src/)",
+        [
+          "(src/)",
+          "(lib/)"
+        ]
       ],
+      "items": {
+        "type": "string"
+      },
       "title": "Including regex filter",
-      "type": "string",
+      "type": [
+        "string",
+        "array"
+      ],
       "x-category": "GENERAL",
       "x-order": 200010,
       "x-section": "SCOPE"

--- a/megalinter/tests/test_megalinter/config_test.py
+++ b/megalinter/tests/test_megalinter/config_test.py
@@ -146,6 +146,31 @@ class config_test(unittest.TestCase):
         self.assertEqual("(local)", config.get(request_id, "FILTER_REGEX_INCLUDE"))
         self.restore_branch_in_input_files(changed_files)
 
+    def test_local_config_extends_filter_regex_append_success(self):
+        local_config = "local.mega-linter.yml"
+        request_id = str(uuid.uuid1())
+        config.init_config(
+            request_id,
+            REPO_HOME_DEFAULT
+            + os.path.sep
+            + ".automation"
+            + os.path.sep
+            + "test"
+            + os.path.sep
+            + "mega-linter-config-test"
+            + os.path.sep
+            + "local_extends_filter_regex_append",
+            {"MEGALINTER_CONFIG": local_config},
+        )
+        self.assertEqual(
+            ["(src)", "(lib)"],
+            config.get(request_id, "FILTER_REGEX_INCLUDE"),
+        )
+        self.assertEqual(
+            ["(base_excluded)", "(local_excluded)"],
+            config.get(request_id, "FILTER_REGEX_EXCLUDE"),
+        )
+
     def test_local_config_extends_recurse_success(self):
         changed_files = self.replace_branch_in_input_files()
         local_config = "recurse.mega-linter.yml"

--- a/megalinter/tests/test_megalinter/filters_test.py
+++ b/megalinter/tests/test_megalinter/filters_test.py
@@ -149,3 +149,86 @@ class filters_test(unittest.TestCase):
             sorted(["target/foo.md"]),
             "check regex_exclude_multilevel",
         )
+
+    def test_filter_regex_include_list(self):
+        all_files = [
+            "src/foo.ext",
+            "lib/bar.ext",
+            "other/baz.ext",
+        ]
+        filtered_files = utils.filter_files(
+            all_files=all_files,
+            filter_regex_include=["(src)", "(lib)"],
+            filter_regex_exclude=[],
+            file_names_regex=[],
+            file_extensions=["*"],
+            ignored_files=[],
+            ignore_generated_files=False,
+        )
+        self.assertListEqual(
+            sorted(filtered_files),
+            sorted(["src/foo.ext", "lib/bar.ext"]),
+            "check regex_include_list matches any (OR)",
+        )
+
+    def test_filter_regex_include_string_still_works(self):
+        all_files = [
+            "src/foo.ext",
+            "other/baz.ext",
+        ]
+        filtered_files = utils.filter_files(
+            all_files=all_files,
+            filter_regex_include="(src)",
+            filter_regex_exclude=[],
+            file_names_regex=[],
+            file_extensions=["*"],
+            ignored_files=[],
+            ignore_generated_files=False,
+        )
+        self.assertListEqual(
+            sorted(filtered_files),
+            sorted(["src/foo.ext"]),
+            "check regex_include single string still works",
+        )
+
+    def test_filter_regex_exclude_list(self):
+        all_files = [
+            "src/foo.ext",
+            "test/bar.ext",
+            "vendor/baz.ext",
+        ]
+        filtered_files = utils.filter_files(
+            all_files=all_files,
+            filter_regex_include=None,
+            filter_regex_exclude=["(test)", "(vendor)"],
+            file_names_regex=[],
+            file_extensions=["*"],
+            ignored_files=[],
+            ignore_generated_files=False,
+        )
+        self.assertListEqual(
+            sorted(filtered_files),
+            sorted(["src/foo.ext"]),
+            "check regex_exclude_list matches any (OR)",
+        )
+
+    def test_filter_regex_exclude_nested_list(self):
+        all_files = [
+            "src/foo.ext",
+            "test/bar.ext",
+            "vendor/baz.ext",
+        ]
+        filtered_files = utils.filter_files(
+            all_files=all_files,
+            filter_regex_include=None,
+            filter_regex_exclude=[["(test)"], "(vendor)", None],
+            file_names_regex=[],
+            file_extensions=["*"],
+            ignored_files=[],
+            ignore_generated_files=False,
+        )
+        self.assertListEqual(
+            sorted(filtered_files),
+            sorted(["src/foo.ext"]),
+            "check regex_exclude nested list flattens",
+        )

--- a/megalinter/utils.py
+++ b/megalinter/utils.py
@@ -10,7 +10,7 @@ import urllib.parse
 import warnings
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Any, Optional, Pattern, Sequence
+from typing import Any, Optional, Pattern, Sequence, Union
 
 import git
 import regex
@@ -122,10 +122,23 @@ def get_excluded_directories(request_id):
     return result
 
 
+# Flatten None, a single regex string, or a (possibly nested) list of regex strings
+# into a flat list of non-empty regex strings.
+def normalize_regex_filter(value) -> Sequence[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value != "" else []
+    result = []
+    for item in value:
+        result += normalize_regex_filter(item)
+    return result
+
+
 def filter_files(
     all_files: Sequence[str],
-    filter_regex_include: Optional[str],
-    filter_regex_exclude: Sequence[str],
+    filter_regex_include: Optional[Union[str, Sequence[str]]],
+    filter_regex_exclude: Optional[Union[str, Sequence[str]]],
     file_names_regex: Sequence[str],
     file_extensions: Any,
     ignored_files: Optional[Sequence[str]],
@@ -138,15 +151,12 @@ def filter_files(
     workspace: str = "",
 ) -> Sequence[str]:
     file_extensions = frozenset(file_extensions)
-    filter_regex_include_object = (
-        re.compile(filter_regex_include) if filter_regex_include else None
-    )
-    filter_regex_exclude_objects = []
-    for filter_regex_exclude_item in filter_regex_exclude:
-        filter_regex_exclude_object = (
-            re.compile(filter_regex_exclude_item) if filter_regex_exclude_item else None
-        )
-        filter_regex_exclude_objects += [filter_regex_exclude_object]
+    filter_regex_include_objects = [
+        re.compile(item) for item in normalize_regex_filter(filter_regex_include)
+    ]
+    filter_regex_exclude_objects = [
+        re.compile(item) for item in normalize_regex_filter(filter_regex_exclude)
+    ]
     file_names_regex_object = re.compile("|".join(file_names_regex))
     filtered_files = []
     file_contains_regex_object = (
@@ -183,20 +193,22 @@ def filter_files(
 
         base_file_name = os.path.basename(file)
         _, file_extension = os.path.splitext(base_file_name)
-        # Skip according to FILTER_REGEX_INCLUDE
-        if filter_regex_include_object and (
-            not filter_regex_include_object.search(file)
+        # Skip according to FILTER_REGEX_INCLUDE list (kept if matching any, logical OR)
+        if filter_regex_include_objects and not any(
+            filter_regex_include_object.search(file)
             # Compatibility with v6 regexes
-            and not filter_regex_include_object.search(file_with_workspace)
+            or filter_regex_include_object.search(file_with_workspace)
+            for filter_regex_include_object in filter_regex_include_objects
         ):
             continue
-        # Skip according to FILTER_REGEX_EXCLUDE list
+        # Skip according to FILTER_REGEX_EXCLUDE list (excluded if matching any, logical OR)
         excluded_by_regex = False
         for filter_regex_exclude_object in filter_regex_exclude_objects:
-            if filter_regex_exclude_object and (
-                filter_regex_exclude_object.search(file)
+            if filter_regex_exclude_object.search(
+                file
+            ) or filter_regex_exclude_object.search(
                 # Compatibility with v6 regexes
-                or filter_regex_exclude_object.search(file_with_workspace)
+                file_with_workspace
             ):
                 excluded_by_regex = True
                 break

--- a/megalinter/utils.py
+++ b/megalinter/utils.py
@@ -129,7 +129,7 @@ def normalize_regex_filter(value) -> Sequence[str]:
         return []
     if isinstance(value, str):
         return [value] if value != "" else []
-    result = []
+    result: list = []
     for item in value:
         result += normalize_regex_filter(item)
     return result


### PR DESCRIPTION
## Summary

Fixes #8361.

`FILTER_REGEX_INCLUDE` and `FILTER_REGEX_EXCLUDE` (global, per-descriptor, and per-linter variants) can now be defined as a **list of regexes** in addition to the existing single string. List entries are combined with a logical **OR** (a file matches the filter if it matches any entry).

This lets these variables participate in the existing `CONFIG_PROPERTIES_TO_APPEND` + `EXTENDS` merge machinery, so an extended configuration can **append to** a filter regex instead of overwriting it:

```yaml
# base.mega-linter.yml
FILTER_REGEX_EXCLUDE:
  - "(vendor/)"

# .mega-linter.yml
EXTENDS: base.mega-linter.yml
CONFIG_PROPERTIES_TO_APPEND:
  - FILTER_REGEX_EXCLUDE
FILTER_REGEX_EXCLUDE:
  - "(generated/)"
# effective value: ["(vendor/)", "(generated/)"]
```

## Backward compatibility

Fully preserved. Single-string values — including environment variables, which are always strings — behave exactly as before. Only the new YAML list form is added; nothing is split or reinterpreted for existing string values.

## Changes

- `megalinter/utils.py` — new `normalize_regex_filter()` helper (flattens `None` / string / nested list into a flat regex list); `filter_files` now accepts a string or a list for both include and exclude, with include OR-matched like exclude already was.
- `megalinter/MegaLinter.py` — the include/exclude log lines now render list values.
- `.automation/build.py` — the per-descriptor and per-linter config-schema generators emit `"type": ["string", "array"]` with `"items"`.
- `megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json` — the two hand-maintained global entries widened, with array-form examples. (Per-descriptor / per-linter schema entries are regenerated by the auto-update workflow.)

## Tests

- `filters_test.py` — new unit tests: include-as-list (OR), single-string include regression, exclude-as-list (OR), nested-list flatten.
- New `local_extends_filter_regex_append` fixture + `config_test.py` case asserting the append-across-`EXTENDS` merge produces the combined list.

All fast unit tests pass locally.
