### PR TITLE
Fix invalid empty SARIF fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Fixes
 
+  - Remove invalid SARIF fixes with empty `artifactChanges` arrays before report aggregation, fixes [#8474](https://github.com/oxsecurity/megalinter/issues/8474)
   - Write `REPOSITORY_CHECKOV`'s transient GitHub-config scan directory (`branch_protection_rules.json` and similar) to a hidden `.checkov-github-conf` subfolder of the MegaLinter report folder instead of the repository root, so the artifact stays out of the linted tree (gitignored, excluded from file discovery, and skipped by project-mode linters), extending the earlier ansible-lint race-condition fix (#8092)
   - Make remote configuration loading resilient to transient network failures by adding a request timeout and bounded retries with backoff when fetching `MEGALINTER_CONFIG` and `EXTENDS` files over HTTP (fixes intermittent `config_test` failures caused by `raw.githubusercontent.com` CDN cache lag)
   - Disable `TERRAFORM_TERRASCAN` (upstream repo archived by Tenable, unmaintained) and `SQL_TSQLLINT` (no upstream release since 2024-09), as both ship unpatched CVEs with no prospect of a fixed release

--- a/megalinter/tests/test_megalinter/mega_linter_3_sarif_test.py
+++ b/megalinter/tests/test_megalinter/mega_linter_3_sarif_test.py
@@ -9,9 +9,10 @@ import os
 import tempfile
 import unittest
 import uuid
+from types import SimpleNamespace
 from unittest.mock import patch
 
-from megalinter import Linter, MegaLinter, utils_reporter, utilstest
+from megalinter import Linter, MegaLinter, utils_reporter, utils_sarif, utilstest
 from megalinter.constants import DEFAULT_SARIF_REPORT_FILE_NAME
 from megalinter.reporters.SarifReporter import SarifReporter
 
@@ -92,6 +93,43 @@ class mega_linter_3_sarif_test(unittest.TestCase):
             os.path.isfile(expected_output_file),
             "Output aggregated SARIF file " + expected_output_file + " should exist",
         )
+
+    def test_sarif_fix_removes_empty_artifact_changes(self):
+        linter = SimpleNamespace(
+            name="BASH_SHELLCHECK", get_linter_version=lambda: "0.11.0"
+        )
+        valid_fix = {
+            "artifactChanges": [
+                {
+                    "artifactLocation": {"uri": "test.sh"},
+                    "replacements": [],
+                }
+            ]
+        }
+        sarif = {
+            "runs": [
+                {
+                    "results": [
+                        {
+                            "fixes": [
+                                {"artifactChanges": []},
+                                valid_fix,
+                            ]
+                        },
+                        {"fixes": [{"description": {"text": "["}}]},
+                    ]
+                }
+            ]
+        }
+
+        with patch(
+            "megalinter.utils_sarif.get_linter_doc_url",
+            return_value="https://megalinter.io/",
+        ):
+            fixed_sarif = utils_sarif.fix_sarif(sarif, linter)
+
+        self.assertEqual(fixed_sarif["runs"][0]["results"][0]["fixes"], [valid_fix])
+        self.assertNotIn("fixes", fixed_sarif["runs"][0]["results"][1])
 
     def test_api_output(self):
         self.before_start()

--- a/megalinter/utils_sarif.py
+++ b/megalinter/utils_sarif.py
@@ -162,6 +162,12 @@ def fix_sarif(linter_sarif_obj, linter):
             if "results" in run:
                 # browse run results
                 for id_result, result in enumerate(run["results"]):
+                    if "fixes" in result:
+                        result["fixes"] = [
+                            fix for fix in result["fixes"] if fix.get("artifactChanges")
+                        ]
+                        if not result["fixes"]:
+                            del result["fixes"]
                     if "locations" in result:
                         # browse result locations
                         for id_location, location in enumerate(result["locations"]):


### PR DESCRIPTION
Fixes #8474

## Proposed Changes

1. Remove SARIF fixes whose `artifactChanges` list is missing or empty before aggregation.
2. Preserve valid fixes and remove the `fixes` key when no valid entries remain.
3. Add focused regression coverage for both cases.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request (not needed for this internal SARIF normalization fix)

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
