### PR TITLE
fix: accept zero SARIF result counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Fixes
 
+  - Treat zero matching SARIF findings as a valid result without logging the entire report, fixes [#8295](https://github.com/oxsecurity/megalinter/issues/8295)
   - Remove invalid SARIF fixes with empty `artifactChanges` arrays before report aggregation, fixes [#8474](https://github.com/oxsecurity/megalinter/issues/8474)
   - Write `REPOSITORY_CHECKOV`'s transient GitHub-config scan directory (`branch_protection_rules.json` and similar) to a hidden `.checkov-github-conf` subfolder of the MegaLinter report folder instead of the repository root, so the artifact stays out of the linted tree (gitignored, excluded from file discovery, and skipped by project-mode linters), extending the earlier ansible-lint race-condition fix (#8092)
   - Make remote configuration loading resilient to transient network failures by adding a request timeout and bounded retries with backoff when fetching `MEGALINTER_CONFIG` and `EXTENDS` files over HTTP (fixes intermittent `config_test` failures caused by `raw.githubusercontent.com` CDN cache lag)

--- a/megalinter/Linter.py
+++ b/megalinter/Linter.py
@@ -1709,12 +1709,6 @@ class Linter:
                     if count_results is True:
                         total_result += len(result["locations"])
 
-            # If we got here, we should have found a number of results from SARIF output
-            if total_result == 0:
-                logging.warning(
-                    f"Unable to get total {level}s from SARIF output.\nSARIF:"
-                    + str(sarif_output)
-                )
             return total_result
         except Exception as e:
             total_result = 1

--- a/megalinter/tests/test_megalinter/linter_test.py
+++ b/megalinter/tests/test_megalinter/linter_test.py
@@ -101,3 +101,22 @@ class LinterTest(unittest.TestCase):
         replaced_args = linter.replace_vars(args, additional_variables)
 
         self.assertEqual(["test_additional_var"], replaced_args)
+
+    def test_sarif_zero_results_is_not_a_warning(self):
+        linter = Linter.__new__(Linter)
+        linter.sarif_output_file = None
+        linter.sarif_default_output_file = None
+        sarif = """\
+runs:
+  - tool:
+      driver: {}
+    results:
+      - level: note
+        locations:
+          - physicalLocation: {}
+"""
+
+        with self.assertNoLogs(level="WARNING"):
+            result = linter.get_sarif_result_count(sarif, "error")
+
+        self.assertEqual(0, result)


### PR DESCRIPTION
Fixes #8295

## Proposed Changes

1. Treat a valid SARIF report with no matching severity as a zero count without logging the report.
2. Add regression coverage for a valid report with zero error findings.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request (not needed; behavior now matches the existing return contract)

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
