### PR TITLE
fix(custom-flavors): pin actions/upload-artifact to full-length SHA

### DIFF
--- a/flavors/custom-builder/action.yml
+++ b/flavors/custom-builder/action.yml
@@ -85,7 +85,7 @@ runs:
 
     - name: Upload build artifacts
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: megalinter-custom-flavor-artifacts
         path: |


### PR DESCRIPTION
Fixes #8555

## Problem

The composite action `flavors/custom-builder/action.yml` referenced `actions/upload-artifact@v7` using a floating tag instead of a full-length commit SHA:

```yaml
- name: Upload build artifacts
  if: always()
  uses: actions/upload-artifact@v7   # <-- unpinned
```

Nested action references are resolved by the GitHub Actions runner even when the top-level `uses:` is properly SHA-pinned. As a result, any consumer of `oxsecurity/megalinter/flavors/custom-builder@<sha>` running in a repo/org that enforces **"Require actions to be pinned to a full-length commit SHA"** fails at the `Set up job` stage before any step runs:

```
##[error]The action actions/upload-artifact@v7 is not allowed in <owner>/<repo>
because all actions must be pinned to a full-length commit SHA.
```

## Fix

Pin `actions/upload-artifact` to the full-length commit SHA (same pin already used across the repository`s own workflows):

```yaml
uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
```

`043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` corresponds to tag `v7` / `v7.0.1`.

## Notes

This matches the SHA-pinning convention already used in all `.github/workflows/*.yml` files in this repository, and keeps the comment format (`# v7`) consistent so Renovate can continue to manage updates.