### PR TITLE
fix: allow CSS_STYLELINT_COMMAND_REMOVE_ARGUMENTS to remove --config-basedir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Fixes
 
   - Make `test_api_output` resilient to remote server outages: probe several public echo endpoints, run the test with the ones that are up, retry with another server when a post fails, and skip the test when none of them is reachable, as a remote outage is not a MegaLinter issue
+  - Allow `CSS_STYLELINT_COMMAND_REMOVE_ARGUMENTS` to remove `--config-basedir` (which is not added anymore when the user requests its removal or defines its own value in `CSS_STYLELINT_ARGUMENTS`), and stop raising a `ValueError` when an argument listed in `<LINTER>_COMMAND_REMOVE_ARGUMENTS` is not in the command line, fixes [#8552](https://github.com/oxsecurity/megalinter/issues/8552)
   - Treat zero matching SARIF findings as a valid result without logging the entire report, fixes [#8295](https://github.com/oxsecurity/megalinter/issues/8295)
   - Remove invalid SARIF fixes with empty `artifactChanges` arrays before report aggregation, fixes [#8474](https://github.com/oxsecurity/megalinter/issues/8474)
   - Write `REPOSITORY_CHECKOV`'s transient GitHub-config scan directory (`branch_protection_rules.json` and similar) to a hidden `.checkov-github-conf` subfolder of the MegaLinter report folder instead of the repository root, so the artifact stays out of the linted tree (gitignored, excluded from file discovery, and skipped by project-mode linters), extending the earlier ansible-lint race-condition fix (#8092)

--- a/megalinter/Linter.py
+++ b/megalinter/Linter.py
@@ -1519,8 +1519,7 @@ class Linter:
                 cmd.remove("--megalinter-fix-flag")
 
         # Remove arguments at user request
-        for arg in self.cli_command_remove_args:
-            cmd.remove(arg)
+        cmd = self.remove_command_args(cmd)
 
         # Append file in command arguments
         if file is not None:
@@ -1532,6 +1531,21 @@ class Linter:
                 cmd += [self.files_separator.join(self.files)]
             else:
                 cmd += self.files
+        return cmd
+
+    # Remove arguments listed in <LINTER_NAME>_COMMAND_REMOVE_ARGUMENTS.
+    # Arguments that are not in the command line are just ignored, as they can be
+    # conditionally added (or not) by linter subclasses
+    def remove_command_args(self, cmd: list) -> list:
+        for arg in self.cli_command_remove_args:
+            if arg in cmd:
+                cmd.remove(arg)
+            else:
+                logging.debug(
+                    f"[{self.name}] Argument {arg} listed in "
+                    f"{self.name}_COMMAND_REMOVE_ARGUMENTS is not in the command line, "
+                    "so it has not been removed"
+                )
         return cmd
 
     # Manage ignore arguments

--- a/megalinter/linters/StyleLintLinter.py
+++ b/megalinter/linters/StyleLintLinter.py
@@ -8,6 +8,7 @@ import os
 from megalinter import Linter, config
 
 NODE_DEPS_DIR = "/node-deps"
+CONFIG_BASEDIR_ARG = "--config-basedir"
 
 
 class StyleLintLinter(Linter):
@@ -25,8 +26,14 @@ class StyleLintLinter(Linter):
         # which is not on the standard Node.js resolution path when the config file lives
         # elsewhere (e.g. /action/lib/.automation/ or the user's workspace).
         # Passing --config-basedir tells stylelint where to look for extended packages.
-        if os.path.isdir(NODE_DEPS_DIR):
-            cmd += ["--config-basedir", NODE_DEPS_DIR]
+        # Do not add it if the user already defined it in CSS_STYLELINT_ARGUMENTS,
+        # or asked to get rid of it using CSS_STYLELINT_COMMAND_REMOVE_ARGUMENTS
+        if (
+            os.path.isdir(NODE_DEPS_DIR)
+            and CONFIG_BASEDIR_ARG not in cmd
+            and CONFIG_BASEDIR_ARG not in self.cli_command_remove_args
+        ):
+            cmd += [CONFIG_BASEDIR_ARG, NODE_DEPS_DIR]
         return cmd
 
     def pre_test(self, test_name):

--- a/megalinter/tests/test_megalinter/linter_test.py
+++ b/megalinter/tests/test_megalinter/linter_test.py
@@ -6,8 +6,10 @@ Unit tests for Linter class
 
 import unittest
 import uuid
+from unittest import mock
 
 from megalinter.Linter import Linter
+from megalinter.linters.StyleLintLinter import StyleLintLinter
 
 
 class LinterTest(unittest.TestCase):
@@ -101,6 +103,69 @@ class LinterTest(unittest.TestCase):
         replaced_args = linter.replace_vars(args, additional_variables)
 
         self.assertEqual(["test_additional_var"], replaced_args)
+
+    def test_remove_command_args_removes_existing_args(self):
+        linter = Linter.__new__(Linter)
+        linter.name = "CSS_STYLELINT"
+        linter.cli_command_remove_args = ["--formatter", "json"]
+
+        cmd = linter.remove_command_args(
+            ["stylelint", "--formatter", "json", "--config", "conf.json"]
+        )
+
+        self.assertEqual(["stylelint", "--config", "conf.json"], cmd)
+
+    def test_remove_command_args_ignores_missing_args(self):
+        # Missing arguments must not raise ValueError: they can be conditionally
+        # added by linter subclasses after the removal has been performed
+        linter = Linter.__new__(Linter)
+        linter.name = "CSS_STYLELINT"
+        linter.cli_command_remove_args = ["--config-basedir"]
+
+        cmd = linter.remove_command_args(["stylelint", "--config", "conf.json"])
+
+        self.assertEqual(["stylelint", "--config", "conf.json"], cmd)
+
+    def test_stylelint_skips_config_basedir_when_removed_by_user(self):
+        linter = StyleLintLinter.__new__(StyleLintLinter)
+        linter.name = "CSS_STYLELINT"
+        linter.cli_lint_mode = "list_of_files"
+        linter.cli_command_remove_args = ["--config-basedir"]
+
+        with mock.patch.object(
+            Linter, "build_lint_command", return_value=["stylelint"]
+        ), mock.patch("os.path.isdir", return_value=True):
+            cmd = linter.build_lint_command()
+
+        self.assertEqual(["stylelint"], cmd)
+
+    def test_stylelint_adds_config_basedir_by_default(self):
+        linter = StyleLintLinter.__new__(StyleLintLinter)
+        linter.name = "CSS_STYLELINT"
+        linter.cli_lint_mode = "list_of_files"
+        linter.cli_command_remove_args = []
+
+        with mock.patch.object(
+            Linter, "build_lint_command", return_value=["stylelint"]
+        ), mock.patch("os.path.isdir", return_value=True):
+            cmd = linter.build_lint_command()
+
+        self.assertEqual(["stylelint", "--config-basedir", "/node-deps"], cmd)
+
+    def test_stylelint_does_not_duplicate_user_defined_config_basedir(self):
+        linter = StyleLintLinter.__new__(StyleLintLinter)
+        linter.name = "CSS_STYLELINT"
+        linter.cli_lint_mode = "list_of_files"
+        linter.cli_command_remove_args = []
+
+        with mock.patch.object(
+            Linter,
+            "build_lint_command",
+            return_value=["stylelint", "--config-basedir", "/tmp"],
+        ), mock.patch("os.path.isdir", return_value=True):
+            cmd = linter.build_lint_command()
+
+        self.assertEqual(["stylelint", "--config-basedir", "/tmp"], cmd)
 
     def test_sarif_zero_results_is_not_a_warning(self):
         linter = Linter.__new__(Linter)

--- a/megalinter/tests/test_megalinter/linter_test.py
+++ b/megalinter/tests/test_megalinter/linter_test.py
@@ -132,9 +132,10 @@ class LinterTest(unittest.TestCase):
         linter.cli_lint_mode = "list_of_files"
         linter.cli_command_remove_args = ["--config-basedir"]
 
-        with mock.patch.object(
-            Linter, "build_lint_command", return_value=["stylelint"]
-        ), mock.patch("os.path.isdir", return_value=True):
+        with (
+            mock.patch.object(Linter, "build_lint_command", return_value=["stylelint"]),
+            mock.patch("os.path.isdir", return_value=True),
+        ):
             cmd = linter.build_lint_command()
 
         self.assertEqual(["stylelint"], cmd)
@@ -145,9 +146,10 @@ class LinterTest(unittest.TestCase):
         linter.cli_lint_mode = "list_of_files"
         linter.cli_command_remove_args = []
 
-        with mock.patch.object(
-            Linter, "build_lint_command", return_value=["stylelint"]
-        ), mock.patch("os.path.isdir", return_value=True):
+        with (
+            mock.patch.object(Linter, "build_lint_command", return_value=["stylelint"]),
+            mock.patch("os.path.isdir", return_value=True),
+        ):
             cmd = linter.build_lint_command()
 
         self.assertEqual(["stylelint", "--config-basedir", "/node-deps"], cmd)
@@ -158,11 +160,14 @@ class LinterTest(unittest.TestCase):
         linter.cli_lint_mode = "list_of_files"
         linter.cli_command_remove_args = []
 
-        with mock.patch.object(
-            Linter,
-            "build_lint_command",
-            return_value=["stylelint", "--config-basedir", "/tmp"],
-        ), mock.patch("os.path.isdir", return_value=True):
+        with (
+            mock.patch.object(
+                Linter,
+                "build_lint_command",
+                return_value=["stylelint", "--config-basedir", "/tmp"],
+            ),
+            mock.patch("os.path.isdir", return_value=True),
+        ):
             cmd = linter.build_lint_command()
 
         self.assertEqual(["stylelint", "--config-basedir", "/tmp"], cmd)


### PR DESCRIPTION
## Summary

`StyleLintLinter` appended `--config-basedir /node-deps` **after** `super().build_lint_command()` had already applied `<LINTER>_COMMAND_REMOVE_ARGUMENTS`, so `CSS_STYLELINT_COMMAND_REMOVE_ARGUMENTS: --config-basedir` could never remove it — and worse, it crashed with `ValueError: list.remove(x): x not in list` because the base class removal was intolerant of missing arguments.

This PR makes stylelint skip the automatic `--config-basedir` injection when the user asks for its removal (or defines their own value in `CSS_STYLELINT_ARGUMENTS`), and makes `<LINTER>_COMMAND_REMOVE_ARGUMENTS` ignore arguments that are absent from the command line instead of raising.

## Changes

- `megalinter/Linter.py`: extract the removal loop into `remove_command_args()`, which now logs a debug message instead of raising when an argument is not present in the command line
- `megalinter/linters/StyleLintLinter.py`: do not add `--config-basedir /node-deps` when `--config-basedir` is already in the command line (user-defined via `CSS_STYLELINT_ARGUMENTS`) or listed in `CSS_STYLELINT_COMMAND_REMOVE_ARGUMENTS`
- `megalinter/tests/test_megalinter/linter_test.py`: unit tests for both behaviors
- `CHANGELOG.md`: entry under Fixes

## Test plan

- [x] `pytest megalinter/tests/test_megalinter/linter_test.py`
- [ ] CSS_STYLELINT tests in CI (default behavior unchanged: `--config-basedir /node-deps` still added)
- [ ] With `CSS_STYLELINT_COMMAND_REMOVE_ARGUMENTS: --config-basedir`, stylelint runs without `--config-basedir` and without any exception

Fixes https://github.com/oxsecurity/megalinter/issues/8552