### PR TITLE
fix(ci): skip linters manifest merge job when the matrix job is skipped

### DIFF
--- a/.github/workflows/deploy-BETA-linters.yml
+++ b/.github/workflows/deploy-BETA-linters.yml
@@ -241,7 +241,16 @@ jobs:
     needs:
       - get-linters-matrix
       - build
-    if: ${{ !cancelled() && github.repository == 'oxsecurity/megalinter' }}
+    # get-linters-matrix must have succeeded: when it is skipped (BETA linters
+    # disabled), its outputs are empty and `fromJson` below would abort the run.
+    # build must not be skipped either, otherwise there is no digest to merge.
+    if: >-
+      (
+           !cancelled()
+        && github.repository == 'oxsecurity/megalinter'
+        && needs.get-linters-matrix.result == 'success'
+        && needs.build.result != 'skipped'
+      )
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/deploy-RELEASE-linters.yml
+++ b/.github/workflows/deploy-RELEASE-linters.yml
@@ -240,7 +240,16 @@ jobs:
     needs:
       - get-linters-matrix
       - build
-    if: ${{ !cancelled() && github.repository == 'oxsecurity/megalinter' }}
+    # get-linters-matrix must have succeeded: without its outputs, `fromJson`
+    # below would abort the whole run instead of skipping this job.
+    # build must not be skipped either, otherwise there is no digest to merge.
+    if: >-
+      (
+           !cancelled()
+        && github.repository == 'oxsecurity/megalinter'
+        && needs.get-linters-matrix.result == 'success'
+        && needs.build.result != 'skipped'
+      )
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Problem

**Build & Deploy - BETA linters has failed on every one of its last 100 runs**, i.e. continuously since the multi-arch merge job was added in #8247.

The failure is invisible in the usual places: the run has **no failing job** and **no annotation**, and `gh run view --log-failed` returns nothing. Only two jobs appear, both `skipped`.

## Root cause

The repository variable `BETA_LINTERS_ENABLED` is set to `false`, which deliberately disables BETA linter image builds:

- `get-linters-matrix` → skipped (`if: ... vars.BETA_LINTERS_ENABLED != 'false'`)
- `build` (BETA/Linters) → skipped
- `merge` → **still ran**, because it was only gated on `!cancelled() && github.repository == 'oxsecurity/megalinter'`

The merge job then evaluates:

```yaml
matrix:
  linter: ${{ fromJson(needs.get-linters-matrix.outputs.linters) }}
```

A skipped job produces an **empty** output, so `fromJson('')` aborts matrix expansion and fails the run *before any job is created* — which is why the failure carries no logs.

Prior to #8247 there was no `merge` job, so a disabled BETA build simply skipped cleanly.

## Fix

Gate the merge job on the matrix job having actually produced its output:

```yaml
if: >-
  (
       !cancelled()
    && github.repository == 'oxsecurity/megalinter'
    && needs.get-linters-matrix.result == 'success'
    && needs.build.result != 'skipped'
  )
```

- `needs.get-linters-matrix.result == 'success'` — no outputs, no merge.
- `needs.build.result != 'skipped'` — covers the other skip path: a `skip deploy` or `Release MegaLinter v` commit message skips `build`, leaving no digests to assemble.
- `!cancelled()` is preserved, so the manifest is still published when only *some* matrix legs fail (`fail-fast: false`).

`deploy-RELEASE-linters.yml` had the identical unguarded `merge` job, so the same guard is applied there. It is latent rather than firing today (its `get-linters-matrix` has no `if`), but it would take down a release run the same way if that job ever failed.

## Effect

With `BETA_LINTERS_ENABLED=false`, the workflow now reports **skipped/success** instead of a phantom failure. This is purely CI plumbing — it does not re-enable BETA linter builds; flipping the repo variable does that, independently of this change.

## Notes

- No CHANGELOG entry: internal CI only, nothing user-facing.
- Adjacent gap left untouched: if *all* platform builds for one linter fail, `merge` downloads no digests and `printf ...@sha256:%s *` expands to a literal `*`, producing a confusing `invalid reference` error rather than a clear "nothing to merge". Worth a follow-up.
