### PR TITLE
fix(copypaste): declare jscpd as linux/amd64 only

### DIFF
--- a/.automation/generated/linters_matrix.json
+++ b/.automation/generated/linters_matrix.json
@@ -137,7 +137,6 @@
     "c_clang_format",
     "cloudformation_cfn_lint",
     "coffee_coffeelint",
-    "copypaste_jscpd",
     "cpp_cppcheck",
     "cpp_cpplint",
     "cpp_clang_format",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Fix outdated links in `docs/descriptors/repository_kingfisher.md`
   - Fix `LINTER_RULES_PATH` not being used to resolve config files for linters using `active_only_if_file_found` (e.g. `REPOSITORY_LS_LINT`, `SPELL_PROSELINT`, `SPELL_VALE`), fixes [#8416](https://github.com/oxsecurity/megalinter/issues/8416)
   - Honor `EXCLUDED_DIRECTORIES` and `ADDITIONAL_EXCLUDED_DIRECTORIES` in changed-files mode (`VALIDATE_ALL_CODEBASE: false`), so files inside excluded directories are pruned from the `git diff` file list the same way they are during full-codebase validation ([#8360](https://github.com/oxsecurity/megalinter/issues/8360))
+  - Declare `COPYPASTE_JSCPD` as `linux/amd64` only: since jscpd v5 the tool is a Rust binary shipped through per-platform npm packages, and upstream publishes no `linux-arm64-musl` target, so it exits with `Unsupported platform linux/arm64` on the Alpine-based ARM images
 
 - Reporters
 

--- a/megalinter/descriptors/copypaste.megalinter-descriptor.yml
+++ b/megalinter/descriptors/copypaste.megalinter-descriptor.yml
@@ -69,7 +69,10 @@ linters:
           ARG NPM_JSCPD_VERSION=5.0.14
       npm:
         - jscpd@${NPM_JSCPD_VERSION}
+    # jscpd v5 is a Rust binary distributed through per-platform npm packages,
+    # and upstream publishes no linux-arm64-musl target (only linux-arm64-gnu).
+    # On the Alpine base image the wrapper exits with
+    # "jscpd: Unsupported platform linux/arm64", so arm64 is not supported.
     supported_platforms:
       platform:
         - linux/amd64
-        - linux/arm64


### PR DESCRIPTION
## Problem

In [run 30764222764](https://github.com/oxsecurity/megalinter/actions/runs/30764222764) (workflow_dispatch of *Build & Deploy - BETA linters*), exactly one job out of 361 failed: **`BETA/Linters (copypaste_jscpd, linux/arm64)`**. All four tests fail:

```
copypaste_jscpd_test::test_failure_project_lint_mode
copypaste_jscpd_test::test_get_linter_help
copypaste_jscpd_test::test_get_linter_version
copypaste_jscpd_test::test_success_project_lint_mode
```

with the same underlying cause:

```
[jscpd] result: 1 jscpd: Unsupported platform linux/arm64
```

## Root cause

Since **v5**, jscpd is no longer pure JavaScript — it is a Rust binary distributed through per-platform npm optional dependencies. `npm view jscpd@5.0.14 optionalDependencies`:

| target | published |
|---|---|
| `jscpd-darwin-x64` | ✅ |
| `jscpd-darwin-arm64` | ✅ |
| `jscpd-linux-x64-gnu` | ✅ |
| `jscpd-linux-x64-musl` | ✅ |
| `jscpd-linux-arm64-gnu` | ✅ |
| **`jscpd-linux-arm64-musl`** | ❌ **does not exist** |

MegaLinter's base image is `python:3.14-alpine3.24`, i.e. **musl**. jscpd's `platform-map.js` detects libc and requires an exact `os + cpu + libc` match:

```js
if (target.os === "linux" && target.libc !== libc) continue;
```

On arm64 + musl nothing matches, `getPlatformKey()` returns `undefined`, and `run-jscpd.js` exits 1 with `Unsupported platform linux/arm64`. amd64 works only because `linux-x64-musl` is published.

This has been broken since jscpd went to v5 in #8117. It surfaced only now because the workflow was previously failing during matrix expansion (see #8608) and never reached the test step.

## Fix

Drop `linux/arm64` from `supported_platforms` for jscpd, matching the 12 linters that are already amd64-only (`powershell_powershell`, `dart_dartanalyzer`, `clojure_clj_kondo`, the `salesforce_code_analyzer_*` family, …), and regenerate `linters_matrix.json` via `make megalinter-build`.

Alternatives considered and rejected:

- **Pin jscpd v4 on arm64 via `install_override`** — v4.2.5 is the last pure-JS release and would work, but it introduces a permanent major-version skew between architectures plus a second renovate-pinned ARG.
- **Install the `linux-arm64-gnu` binary under Alpine `gcompat`** — could not be validated (no arm64 Docker available here), and running a glibc-linked Rust binary on musl is not something to ship unverified.

## Effect

`copypaste_jscpd` disappears from the `linux/arm64` matrix, so no arm64 standalone image is built, tested or published for it. `linters_matrix.json` loses exactly one entry.

## Note on scope

`supported_platforms` is only consumed by `.automation/build.py` when generating `linters_matrix.json` and the docs table — it does **not** remove the linter from the main and flavor ARM images, which still `npm install` jscpd. ARM users of `megalinter:beta` will therefore still see jscpd fail at runtime. That gap is pre-existing and identical for the other 12 amd64-only linters (there is no runtime platform gating anywhere in `megalinter/`), so it is deliberately left out of this fix.

Separately, that run exposed a publication problem worth its own change: the arm64 image was **pushed and its digest uploaded three steps before the tests ran**, so `BETA/Linters Merge (copypaste_jscpd)` succeeded and published a multi-arch `:beta` manifest containing the known-broken arm64 image. Test and Trivy results currently gate nothing.
