### PR TITLE
Hide internal .claude skills from npx skills add discovery

### DIFF
--- a/.claude/skills/add-flavor/SKILL.md
+++ b/.claude/skills/add-flavor/SKILL.md
@@ -2,8 +2,10 @@
 name: add-flavor
 description: Add a new MegaLinter flavor (language-specific Docker image). Use when creating a new specialized Docker image variant.
 allowed-tools: Read Grep Glob Bash Edit Write
-argument-hint: [flavor-name]
+argument-hint: "[flavor-name]"
 model: sonnet
+metadata:
+  internal: true
 ---
 
 Guide through adding a new flavor named `$ARGUMENTS`.

--- a/.claude/skills/add-linter/SKILL.md
+++ b/.claude/skills/add-linter/SKILL.md
@@ -2,8 +2,10 @@
 name: add-linter
 description: Guided workflow for adding a new linter to MegaLinter. Use when a contributor needs to add support for a new linting tool.
 allowed-tools: Read Grep Glob Bash Edit Write WebSearch WebFetch
-argument-hint: [linter-name]
+argument-hint: "[linter-name]"
 model: sonnet
+metadata:
+  internal: true
 ---
 
 Guide me through adding the linter `$ARGUMENTS` to MegaLinter. If no linter name was provided, ask me for:

--- a/.claude/skills/add-reporter/SKILL.md
+++ b/.claude/skills/add-reporter/SKILL.md
@@ -2,8 +2,10 @@
 name: add-reporter
 description: Add a new output reporter to MegaLinter. Use when adding support for a new CI system or output format.
 allowed-tools: Read Grep Glob Edit Write
-argument-hint: [reporter-name]
+argument-hint: "[reporter-name]"
 model: sonnet
+metadata:
+  internal: true
 ---
 
 Guide through adding a new reporter named `$ARGUMENTS` to MegaLinter.

--- a/.claude/skills/analyze/SKILL.md
+++ b/.claude/skills/analyze/SKILL.md
@@ -5,6 +5,8 @@ disable-model-invocation: true
 allowed-tools: Read Glob Grep WebSearch WebFetch AskUserQuestion
 argument-hint: "[description of the change]"
 model: sonnet
+metadata:
+  internal: true
 ---
 
 You are a requirements analyst for the **MegaLinter** project.

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: build
+description: Run the MegaLinter build system to regenerate Dockerfiles, test classes, docs, and schemas from YAML descriptors.
+allowed-tools: Bash Read
+model: haiku
+metadata:
+  internal: true
+---
+
+Run the MegaLinter build system. Ask what to build if unclear.
+
+## Make Targets
+
+- `make megalinter-build` — regenerate Dockerfiles and test classes from descriptors
+- `make megalinter-build-with-doc` — also regenerate documentation pages
+- `make megalinter-build-custom` — build custom flavor
+
+## Prerequisites
+
+Requires an activated Python venv. If it fails:
+1. Run `make bootstrap` to set up the environment (creates venv, installs deps with uv)
+2. If running `build.sh` manually instead of `make`, activate venv first:
+   - Linux/macOS: `source .venv/bin/activate`
+   - Windows: `source .venv/Scripts/activate`
+
+## Underlying build.py Flags
+
+`.automation/build.py` supports: `--doc`, `--stats`, `--dependents`, `--changelog`, `--release <version>`, `--version <version>`, `--latest`, `--custom-flavor`, `--delete-dockerfiles`, `--delete-test-classes`.
+
+## What Gets Generated
+
+From YAML descriptors, the build creates:
+- `linters/*/Dockerfile` — per-linter Docker images
+- `flavors/*/Dockerfile`, `action.yml`, `flavor.json` — flavor Docker images
+- `megalinter/tests/test_megalinter/linters/*_test.py` — test classes
+- `docs/descriptors/*` — documentation pages
+- `.automation/generated/` — cached linter versions, helps, licenses
+
+## Updating Dockerfile Base Image
+
+If updating the base image in `/Dockerfile`, run `make megalinter-build` and it will propagate to all other Dockerfiles automatically.
+
+## CI Build Commands
+
+Maintainers with write access can comment `/build` on a PR to trigger the build workflow. Use `/help` to see all available PR commands.

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -5,6 +5,8 @@ disable-model-invocation: true
 allowed-tools: Read Glob Grep
 argument-hint: "[additional context]"
 model: opus
+metadata:
+  internal: true
 ---
 
 You are a software architect for the **MegaLinter** project.

--- a/.claude/skills/diagnose-config/SKILL.md
+++ b/.claude/skills/diagnose-config/SKILL.md
@@ -2,8 +2,10 @@
 name: diagnose-config
 description: Diagnose MegaLinter .mega-linter.yml configuration issues. Use when linters aren't running as expected or configuration seems wrong.
 allowed-tools: Read Grep Glob
-argument-hint: [config-file-path]
+argument-hint: "[config-file-path]"
 model: sonnet
+metadata:
+  internal: true
 ---
 
 Diagnose MegaLinter configuration. Read the `.mega-linter.yml` (or path provided in `$ARGUMENTS`) and check for:

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -5,6 +5,8 @@ allowed-tools: Bash Read Grep Glob Edit Write AskUserQuestion WebFetch WebSearch
 argument-hint: "[github issue URL or #number]"
 user-invocable: true
 model: opus
+metadata:
+  internal: true
 ---
 
 Resolve the GitHub issue `$ARGUMENTS` end-to-end.

--- a/.claude/skills/fix-linter-test/SKILL.md
+++ b/.claude/skills/fix-linter-test/SKILL.md
@@ -2,8 +2,10 @@
 name: fix-linter-test
 description: Debug and fix a failing MegaLinter linter test. Use when a linter test fails in CI or locally.
 allowed-tools: Read Grep Glob Bash Edit
-argument-hint: [linter-name-or-test-output]
+argument-hint: "[linter-name-or-test-output]"
 model: sonnet
+metadata:
+  internal: true
 ---
 
 Debug the failing test for `$ARGUMENTS`.

--- a/.claude/skills/fix-security-issue/SKILL.md
+++ b/.claude/skills/fix-security-issue/SKILL.md
@@ -4,6 +4,8 @@ description: Handle CVE/vulnerability reports from security linters (trivy, osv-
 allowed-tools: Read Grep Glob Edit Write Bash WebFetch WebSearch
 argument-hint: "[CVE-ID or vulnerability description]"
 model: opus
+metadata:
+  internal: true
 ---
 
 Investigate and fix the security issue `$ARGUMENTS` reported by trivy, osv-scanner, grype, or another security linter.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -5,6 +5,8 @@ disable-model-invocation: true
 allowed-tools: Read Glob Grep Write Edit Bash WebSearch WebFetch
 argument-hint: "[feature or change to implement]"
 model: sonnet
+metadata:
+  internal: true
 ---
 
 You are a developer working on the **MegaLinter** project.

--- a/.claude/skills/pr-watch-fix-renovate/SKILL.md
+++ b/.claude/skills/pr-watch-fix-renovate/SKILL.md
@@ -5,6 +5,8 @@ allowed-tools: Bash Agent AskUserQuestion Read
 argument-hint: "[optional: specific PR numbers e.g. \"8313 7929\", or a max count]"
 user-invocable: true
 model: sonnet
+metadata:
+  internal: true
 ---
 
 Watch and fix CI for **all open Renovate-bot PRs at once** by fanning out one isolated git-worktree agent per PR. Each agent checks out its PR branch and runs the `/pr-watch-fix` loop independently, so many dependency-update PRs are driven to green (or triaged) in parallel.

--- a/.claude/skills/pr-watch-fix/SKILL.md
+++ b/.claude/skills/pr-watch-fix/SKILL.md
@@ -4,6 +4,8 @@ description: Watch the GitHub PR for the current branch, wait for CI to finish, 
 allowed-tools: Bash Read Grep Glob Edit Write AskUserQuestion Skill
 user-invocable: true
 model: sonnet
+metadata:
+  internal: true
 ---
 
 Watch the open PR for the current branch, wait for CI, and fix failures.

--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -5,6 +5,8 @@ allowed-tools: Bash Read Grep Glob Edit Write AskUserQuestion
 argument-hint: "[vX.Y.Z]"
 user-invocable: true
 model: opus
+metadata:
+  internal: true
 ---
 
 Prepare a MegaLinter release.

--- a/.claude/skills/renovate-rebase/SKILL.md
+++ b/.claude/skills/renovate-rebase/SKILL.md
@@ -5,6 +5,8 @@ allowed-tools: Bash Read
 argument-hint: "[optional: sections e.g. \"open\" or \"rate-limited\", plus --individual / --trigger-run]"
 user-invocable: true
 model: sonnet
+metadata:
+  internal: true
 ---
 
 Force Renovate to act now: find the **Dependency Dashboard** GitHub issue and tick its checkboxes in the **Rate-Limited** and **Open** sections. Renovate watches its own dashboard issue body — a ticked box is an instruction:

--- a/.claude/skills/review-descriptor/SKILL.md
+++ b/.claude/skills/review-descriptor/SKILL.md
@@ -2,8 +2,10 @@
 name: review-descriptor
 description: Audit a linter descriptor YAML for completeness, correctness, and best practices. Checks all properties against the full schema.
 allowed-tools: Read Grep Glob Bash WebSearch WebFetch
-argument-hint: [descriptor-file-or-linter-name]
+argument-hint: "[descriptor-file-or-linter-name]"
 model: sonnet
+metadata:
+  internal: true
 ---
 
 Review the descriptor for `$ARGUMENTS`. If a linter name is given, find its descriptor in `megalinter/descriptors/`.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -5,6 +5,8 @@ disable-model-invocation: true
 allowed-tools: Read Glob Grep Write Edit Bash
 argument-hint: "[linter or test focus]"
 model: sonnet
+metadata:
+  internal: true
 ---
 
 You are a QA engineer for the **MegaLinter** project.

--- a/.claude/skills/update-linter-version/SKILL.md
+++ b/.claude/skills/update-linter-version/SKILL.md
@@ -2,9 +2,11 @@
 name: update-linter-version
 description: Update a linter's pinned version in its descriptor YAML. Use when upgrading a linter tool to a new release.
 allowed-tools: Read Grep Glob Edit Bash
-argument-hint: [linter-name] [new-version]
+argument-hint: "[linter-name] [new-version]"
 arguments: [linter, version]
 model: haiku
+metadata:
+  internal: true
 ---
 
 Update the version of linter `$linter` to `$version`.

--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
+!.claude/skills/build/
 develop-eggs/
 dist/
 downloads/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Dev
 
+  - Mark the repository's internal Claude Code skills (`.claude/skills/`) as `internal` so `npx skills add oxsecurity/megalinter` only offers the four MegaLinter agent skills from the `skills/` folder
+  - Fix the `/build` contribution skill being accidentally gitignored by the `build/` packaging pattern, so it is now actually versioned
+
 - CI
   - Speed up PR jobs by handing the built Docker image over to consumer jobs through ghcr.io (`megalinter-dev` per-commit tags, pruned daily) instead of a workflow artifact + `docker load`, for branches of the main repository; forked PRs keep the artifact-based handoff since their GITHUB_TOKEN cannot push packages. Measured on the "Run against all code base" job: image handoff dropped from 8m42s to 2m36s and the whole job from 14m41s to 7m07s
   - Build only the per-linter Docker images impacted by the changed files of a PR (descriptor edits, per-linter Dockerfiles, single-linter test fixtures); any change to shared code or unrecognized files keeps building the full matrix


### PR DESCRIPTION
`npx skills add oxsecurity/megalinter` scans agent-specific folders including `.claude/skills/`, so it offered the repository's 18 internal contribution skills alongside the 4 MegaLinter agent skills.

## Changes

- Add `metadata: internal: true` to every `.claude/skills/*/SKILL.md` — the [documented mechanism](https://github.com/vercel-labs/skills#optional-fields) to hide a skill from normal discovery (still installable with `INSTALL_INTERNAL_SKILLS=1`). Claude Code ignores the extra frontmatter, so local usage is unchanged.
- Quote bracketed `argument-hint` values that parsed as YAML flow sequences instead of strings (`update-linter-version`'s two-bracket value was outright invalid YAML, reported by the skills CLI scan).
- Fix `.claude/skills/build/` being accidentally gitignored by the generic `build/` packaging pattern — the `/build` skill referenced by CLAUDE.md was never actually versioned; add a negation pattern and commit it.

Verified locally: `npx skills add . --list` now finds exactly 4 skills (megalinter, megalinter-check, megalinter-fix, megalinter-setup) with no YAML warnings.