### PR TITLE
Docs: document per-agent skills install (-a claude-code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,14 +244,16 @@ MegaLinter is designed to work hand in hand with your coding agent:
 
 Install the [MegaLinter agent skills](https://github.com/oxsecurity/megalinter/tree/main/skills) at the root of your repository:
 
-```bash
-npx skills add oxsecurity/megalinter/skills -s '*' -y --copy
-```
-
-This installs the four MegaLinter skills for every coding agent detected on your machine. To install them for a single agent only, target it with `-a` — e.g. for Claude Code, the skills land directly in `.claude/skills/`:
+With **Claude Code** (the skills are copied directly into `.claude/skills/`):
 
 ```bash
 npx skills add oxsecurity/megalinter/skills -s '*' -a claude-code -y
+```
+
+With **another coding agent**, replace `claude-code` with your agent's identifier (`cursor`, `github-copilot`, `codex`, `antigravity`, `opencode`... full list in the [skills CLI documentation](https://github.com/vercel-labs/skills#supported-agents)) — or let the CLI **detect your installed agents** and install the skills for all of them at once:
+
+```bash
+npx skills add oxsecurity/megalinter/skills -s '*' -y --copy
 ```
 
 Then just talk to your agent:
@@ -499,14 +501,16 @@ description: Setup and drive MegaLinter from Claude Code, Cursor, GitHub Copilot
 
 MegaLinter ships [**agent skills**](https://github.com/oxsecurity/megalinter/tree/main/skills) making it easy to drive from coding agents like **Claude Code, Cursor CLI, GitHub Copilot CLI, Codex, Antigravity or OpenCode**:
 
-```bash
-npx skills add oxsecurity/megalinter/skills -s '*' -y --copy
-```
-
-This installs the four MegaLinter skills for every coding agent detected on your machine. To install them for a single agent only, target it with `-a` — e.g. for Claude Code, the skills land directly in `.claude/skills/`:
+With **Claude Code** (the skills are copied directly into `.claude/skills/`):
 
 ```bash
 npx skills add oxsecurity/megalinter/skills -s '*' -a claude-code -y
+```
+
+With **another coding agent**, replace `claude-code` with your agent's identifier (`cursor`, `github-copilot`, `codex`, `antigravity`, `opencode`... full list in the [skills CLI documentation](https://github.com/vercel-labs/skills#supported-agents)) — or let the CLI **detect your installed agents** and install the skills for all of them at once:
+
+```bash
+npx skills add oxsecurity/megalinter/skills -s '*' -y --copy
 ```
 
 Then just ask your agent to _"setup megalinter"_ or _"run megalinter and fix the errors"_. The skills handle:

--- a/README.md
+++ b/README.md
@@ -248,6 +248,12 @@ Install the [MegaLinter agent skills](https://github.com/oxsecurity/megalinter/t
 npx skills add oxsecurity/megalinter/skills -s '*' -y --copy
 ```
 
+This installs the four MegaLinter skills for every coding agent detected on your machine. To install them for a single agent only, target it with `-a` — e.g. for Claude Code, the skills land directly in `.claude/skills/`:
+
+```bash
+npx skills add oxsecurity/megalinter/skills -s '*' -a claude-code -y
+```
+
 Then just talk to your agent:
 
 - _"Setup MegaLinter on this repo"_
@@ -495,6 +501,12 @@ MegaLinter ships [**agent skills**](https://github.com/oxsecurity/megalinter/tre
 
 ```bash
 npx skills add oxsecurity/megalinter/skills -s '*' -y --copy
+```
+
+This installs the four MegaLinter skills for every coding agent detected on your machine. To install them for a single agent only, target it with `-a` — e.g. for Claude Code, the skills land directly in `.claude/skills/`:
+
+```bash
+npx skills add oxsecurity/megalinter/skills -s '*' -a claude-code -y
 ```
 
 Then just ask your agent to _"setup megalinter"_ or _"run megalinter and fix the errors"_. The skills handle:

--- a/docs/coding-agents.md
+++ b/docs/coding-agents.md
@@ -30,14 +30,16 @@ MegaLinter is designed to work hand in hand with your coding agent:
 
 Install the [MegaLinter agent skills](https://github.com/oxsecurity/megalinter/tree/main/skills) at the root of your repository:
 
-```bash
-npx skills add oxsecurity/megalinter/skills -s '*' -y --copy
-```
-
-This installs the four MegaLinter skills for every coding agent detected on your machine. To install them for a single agent only, target it with `-a` — e.g. for Claude Code, the skills land directly in `.claude/skills/`:
+With **Claude Code** (the skills are copied directly into `.claude/skills/`):
 
 ```bash
 npx skills add oxsecurity/megalinter/skills -s '*' -a claude-code -y
+```
+
+With **another coding agent**, replace `claude-code` with your agent's identifier (`cursor`, `github-copilot`, `codex`, `antigravity`, `opencode`... full list in the [skills CLI documentation](https://github.com/vercel-labs/skills#supported-agents)) — or let the CLI **detect your installed agents** and install the skills for all of them at once:
+
+```bash
+npx skills add oxsecurity/megalinter/skills -s '*' -y --copy
 ```
 
 Then just talk to your agent:

--- a/docs/coding-agents.md
+++ b/docs/coding-agents.md
@@ -34,6 +34,12 @@ Install the [MegaLinter agent skills](https://github.com/oxsecurity/megalinter/t
 npx skills add oxsecurity/megalinter/skills -s '*' -y --copy
 ```
 
+This installs the four MegaLinter skills for every coding agent detected on your machine. To install them for a single agent only, target it with `-a` — e.g. for Claude Code, the skills land directly in `.claude/skills/`:
+
+```bash
+npx skills add oxsecurity/megalinter/skills -s '*' -a claude-code -y
+```
+
 Then just talk to your agent:
 
 - _"Setup MegaLinter on this repo"_

--- a/docs/install-agent-skills.md
+++ b/docs/install-agent-skills.md
@@ -10,14 +10,16 @@ description: Setup and drive MegaLinter from Claude Code, Cursor, GitHub Copilot
 
 MegaLinter ships [**agent skills**](https://github.com/oxsecurity/megalinter/tree/main/skills) making it easy to drive from coding agents like **Claude Code, Cursor CLI, GitHub Copilot CLI, Codex, Antigravity or OpenCode**:
 
-```bash
-npx skills add oxsecurity/megalinter/skills -s '*' -y --copy
-```
-
-This installs the four MegaLinter skills for every coding agent detected on your machine. To install them for a single agent only, target it with `-a` — e.g. for Claude Code, the skills land directly in `.claude/skills/`:
+With **Claude Code** (the skills are copied directly into `.claude/skills/`):
 
 ```bash
 npx skills add oxsecurity/megalinter/skills -s '*' -a claude-code -y
+```
+
+With **another coding agent**, replace `claude-code` with your agent's identifier (`cursor`, `github-copilot`, `codex`, `antigravity`, `opencode`... full list in the [skills CLI documentation](https://github.com/vercel-labs/skills#supported-agents)) — or let the CLI **detect your installed agents** and install the skills for all of them at once:
+
+```bash
+npx skills add oxsecurity/megalinter/skills -s '*' -y --copy
 ```
 
 Then just ask your agent to _"setup megalinter"_ or _"run megalinter and fix the errors"_. The skills handle:

--- a/docs/install-agent-skills.md
+++ b/docs/install-agent-skills.md
@@ -14,6 +14,12 @@ MegaLinter ships [**agent skills**](https://github.com/oxsecurity/megalinter/tre
 npx skills add oxsecurity/megalinter/skills -s '*' -y --copy
 ```
 
+This installs the four MegaLinter skills for every coding agent detected on your machine. To install them for a single agent only, target it with `-a` — e.g. for Claude Code, the skills land directly in `.claude/skills/`:
+
+```bash
+npx skills add oxsecurity/megalinter/skills -s '*' -a claude-code -y
+```
+
 Then just ask your agent to _"setup megalinter"_ or _"run megalinter and fix the errors"_. The skills handle:
 
 - **megalinter-setup**: install or upgrade MegaLinter on the repository (non-interactive `npx mega-linter-runner --install`)

--- a/skills/README.md
+++ b/skills/README.md
@@ -8,7 +8,11 @@ Skills that make [MegaLinter](https://megalinter.io/) easy to drive from any cod
 npx skills add oxsecurity/megalinter/skills -s '*' -y --copy
 ```
 
-This installs the skills into your agent's configuration (e.g. `.claude/skills/`, `.cursor/`, `.codex/`).
+This installs the skills into the configuration of every coding agent detected on your machine (e.g. `.claude/skills/`, `.cursor/`, `.codex/`). To install them for a single agent only, target it with `-a` — e.g. for Claude Code, the skills land directly in `.claude/skills/`:
+
+```bash
+npx skills add oxsecurity/megalinter/skills -s '*' -a claude-code -y
+```
 
 ## Skills
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,14 +4,16 @@ Skills that make [MegaLinter](https://megalinter.io/) easy to drive from any cod
 
 ## Installation
 
-```bash
-npx skills add oxsecurity/megalinter/skills -s '*' -y --copy
-```
-
-This installs the skills into the configuration of every coding agent detected on your machine (e.g. `.claude/skills/`, `.cursor/`, `.codex/`). To install them for a single agent only, target it with `-a` — e.g. for Claude Code, the skills land directly in `.claude/skills/`:
+With **Claude Code** (the skills are copied directly into `.claude/skills/`):
 
 ```bash
 npx skills add oxsecurity/megalinter/skills -s '*' -a claude-code -y
+```
+
+With **another coding agent**, replace `claude-code` with your agent's identifier (`cursor`, `github-copilot`, `codex`, `antigravity`, `opencode`... full list in the [skills CLI documentation](https://github.com/vercel-labs/skills#supported-agents)) — or let the CLI **detect your installed agents** and install the skills for all of them at once:
+
+```bash
+npx skills add oxsecurity/megalinter/skills -s '*' -y --copy
 ```
 
 ## Skills

--- a/skills/megalinter-fix/linters/html_djlint.md
+++ b/skills/megalinter-fix/linters/html_djlint.md
@@ -9,7 +9,7 @@
 - Rules index: <https://djlint.com/docs/linter/>
 - Rules configuration: <https://djlint.com/docs/configuration/>
 - How to disable rules inline: <https://djlint.com/docs/ignoring-code/>
-- Error line format (regex): `[A-Z][0-9]{3} `
+- Error line format (regex): `[A-Z][0-9]{3}`
 - MegaLinter tuning variables (in `.mega-linter.yml`):
   - `DISABLE_LINTERS`: add `HTML_DJLINT` to fully disable this linter
   - `HTML_DJLINT_DISABLE_ERRORS: true`: keep the linter active but non-blocking


### PR DESCRIPTION
Add, after each agent-skills install command, the single-agent variant:

```bash
npx skills add oxsecurity/megalinter/skills -s '*' -a claude-code -y
```

With `-a <agent>` the skills CLI copies the skills directly into that agent's folder (`.claude/skills/` for Claude Code) and creates nothing else — no universal `.agents/` folder. Applied to the README (Coding Agents + install sections), docs/coding-agents.md, docs/install-agent-skills.md and skills/README.md.