### PR TITLE
fix(ci): restore NODE_AUTH_TOKEN fallback for mega-linter-runner publish

### DIFF
--- a/.github/workflows/deploy-mega-linter-runner.yml
+++ b/.github/workflows/deploy-mega-linter-runner.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        env:
+          NODE_AUTH_TOKEN: ""
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary
- The mega-linter-runner npm publish workflow was failing at the `Set up Node` step: `error Error: Failed to replace env in config: ${NODE_AUTH_TOKEN}`.
- Root cause: `actions/setup-node` v7 dropped its dummy `NODE_AUTH_TOKEN` export. With `registry-url` set, the action writes an `.npmrc` referencing `${NODE_AUTH_TOKEN}`, and Yarn Classic's `cache: yarn` step (`yarn cache dir`) hard-fails when that env var is undefined (unlike npm, which tolerates it).
- This is unrelated to OIDC trusted publishing — that flow doesn't use `NODE_AUTH_TOKEN` at all.
- Fix: set `NODE_AUTH_TOKEN: ""` as an env var on the `Set up Node` step, restoring the old fallback behavior.

Run that surfaced this: https://github.com/oxsecurity/megalinter/actions/runs/30986324229/job/92241791449

## Test plan
- [ ] Re-run the `Deploy mega-linter-runner` workflow (workflow_dispatch) and confirm `Set up Node` succeeds and `npm publish --provenance` completes via OIDC