### PR TITLE
fix: collapse fully-ignored directories when detecting gitignored files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
     - Suggested exclusions: top-level directories containing only gitignored files (safe: linting scope is unchanged, and project-mode linters stop scanning them), and well-known generated/vendored folder names (`site`, `dist`, `vendor`...) still containing lintable files (to confirm by the user)
     - A lighter matching flavor is also suggested when available
     - The `megalinter-check` agent skill uses it on the first local run to tune `.mega-linter.yml` with the user before the real lint
+    - Fixed a performance issue where detecting `.gitignore`d files enumerated every individual file inside large ignored folders (`node_modules`, build output...) instead of stopping at the folder boundary, which could make the file collection step (including prerun) take several minutes on big repositories
   - **Much lighter Docker images**: the main image download shrinks by **9%**, flavors by **9% to 22%**, and standalone `megalinter-only-*` images are **35% to 65% smaller**
     - If your `PRE_COMMANDS` compile native code: the compilation toolchain is no longer shipped in the images, install it back with `apk add --no-cache gcc make musl-dev`
     - Main and flavor images, compressed download size on ghcr.io, linux/amd64 (before = v9.6.0, so deltas also include the linters removed in this version):

--- a/megalinter/MegaLinter.py
+++ b/megalinter/MegaLinter.py
@@ -1144,6 +1144,7 @@ class Megalinter:
                 "--ignored",
                 "--others",
                 "--cached",
+                "--directory",
                 *pathspec_excludes,
             ]
         ).splitlines()

--- a/megalinter/tests/test_megalinter/mega_linter_files_test.py
+++ b/megalinter/tests/test_megalinter/mega_linter_files_test.py
@@ -2,6 +2,7 @@
 """Tests for MegaLinter file listing helpers."""
 
 import os
+import subprocess
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
@@ -162,6 +163,69 @@ class MegaLinterFilesTest(unittest.TestCase):
             self.assertNotIn("excluded/skip.py", files)
             self.assertNotIn("pkg/excluded/deep.py", files)
             self.assertNotIn("keep/nested_excluded/skip.py", files)
+
+    def test_list_git_ignored_files_collapses_fully_ignored_directories(self):
+        # Regression test: a fully-ignored directory (e.g. node_modules) must
+        # be reported as a single collapsed entry ("dirname/**"), not as one
+        # entry per file. Without `--directory`, git ls-files enumerates every
+        # individual file under a large ignored tree, which is what made
+        # list_git_ignored_files pathologically slow on real-world repos.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            run = lambda *args: subprocess.run(  # noqa: E731
+                ["git", *args], cwd=tmp_dir, check=True, capture_output=True
+            )
+            run("init", "-q")
+            run("config", "user.email", "test@example.com")
+            run("config", "user.name", "Test")
+
+            with open(os.path.join(tmp_dir, ".gitignore"), "w", encoding="utf-8") as f:
+                f.write("node_modules/\nbuild/only_ignored.log\n")
+
+            # Fully-ignored directory: no tracked file anywhere inside it.
+            modules_dir = os.path.join(tmp_dir, "node_modules", "pkg")
+            os.makedirs(modules_dir, exist_ok=True)
+            for i in range(20):
+                with open(
+                    os.path.join(modules_dir, f"file{i}.js"), "w", encoding="utf-8"
+                ):
+                    pass
+
+            # Partially-ignored directory: one tracked file, one ignored file.
+            build_dir = os.path.join(tmp_dir, "build")
+            os.makedirs(build_dir, exist_ok=True)
+            with open(os.path.join(build_dir, "keep.txt"), "w", encoding="utf-8"):
+                pass
+            with open(
+                os.path.join(build_dir, "only_ignored.log"), "w", encoding="utf-8"
+            ):
+                pass
+
+            with open(os.path.join(tmp_dir, "README.md"), "w", encoding="utf-8"):
+                pass
+
+            run("add", "README.md", ".gitignore", "build/keep.txt")
+            run("commit", "-q", "-m", "init")
+
+            ml = Megalinter.__new__(Megalinter)
+            ml.workspace = tmp_dir
+            ml.github_workspace = tmp_dir
+            ml.request_id = "test"
+
+            config.set_config(ml.request_id, {})
+            self.addCleanup(config.delete, ml.request_id)
+
+            with patch("megalinter.utils.get_excluded_directories", return_value=set()):
+                ignored_files = ml.list_git_ignored_files()
+
+            # Collapsed into a single directory entry, not one per file.
+            self.assertIn("node_modules/**", ignored_files)
+            self.assertNotIn("node_modules/pkg/file0.js", ignored_files)
+
+            # A directory that is only partially ignored keeps listing its
+            # individual ignored files instead of being collapsed.
+            self.assertIn("build/only_ignored.log", ignored_files)
+            self.assertNotIn("build/**", ignored_files)
+            self.assertNotIn("build/keep.txt", ignored_files)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`list_git_ignored_files()` runs `git ls-files --ignored --others --exclude-standard` without `--directory`, so a fully gitignored tree (`node_modules`, build output, doc site builds...) gets enumerated one file at a time instead of being reported as a single collapsed directory entry. On real-world repositories this makes the file-collection step - including the prerun analysis mode, whose whole point is to be fast - take minutes instead of seconds.

The post-processing right after the git call already anticipates directory-style entries (it appends `**` to anything ending in `/`), so this looks like a flag that was meant to be there from the start. Adding `--directory` completes that behavior: git now stops descending into a directory as soon as it determines the whole subtree is untracked/ignored, and only enumerates individual files for directories that are partially ignored (a mix of tracked and ignored content), which is exactly the case where per-file granularity is still needed.

Found and reproduced while investigating a slow local prerun run on a real project: plain `git ls-files --ignored --others --cached --exclude-standard` with pathspec excludes hung for 30+ seconds even outside Docker, while the same call with `--directory` returned instantly.

## Test plan

- [x] Added `test_list_git_ignored_files_collapses_fully_ignored_directories` in `mega_linter_files_test.py`: builds a real temp git repo with a fully-ignored directory (collapses to `dirname/**`) and a partially-ignored directory (individual ignored file still listed, tracked sibling file not), asserting both behaviors.
- [x] Ran the full `mega_linter_files_test.py`, `mega_linter_prerun_test.py`, and `filters_test.py` suites - all pass except one pre-existing, unrelated Windows path-separator failure in `test_list_files_all_skips_excluded_directories` (reproduces identically on `main`, untouched by this change).
- [x] `black --check` clean on the touched files.