### PR TITLE
docs: state that custom flavors are AGPL-3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - New **`--timeout <seconds>`** option (`-t`): bound the whole run; on expiration the runner prints the container's last log lines, stops and removes the container (no orphan left behind, even on Windows where killing the CLI process does not stop the container), and exits with code 124
   - **Skip `docker pull`** when the requested version is a pinned release tag (`vX.Y.Z`, immutable) and the image is already available locally, removing a useless registry round-trip
   - Print a hint before mounting the workspace when it contains **well-known heavy folders** (build caches, package stores), pointing at `SKIP_CLI_LINT_MODES=project` to keep local runs fast
+  - **`--custom-flavor-setup`**: the generated README now has a **License** section stating the flavor is covered by **AGPL-3.0**, with a link to the MegaLinter source repository
 
 - Dev
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - **megalinter-setup skill**: after install or upgrade, suggest either running MegaLinter locally or creating a pull request and then watching its CI results with megalinter-check
   - **megalinter-check skill**: the first local run now starts with a `--prerun` analysis, so the user can validate the suggested `.mega-linter.yml` performance tuning before the real lint
   - **megalinter-check skill and watcher/runner sub-agents**: the console tips MegaLinter prints (performance warnings, flavor suggestions, `[Activation]` notices, deprecations) are now extracted from the persisted log file and returned to the calling agent in a `tips` field, instead of being lost when reading only the JSON report
+  - **Custom Flavors**: new [Licensing](https://megalinter.io/beta/custom-flavors/#licensing) section — a custom flavor is still MegaLinter, so your flavor repository and the image it publishes are covered by **AGPL-3.0**. Add an `AGPL-3.0` `LICENSE` file to your flavor repository and keep the link to the MegaLinter source in its README, fixes [#8681](https://github.com/oxsecurity/megalinter/issues/8681)
   - Fix outdated links in `docs/descriptors/repository_kingfisher.md`
 
 - mega-linter-runner

--- a/docs/custom-flavors.md
+++ b/docs/custom-flavors.md
@@ -172,6 +172,19 @@ mega-linter:
   image: ghcr.io/nvuillam/megalinter-custom-flavor-npm-groovy-lint/megalinter-custom-flavor:latest
 ```
 
+## Licensing
+
+**A custom flavor is still MegaLinter, so it is covered by the [AGPL-3.0 license](https://github.com/oxsecurity/megalinter/blob/main/LICENSE).**
+
+This applies both to the files created by the generator in your repository, and to the Docker image you publish, which is built from the official MegaLinter image and bundles MegaLinter itself.
+
+Concretely, when you create a custom flavor repository:
+
+- Add an `AGPL-3.0` `LICENSE` file at the root of your repository
+- Keep the link to the MegaLinter source repository ([oxsecurity/megalinter](https://github.com/oxsecurity/megalinter)) in your README, so users of your image can find the corresponding source
+
+The generated README already contains a **License** section stating this, so you have nothing else to do besides adding the `LICENSE` file.
+
 ## Update your custom flavor
 
 If you add/remove linters in your `mega-linter-flavor.yml`:

--- a/mega-linter-runner/generators/mega-linter-custom-flavor/templates/README.md
+++ b/mega-linter-runner/generators/mega-linter-custom-flavor/templates/README.md
@@ -73,4 +73,10 @@ Follow [MegaLinter installation guide](https://megalinter.io/latest/install-assi
 - **GitHub Action**: On MegaLinter step in `.github/workflows/mega-linter.yml`, define `uses: <%= CUSTOM_FLAVOR_GITHUB_ACTION %>@main`
 - **Docker image**: Replace official MegaLinter image with `<%= DOCKER_IMAGE_VERSION %>`
 
+## License
+
+A MegaLinter custom flavor is still MegaLinter: this repository and the Docker image it publishes are covered by the [AGPL-3.0 license](https://github.com/oxsecurity/megalinter/blob/main/LICENSE).
+
+The published image is built from the official MegaLinter image and bundles MegaLinter, whose source is available at [oxsecurity/megalinter](https://github.com/oxsecurity/megalinter).
+
 [![MegaLinter is graciously provided by OX Security](https://raw.githubusercontent.com/oxsecurity/megalinter/main/docs/assets/images/ox-banner.png)](https://www.ox.security/?ref=megalinter)


### PR DESCRIPTION
## Summary

Documents the licence that applies to MegaLinter custom flavors, as confirmed by @nvuillam in #8681:

> MegaLinter custom flavors are still MegaLinter, so are AGPLV3 :)

Fixes #8681

## Changes

**1. `docs/custom-flavors.md` — new "Licensing" section** (what the issue asked for)

States that a custom flavor is still MegaLinter and is therefore covered by AGPL-3.0 — both the generated scaffolding and the published Docker image, which is built from the official MegaLinter image. It then tells the flavor author what to actually do: add an `AGPL-3.0` `LICENSE` file, and keep the link to the MegaLinter source repository in the README.

**2. `mega-linter-runner` custom flavor generator — "License" section in the generated README** (scope expansion, please review on its own merits)

The issue asked only for the docs page, so this second part goes beyond it and I want to be explicit about why I added it rather than slipping it in:

- The point raised in the issue was that *"most flavor authors haven't thought about it at all"*. Someone who never wondered about the licence will not go looking for a Licensing section in the docs — but they do read the README the generator drops in their repository. Putting the statement there is what actually reaches the people the issue is about.
- Surveying existing flavor repos, most carry no licence file at all and a couple use CC0-1.0, i.e. the opposite of the intent confirmed above. A default that states the answer in-place fixes that going forward, whereas a docs-only change only helps authors who already suspected there was a question.
- It keeps the two places consistent: the docs section explicitly says the generated README already contains this statement, so an author has nothing to do beyond adding the `LICENSE` file.

**The two changes are in separate commits**, so if you would rather keep this strictly to the docs page, the second commit can be dropped without touching the first.

## Testing

- Docs-only for commit 1.
- Commit 2 adds static markdown to the EJS template with no new template variables, so generator rendering is unaffected; `test/custom-flavor-generator.test.js` asserts README existence and the `CUSTOM_FLAVOR_LABEL` / repo URL substitutions, none of which this touches. I did not run the runner test suite locally (no `node_modules` in my checkout) — flagging that rather than implying I did.

## Note on wording

I have deliberately kept the wording to a statement of the project's intent plus the two concrete steps, and avoided anything that reads as legal advice. Happy to reword either section however you prefer.
