### PR TITLE
Refresh MegaLinter references in linter descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 
 - Doc
   - New **Docker pulls per month** graph, showing the growth of MegaLinter adoption since October 2020, displayed in the README and on the [Flavors statistics](https://megalinter.io/latest/flavors-stats/) page
+  - Refreshed the **MegaLinter references in linters documentation** (`linter_megalinter_ref_url`): verified all existing links, updated moved pages (ktlint, robocop, csharpier, zizmor, ruff, proselint), and opened 47 suggestion PRs on linters repositories that did not mention MegaLinter yet
 
 - mega-linter-runner
 

--- a/megalinter/descriptors/action.megalinter-descriptor.yml
+++ b/megalinter/descriptors/action.megalinter-descriptor.yml
@@ -24,6 +24,7 @@ linters:
       - **Advanced Validations**: Includes glob syntax validation, dependency checks for `needs:`, runner label validation, and cron syntax validation
     linter_url: https://rhysd.github.io/actionlint/
     linter_repo: https://github.com/rhysd/actionlint
+    linter_megalinter_ref_url: https://github.com/rhysd/actionlint/pull/722
     linter_rules_configuration_url: https://github.com/rhysd/actionlint/blob/main/docs/config.md
     linter_spdx_license: MIT
     files_sub_directory: .github/workflows
@@ -83,6 +84,7 @@ linters:
       > ```
     linter_url: https://zizmor.sh/
     linter_repo: https://github.com/zizmorcore/zizmor
+    linter_megalinter_ref_url: https://docs.zizmor.sh/integrations/
     linter_image_url: https://docs.zizmor.sh/assets/rainbow.svg
     linter_rules_url: https://docs.zizmor.sh/audits/
     linter_rules_configuration_url: https://docs.zizmor.sh/configuration/

--- a/megalinter/descriptors/ansible.megalinter-descriptor.yml
+++ b/megalinter/descriptors/ansible.megalinter-descriptor.yml
@@ -40,6 +40,7 @@ linters:
     can_output_sarif: true
     linter_url: https://ansible-lint.readthedocs.io/
     linter_repo: https://github.com/ansible/ansible-lint
+    linter_megalinter_ref_url: https://github.com/ansible/ansible-lint/pull/5144
     linter_spdx_license: GPL-3.0-only
     linter_rules_url: https://ansible-lint.readthedocs.io/rules/
     linter_rules_configuration_url: https://ansible-lint.readthedocs.io/configuring/#configuration-file

--- a/megalinter/descriptors/arm.megalinter-descriptor.yml
+++ b/megalinter/descriptors/arm.megalinter-descriptor.yml
@@ -47,6 +47,7 @@ linters:
       ARM TTK helps ensure your ARM templates are secure, maintainable, and follow Azure best practices for infrastructure as code.
     linter_url: https://github.com/Azure/arm-ttk
     linter_repo: https://github.com/Azure/arm-ttk
+    linter_megalinter_ref_url: https://github.com/Azure/arm-ttk/pull/802
     linter_rules_configuration_url: https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/test-toolkit#customize-tests
     linter_spdx_license: MIT
     config_file_name: .arm-ttk.psd1

--- a/megalinter/descriptors/bicep.megalinter-descriptor.yml
+++ b/megalinter/descriptors/bicep.megalinter-descriptor.yml
@@ -36,6 +36,7 @@ linters:
 
       By default, Bicep linter errors are set as warnings. To customize linter settings, use a `bicepconfig.json` file. For more information, see the [documentation for the Bicep Linter](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-config-linter#customize-linter)
     linter_repo: https://github.com/Azure/bicep
+    linter_megalinter_ref_url: https://github.com/Azure/bicep/pull/20157
     linter_rules_configuration_url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-config
     linter_rules_inline_disable_url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/linter#silencing-false-positives
     linter_rules_url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/linter#default-rules

--- a/megalinter/descriptors/c.megalinter-descriptor.yml
+++ b/megalinter/descriptors/c.megalinter-descriptor.yml
@@ -37,6 +37,7 @@ linters:
     name: C_CPPCHECK
     linter_url: https://cppcheck.sourceforge.io/
     linter_repo: https://cppcheck.sourceforge.io/
+    linter_megalinter_ref_url: https://github.com/cppcheck-opensource/cppcheck/pull/8786
     linter_spdx_license: GPL-3.0
     linter_rules_url: https://sourceforge.net/p/cppcheck/wiki/ListOfChecks/
     linter_rules_configuration_url: https://cppcheck.sourceforge.io/manual.html#configuration
@@ -89,6 +90,7 @@ linters:
     name: C_CPPLINT
     linter_url: https://github.com/cpplint/cpplint
     linter_repo: https://github.com/cpplint/cpplint
+    linter_megalinter_ref_url: https://github.com/cpplint/cpplint/pull/462
     linter_spdx_license: BSD-3-Clause
     linter_rules_url: https://google.github.io/styleguide/cppguide.html
     cli_lint_mode: list_of_files

--- a/megalinter/descriptors/clojure.megalinter-descriptor.yml
+++ b/megalinter/descriptors/clojure.megalinter-descriptor.yml
@@ -103,7 +103,7 @@ linters:
     # linter_banner_image_url: https://github.com/borkdude/clj-kondo/raw/master/logo/logo-300dpi.png
     linter_rules_configuration_url: https://github.com/greglook/cljstyle/blob/main/doc/configuration.md#format-rules
     linter_rules_inline_disable_url: https://github.com/greglook/cljstyle#ignoring-forms
-    linter_megalinter_ref_url: https://github.com/greglook/cljstyle/blob/main/doc/integrations.md
+    linter_megalinter_ref_url: https://github.com/greglook/cljstyle/pull/118
     config_file_name: .cljstyle
     cli_config_arg_name: ""
     cli_lint_mode: list_of_files

--- a/megalinter/descriptors/cloudformation.megalinter-descriptor.yml
+++ b/megalinter/descriptors/cloudformation.megalinter-descriptor.yml
@@ -48,6 +48,7 @@ linters:
     can_output_sarif: true
     linter_url: https://github.com/aws-cloudformation/cfn-lint
     linter_repo: https://github.com/aws-cloudformation/cfn-lint
+    linter_megalinter_ref_url: https://github.com/aws-cloudformation/cfn-lint/pull/4619
     linter_spdx_license: MIT-0
     linter_rules_url: https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/rules.md
     linter_rules_configuration_url: https://github.com/aws-cloudformation/cfn-lint#configuration

--- a/megalinter/descriptors/cpp.megalinter-descriptor.yml
+++ b/megalinter/descriptors/cpp.megalinter-descriptor.yml
@@ -37,6 +37,7 @@ linters:
     name: CPP_CPPCHECK
     linter_url: https://cppcheck.sourceforge.io/
     linter_repo: https://cppcheck.sourceforge.io/
+    linter_megalinter_ref_url: https://github.com/cppcheck-opensource/cppcheck/pull/8786
     linter_spdx_license: GPL-3.0
     linter_rules_url: https://sourceforge.net/p/cppcheck/wiki/ListOfChecks/
     linter_rules_configuration_url: https://cppcheck.sourceforge.io/manual.html#configuration
@@ -80,6 +81,7 @@ linters:
     name: CPP_CPPLINT
     linter_url: https://github.com/cpplint/cpplint
     linter_repo: https://github.com/cpplint/cpplint
+    linter_megalinter_ref_url: https://github.com/cpplint/cpplint/pull/462
     linter_spdx_license: BSD-3-Clause
     linter_rules_url: https://google.github.io/styleguide/cppguide.html
     cli_lint_mode: list_of_files

--- a/megalinter/descriptors/csharp.megalinter-descriptor.yml
+++ b/megalinter/descriptors/csharp.megalinter-descriptor.yml
@@ -82,6 +82,7 @@ linters:
     is_formatter: true
     linter_url: https://csharpier.com/
     linter_repo: https://github.com/belav/csharpier
+    linter_megalinter_ref_url: https://csharpier.com/docs/Pre-commit#megalinter
     linter_spdx_license: MIT
     linter_image_url: https://csharpier.com/img/logo.svg
     linter_rules_configuration_url: https://csharpier.com/docs/Configuration
@@ -156,6 +157,7 @@ linters:
     is_formatter: true
     linter_url: https://github.com/dotnet/Roslynator
     linter_repo: https://github.com/dotnet/Roslynator
+    linter_megalinter_ref_url: https://github.com/dotnet/roslynator/pull/1788
     linter_spdx_license: Apache-2.0
     linter_image_url: https://github.com/dotnet/roslynator/raw/main/images/roslynator-logo-small.png
     linter_rules_url: https://josefpihrt.github.io/docs/roslynator/analyzers

--- a/megalinter/descriptors/csharp.megalinter-descriptor.yml
+++ b/megalinter/descriptors/csharp.megalinter-descriptor.yml
@@ -157,7 +157,7 @@ linters:
     is_formatter: true
     linter_url: https://github.com/dotnet/Roslynator
     linter_repo: https://github.com/dotnet/Roslynator
-    linter_megalinter_ref_url: https://github.com/dotnet/roslynator#readme
+    linter_megalinter_ref_url: https://github.com/dotnet/roslynator#command-line-tool
     linter_spdx_license: Apache-2.0
     linter_image_url: https://github.com/dotnet/roslynator/raw/main/images/roslynator-logo-small.png
     linter_rules_url: https://josefpihrt.github.io/docs/roslynator/analyzers

--- a/megalinter/descriptors/csharp.megalinter-descriptor.yml
+++ b/megalinter/descriptors/csharp.megalinter-descriptor.yml
@@ -157,7 +157,7 @@ linters:
     is_formatter: true
     linter_url: https://github.com/dotnet/Roslynator
     linter_repo: https://github.com/dotnet/Roslynator
-    linter_megalinter_ref_url: https://github.com/dotnet/roslynator/pull/1788
+    linter_megalinter_ref_url: https://github.com/dotnet/roslynator#readme
     linter_spdx_license: Apache-2.0
     linter_image_url: https://github.com/dotnet/roslynator/raw/main/images/roslynator-logo-small.png
     linter_rules_url: https://josefpihrt.github.io/docs/roslynator/analyzers

--- a/megalinter/descriptors/gherkin.megalinter-descriptor.yml
+++ b/megalinter/descriptors/gherkin.megalinter-descriptor.yml
@@ -31,6 +31,7 @@ linters:
       - **Step definition validation** to ensure proper Given/When/Then structure
     linter_url: https://github.com/gherkin-lint/gherkin-lint
     linter_repo: https://github.com/gherkin-lint/gherkin-lint
+    linter_megalinter_ref_url: https://github.com/gherkin-lint/gherkin-lint/pull/352
     linter_spdx_license: ISC
     linter_rules_url: https://github.com/gherkin-lint/gherkin-lint#available-rules
     linter_rules_configuration_url: https://github.com/gherkin-lint/gherkin-lint#rule-configuration

--- a/megalinter/descriptors/go.megalinter-descriptor.yml
+++ b/megalinter/descriptors/go.megalinter-descriptor.yml
@@ -174,7 +174,7 @@ linters:
     linter_spdx_license: MIT
     linter_url: https://revive.run/
     linter_repo: https://github.com/mgechev/revive
-    linter_megalinter_ref_url: https://github.com/mgechev/revive#readme
+    linter_megalinter_ref_url: https://github.com/mgechev/revive#megalinter
     linter_rules_url: https://revive.run/r
     linter_image_url: https://github.com/mgechev/revive/raw/master/assets/logo.png
     linter_rules_configuration_url: https://revive.run/docs#custom-configuration

--- a/megalinter/descriptors/go.megalinter-descriptor.yml
+++ b/megalinter/descriptors/go.megalinter-descriptor.yml
@@ -174,7 +174,7 @@ linters:
     linter_spdx_license: MIT
     linter_url: https://revive.run/
     linter_repo: https://github.com/mgechev/revive
-    linter_megalinter_ref_url: https://github.com/mgechev/revive/pull/1765
+    linter_megalinter_ref_url: https://github.com/mgechev/revive#readme
     linter_rules_url: https://revive.run/r
     linter_image_url: https://github.com/mgechev/revive/raw/master/assets/logo.png
     linter_rules_configuration_url: https://revive.run/docs#custom-configuration

--- a/megalinter/descriptors/go.megalinter-descriptor.yml
+++ b/megalinter/descriptors/go.megalinter-descriptor.yml
@@ -174,6 +174,7 @@ linters:
     linter_spdx_license: MIT
     linter_url: https://revive.run/
     linter_repo: https://github.com/mgechev/revive
+    linter_megalinter_ref_url: https://github.com/mgechev/revive/pull/1765
     linter_rules_url: https://revive.run/r
     linter_image_url: https://github.com/mgechev/revive/raw/master/assets/logo.png
     linter_rules_configuration_url: https://revive.run/docs#custom-configuration

--- a/megalinter/descriptors/javascript.megalinter-descriptor.yml
+++ b/megalinter/descriptors/javascript.megalinter-descriptor.yml
@@ -299,6 +299,7 @@ linters:
         default_value: standard
     linter_url: https://standardjs.com/
     linter_repo: https://github.com/standard/standard
+    linter_megalinter_ref_url: https://github.com/standard/standard/pull/1997
     linter_rules_url: https://standardjs.com/rules.html
     linter_rules_configuration_url: https://standardjs.com/#how-do-i-ignore-files
     linter_rules_inline_disable_url: https://standardjs.com/#how-do-i-disable-a-rule
@@ -366,6 +367,7 @@ linters:
         default_value: standard
     linter_url: https://prettier.io/
     linter_repo: https://github.com/prettier/prettier
+    linter_megalinter_ref_url: https://github.com/prettier/prettier/pull/19818
     linter_rules_url: https://prettier.io/docs/en/options.html
     linter_rules_configuration_url: https://prettier.io/docs/en/configuration.html
     linter_rules_inline_disable_url: https://prettier.io/docs/en/ignore.html#javascript

--- a/megalinter/descriptors/json.megalinter-descriptor.yml
+++ b/megalinter/descriptors/json.megalinter-descriptor.yml
@@ -26,6 +26,7 @@ linters:
       - **Cross-Platform**: Consistent validation behavior across Windows, macOS, and Linux environments
     linter_url: https://github.com/prantlf/jsonlint
     linter_repo: https://github.com/prantlf/jsonlint
+    linter_megalinter_ref_url: https://github.com/prantlf/jsonlint/pull/45
     linter_spdx_license: MIT
     linter_rules_url: https://github.com/prantlf/jsonlint#configuration
     linter_rules_configuration_url: https://github.com/prantlf/jsonlint#configuration
@@ -144,6 +145,7 @@ linters:
     is_formatter: true
     linter_url: https://prettier.io/
     linter_repo: https://github.com/prettier/prettier
+    linter_megalinter_ref_url: https://github.com/prettier/prettier/pull/19818
     linter_spdx_license: MIT
     linter_rules_url: https://prettier.io/docs/en/options.html
     linter_rules_configuration_url: https://prettier.io/docs/en/configuration.html

--- a/megalinter/descriptors/kotlin.megalinter-descriptor.yml
+++ b/megalinter/descriptors/kotlin.megalinter-descriptor.yml
@@ -37,7 +37,7 @@ linters:
     linter_rules_configuration_url: https://pinterest.github.io/ktlint/latest/rules/configuration-ktlint/
     linter_rules_inline_disable_url: https://pinterest.github.io/ktlint/latest/faq/#how-do-i-suppress-errors-for-a-lineblockfile
     linter_banner_image_url: https://miro.medium.com/max/655/1*sLboL6JnC9yUodFsdSMB-w.png
-    linter_megalinter_ref_url: https://github.com/pinterest/ktlint#-with-continuous-integration
+    linter_megalinter_ref_url: https://ktlint.github.io/ktlint/latest/install/integrations/
     cli_lint_fix_arg_name: "--format"
     cli_lint_mode: list_of_files
     supported_cli_lint_modes:
@@ -118,7 +118,7 @@ linters:
     linter_rules_configuration_url: https://detekt.dev/configurations.html
     linter_rules_inline_disable_url: https://detekt.dev/suppressing-rules.html
     linter_banner_image_url: https://repository-images.githubusercontent.com/71729669/8b793230-5d85-4c36-b72e-6911dd7bf6d3
-    linter_megalinter_ref_url: https://detekt.dev/docs/intro
+    linter_megalinter_ref_url: https://github.com/detekt/detekt/pull/9586
     config_file_name: detekt-config.yml
     cli_executable: detekt-cli
     cli_lint_mode: project

--- a/megalinter/descriptors/kubernetes.megalinter-descriptor.yml
+++ b/megalinter/descriptors/kubernetes.megalinter-descriptor.yml
@@ -20,6 +20,7 @@ linters:
     linter_name: kubeconform
     name: KUBERNETES_KUBECONFORM
     linter_repo: https://github.com/yannh/kubeconform
+    linter_megalinter_ref_url: https://github.com/yannh/kubeconform/pull/202
     linter_url: https://github.com/yannh/kubeconform
     linter_spdx_license: Apache-2.0
     linter_rules_configuration_url: https://github.com/yannh/kubeconform#usage
@@ -167,6 +168,7 @@ linters:
     can_output_sarif: true
     files_sub_directory: ""
     linter_repo: https://github.com/kubescape/kubescape
+    linter_megalinter_ref_url: https://github.com/kubescape/kubescape/pull/2859
     linter_url: https://github.com/kubescape/kubescape
     linter_text: |
       **Kubescape** is a comprehensive Kubernetes security scanner that examines charts and Kubernetes files for security vulnerabilities, misconfigurations, and compliance violations. It provides security analysis based on established frameworks and best practices.

--- a/megalinter/descriptors/markdown.megalinter-descriptor.yml
+++ b/megalinter/descriptors/markdown.megalinter-descriptor.yml
@@ -102,6 +102,7 @@ linters:
       - **Standards Compliance**: Ensures tables follow Markdown table formatting best practices and conventions
     linter_url: https://www.npmjs.com/package/markdown-table-formatter
     linter_repo: https://github.com/nvuillam/markdown-table-formatter
+    linter_megalinter_ref_url: https://github.com/nvuillam/markdown-table-formatter#readme
     linter_spdx_license: MIT
     linter_rules_configuration_url: https://github.com/nvuillam/markdown-table-formatter#options
     linter_rules_inline_disable_url: https://github.com/nvuillam/markdown-table-formatter#ignoring-code-blocks
@@ -160,6 +161,7 @@ linters:
       - CI/CD friendly with non-zero exit code on errors
     linter_url: https://github.com/rvben/rumdl
     linter_repo: https://github.com/rvben/rumdl
+    linter_megalinter_ref_url: https://github.com/rvben/rumdl/pull/803
     linter_spdx_license: MIT
     linter_rules_url: https://github.com/rvben/rumdl/blob/main/docs/RULES.md
     linter_rules_configuration_url: https://github.com/rvben/rumdl/blob/main/docs/global-settings.md

--- a/megalinter/descriptors/perl.megalinter-descriptor.yml
+++ b/megalinter/descriptors/perl.megalinter-descriptor.yml
@@ -36,6 +36,7 @@ linters:
       - **Flexible Configuration**: Project-specific configuration files for team-wide standards enforcement
     linter_url: https://metacpan.org/pod/Perl::Critic
     linter_repo: https://github.com/Perl-Critic/Perl-Critic
+    linter_megalinter_ref_url: https://github.com/Perl-Critic/Perl-Critic/pull/1110
     linter_spdx_license: Artistic-1.0-Perl OR GPL-1.0-or-later
     linter_rules_url: https://metacpan.org/pod/Perl::Critic#THE-POLICIES
     linter_banner_image_url: https://chrisdolan.net/madmongers/images/perl-critic-logo.gif

--- a/megalinter/descriptors/php.megalinter-descriptor.yml
+++ b/megalinter/descriptors/php.megalinter-descriptor.yml
@@ -309,7 +309,7 @@ linters:
     can_output_sarif: true
     linter_url: https://github.com/overtrue/phplint
     linter_repo: https://github.com/overtrue/phplint
-    linter_megalinter_ref_url: https://github.com/overtrue/phplint/pull/247
+    linter_megalinter_ref_url: https://github.com/overtrue/phplint#readme
     linter_spdx_license: MIT
     linter_rules_configuration_url: https://github.com/overtrue/phplint/blob/main/docs/configuration.md#configuration
     config_file_name: .phplint.yml

--- a/megalinter/descriptors/php.megalinter-descriptor.yml
+++ b/megalinter/descriptors/php.megalinter-descriptor.yml
@@ -309,7 +309,7 @@ linters:
     can_output_sarif: true
     linter_url: https://github.com/overtrue/phplint
     linter_repo: https://github.com/overtrue/phplint
-    linter_megalinter_ref_url: https://github.com/overtrue/phplint#readme
+    linter_megalinter_ref_url: https://github.com/overtrue/phplint#run-it-with-megalinter
     linter_spdx_license: MIT
     linter_rules_configuration_url: https://github.com/overtrue/phplint/blob/main/docs/configuration.md#configuration
     config_file_name: .phplint.yml

--- a/megalinter/descriptors/php.megalinter-descriptor.yml
+++ b/megalinter/descriptors/php.megalinter-descriptor.yml
@@ -142,7 +142,7 @@ linters:
     linter_spdx_license: MIT
     linter_url: https://phpstan.org/
     linter_repo: https://github.com/phpstan/phpstan
-    linter_megalinter_ref_url: https://github.com/phpstan/phpstan/pull/15062
+    linter_megalinter_ref_url: no
     linter_image_url: https://i.imgur.com/WaRKPlC.png
     linter_rules_configuration_url: https://phpstan.org/config-reference#neon-format
     linter_rules_inline_disable_url: https://phpstan.org/user-guide/ignoring-errors#ignoring-in-code-using-phpdocs

--- a/megalinter/descriptors/php.megalinter-descriptor.yml
+++ b/megalinter/descriptors/php.megalinter-descriptor.yml
@@ -142,6 +142,7 @@ linters:
     linter_spdx_license: MIT
     linter_url: https://phpstan.org/
     linter_repo: https://github.com/phpstan/phpstan
+    linter_megalinter_ref_url: https://github.com/phpstan/phpstan/pull/15062
     linter_image_url: https://i.imgur.com/WaRKPlC.png
     linter_rules_configuration_url: https://phpstan.org/config-reference#neon-format
     linter_rules_inline_disable_url: https://phpstan.org/user-guide/ignoring-errors#ignoring-in-code-using-phpdocs
@@ -228,6 +229,7 @@ linters:
     linter_spdx_license: MIT
     linter_url: https://psalm.dev
     linter_repo: https://github.com/vimeo/psalm
+    linter_megalinter_ref_url: https://github.com/vimeo/psalm/pull/11918
     linter_rules_url: https://psalm.dev/docs/running_psalm/issues/
     linter_banner_image_url: https://i1.wp.com/phpmagazine.net/wp-content/uploads/2018/12/PsalmLogo.png?w=653&ssl=1
     linter_rules_configuration_url: https://psalm.dev/docs/running_psalm/configuration/
@@ -307,6 +309,7 @@ linters:
     can_output_sarif: true
     linter_url: https://github.com/overtrue/phplint
     linter_repo: https://github.com/overtrue/phplint
+    linter_megalinter_ref_url: https://github.com/overtrue/phplint/pull/247
     linter_spdx_license: MIT
     linter_rules_configuration_url: https://github.com/overtrue/phplint/blob/main/docs/configuration.md#configuration
     config_file_name: .phplint.yml
@@ -362,6 +365,7 @@ linters:
       - Add "--allow-risky=yes" option in PHP_PHPCSFIXER_ARGUMENTS variable
     linter_url: https://cs.symfony.com/
     linter_repo: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer
+    linter_megalinter_ref_url: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9771
     linter_spdx_license: MIT
     linter_rules_url: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/index.rst
     linter_rules_configuration_url: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/config.rst

--- a/megalinter/descriptors/powershell.megalinter-descriptor.yml
+++ b/megalinter/descriptors/powershell.megalinter-descriptor.yml
@@ -53,6 +53,7 @@ linters:
       - **Diagnostic Reporting**: Comprehensive reports with file locations, rule descriptions, and remediation suggestions
     linter_url: https://github.com/PowerShell/PSScriptAnalyzer
     linter_repo: https://github.com/PowerShell/PSScriptAnalyzer
+    linter_megalinter_ref_url: https://github.com/PowerShell/PSScriptAnalyzer/pull/2203
     linter_image_url: https://raw.githubusercontent.com/PowerShell/PSScriptAnalyzer/refs/heads/main/logo.png
     linter_rules_url: https://learn.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/rules/readme?view=ps-modules
     linter_rules_configuration_url: https://learn.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/using-scriptanalyzer?view=ps-modules#explicit
@@ -107,6 +108,7 @@ linters:
     is_formatter: true
     linter_url: https://github.com/PowerShell/PSScriptAnalyzer
     linter_repo: https://github.com/PowerShell/PSScriptAnalyzer
+    linter_megalinter_ref_url: https://github.com/PowerShell/PSScriptAnalyzer/pull/2203
     linter_image_url: https://raw.githubusercontent.com/PowerShell/PSScriptAnalyzer/refs/heads/main/logo.png
     linter_rules_url: https://learn.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/rules/readme?view=ps-modules
     linter_rules_configuration_url: https://learn.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/using-scriptanalyzer?view=ps-modules#explicit

--- a/megalinter/descriptors/protobuf.megalinter-descriptor.yml
+++ b/megalinter/descriptors/protobuf.megalinter-descriptor.yml
@@ -24,6 +24,7 @@ linters:
       - **Configuration Flexibility**: YAML-based configuration for team-specific linting preferences
     linter_url: https://github.com/yoheimuta/protolint
     linter_repo: https://github.com/yoheimuta/protolint
+    linter_megalinter_ref_url: https://github.com/yoheimuta/protolint/pull/559
     linter_rules_url: https://github.com/yoheimuta/protolint#rules
     linter_rules_configuration_url: https://github.com/yoheimuta/protolint#rules
     linter_rules_inline_disable_url: https://github.com/yoheimuta/protolint#configuring

--- a/megalinter/descriptors/python.megalinter-descriptor.yml
+++ b/megalinter/descriptors/python.megalinter-descriptor.yml
@@ -49,6 +49,7 @@ linters:
     name: PYTHON_PYLINT
     linter_url: https://pylint.readthedocs.io
     linter_repo: https://github.com/pylint-dev/pylint
+    linter_megalinter_ref_url: https://github.com/pylint-dev/pylint/pull/11237
     linter_spdx_license: GPL-2.0
     linter_speed: 2
     linter_rules_url: https://pylint.readthedocs.io/en/stable/user_guide/messages/index.html
@@ -178,6 +179,7 @@ linters:
         default_value: black
     linter_url: https://black.readthedocs.io/en/stable/
     linter_repo: https://github.com/psf/black
+    linter_megalinter_ref_url: no
     linter_spdx_license: MIT
     linter_speed: 3
     linter_banner_image_url: https://raw.githubusercontent.com/psf/black/master/docs/_static/logo2-readme.png
@@ -333,6 +335,7 @@ linters:
     is_formatter: true
     linter_url: https://pycqa.github.io/isort/
     linter_repo: https://github.com/PyCQA/isort
+    linter_megalinter_ref_url: https://github.com/PyCQA/isort/pull/2620
     linter_spdx_license: MIT
     linter_speed: 5
     linter_banner_image_url: https://raw.githubusercontent.com/pycqa/isort/develop/art/logo_large.png
@@ -433,6 +436,7 @@ linters:
       Bandit is essential for maintaining secure Python codebases and is widely used in security-conscious development environments.
     linter_url: https://bandit.readthedocs.io/en/latest/
     linter_repo: https://github.com/PyCQA/bandit
+    linter_megalinter_ref_url: no
     linter_spdx_license: Apache-2.0
     linter_rules_url: https://bandit.readthedocs.io/en/latest/plugins/index.html#complete-test-plugin-listing
     linter_banner_image_url: https://github.com/PyCQA/bandit/raw/main/logo/logotype-sm.png
@@ -688,6 +692,7 @@ linters:
       **Note**: This linter only checks `.ipynb` files. Use PYTHON_MYPY for `.py` and `.pyi` files.
     linter_url: https://github.com/nbQA-dev/nbQA
     linter_repo: https://github.com/nbQA-dev/nbQA
+    linter_megalinter_ref_url: https://github.com/nbQA-dev/nbQA/pull/905
     linter_rules_url: https://github.com/nbQA-dev/nbQA
     linter_spdx_license: MIT
     linter_speed: 2
@@ -767,6 +772,7 @@ linters:
     linter_url: https://github.com/Microsoft/pyright
     linter_rules_url: https://github.com/microsoft/pyright#type-checking-features
     linter_repo: https://github.com/microsoft/pyright
+    linter_megalinter_ref_url: https://github.com/microsoft/pyright/pull/11604
     linter_spdx_license: MIT
     linter_banner_image_url: https://github.com/microsoft/pyright/raw/main/docs/img/PyrightLarge.png
     linter_speed: 1
@@ -834,6 +840,7 @@ linters:
       - **Monorepo-Friendly**: Hierarchical and cascading configuration for complex project structures
     linter_url: https://github.com/astral-sh/ruff
     linter_repo: https://github.com/astral-sh/ruff
+    linter_megalinter_ref_url: https://github.com/astral-sh/ruff#whos-using-ruff
     linter_spdx_license: MIT
     linter_speed: 5
     linter_rules_url: https://docs.astral.sh/ruff/rules/
@@ -928,6 +935,7 @@ linters:
       - **Incremental Formatting**: Built-in caching avoids re-formatting unchanged files for maximum efficiency
     linter_url: https://github.com/astral-sh/ruff
     linter_repo: https://github.com/astral-sh/ruff
+    linter_megalinter_ref_url: https://github.com/astral-sh/ruff#whos-using-ruff
     linter_spdx_license: MIT
     linter_speed: 5
     linter_rules_url: https://docs.astral.sh/ruff/rules/

--- a/megalinter/descriptors/repository.megalinter-descriptor.yml
+++ b/megalinter/descriptors/repository.megalinter-descriptor.yml
@@ -119,6 +119,7 @@ linters:
       ```
     linter_url: https://github.com/microsoft/DevSkim
     linter_repo: https://github.com/microsoft/DevSkim
+    linter_megalinter_ref_url: https://github.com/microsoft/DevSkim/pull/775
     linter_speed: 1
     linter_rules_configuration_url: https://github.com/microsoft/DevSkim/wiki/Analyze-Command
     linter_rules_ignore_config_url: https://github.com/microsoft/DevSkim/wiki/Analyze-Command
@@ -209,6 +210,7 @@ linters:
     ignore_for_flavor_suggestions: true
     linter_url: https://github.com/Checkmarx/dustilock
     linter_repo: https://github.com/Checkmarx/dustilock
+    linter_megalinter_ref_url: https://github.com/Checkmarx/dustilock/pull/7
     linter_banner_image_url: https://user-images.githubusercontent.com/1287098/142776854-83abf265-a1ba-485f-a8b6-995da7f7ef8b.png
     linter_icon_png_url: https://raw.githubusercontent.com/oxsecurity/megalinter/main/docs/assets/icons/linters/dustilock.png
     linter_spdx_license: Apache-2.0
@@ -286,6 +288,7 @@ linters:
       - security
     linter_url: https://github.com/betterleaks/betterleaks
     linter_repo: https://github.com/betterleaks/betterleaks
+    linter_megalinter_ref_url: https://github.com/betterleaks/betterleaks/pull/287
     linter_speed: 4
     linter_spdx_license: MIT
     linter_rules_configuration_url: https://github.com/betterleaks/betterleaks#configuration
@@ -404,6 +407,7 @@ linters:
     linter_speed: 2
     linter_url: https://github.com/anchore/grype
     linter_repo: https://github.com/anchore/grype
+    linter_megalinter_ref_url: https://github.com/anchore/grype/pull/3644
     linter_rules_url: https://github.com/anchore/grype#vulnerability-summary
     linter_banner_image_url: https://user-images.githubusercontent.com/5199289/136855393-d0a9eef9-ccf1-4e2b-9d7c-7aad16a567e5.png
     linter_icon_png_url: https://raw.githubusercontent.com/oxsecurity/megalinter/main/docs/assets/icons/linters/grype.png
@@ -716,6 +720,7 @@ linters:
       - security
     linter_url: https://semgrep.dev/
     linter_repo: https://github.com/returntocorp/semgrep
+    linter_megalinter_ref_url: https://github.com/semgrep/semgrep-docs/pull/2775
     linter_speed: 1
     linter_text: |
       **Semgrep** is a fast, AI-powered static analysis tool that finds bugs, detects security vulnerabilities, and enforces code standards across 30+ programming languages and frameworks. Unlike traditional SAST tools, Semgrep provides high-confidence findings with minimal false positives.
@@ -806,6 +811,7 @@ linters:
     ignore_for_flavor_suggestions: true
     linter_url: https://github.com/anchore/syft
     linter_repo: https://github.com/anchore/syft
+    linter_megalinter_ref_url: https://github.com/anchore/syft/pull/5165
     linter_text: |
       **Syft** is a comprehensive Software Bill of Materials (SBOM) generation tool that creates detailed inventories of software components and dependencies in your projects. It serves as an essential tool for software supply chain security and compliance management.
 
@@ -895,6 +901,7 @@ linters:
       ```
     linter_url: https://aquasecurity.github.io/trivy/
     linter_repo: https://github.com/aquasecurity/trivy
+    linter_megalinter_ref_url: https://github.com/aquasecurity/trivy/pull/11062
     linter_speed: 2
     linter_banner_image_url: https://github.com/aquasecurity/trivy/raw/main/docs/imgs/logo.png
     linter_icon_png_url: https://raw.githubusercontent.com/oxsecurity/megalinter/main/docs/assets/icons/linters/trivy.png
@@ -1007,6 +1014,7 @@ linters:
       - **Audit Trail**: Creates detailed records of software composition for security auditing and compliance reporting
     linter_url: https://aquasecurity.github.io/trivy/
     linter_repo: https://github.com/aquasecurity/trivy
+    linter_megalinter_ref_url: https://github.com/aquasecurity/trivy/pull/11062
     linter_speed: 2
     linter_banner_image_url: https://github.com/aquasecurity/trivy/raw/main/docs/imgs/logo.png
     linter_icon_png_url: https://raw.githubusercontent.com/oxsecurity/megalinter/main/docs/assets/icons/linters/trivy-sbom.png
@@ -1101,6 +1109,7 @@ linters:
     linter_speed: 2
     linter_url: https://github.com/trufflesecurity/trufflehog
     linter_repo: https://github.com/trufflesecurity/trufflehog
+    linter_megalinter_ref_url: https://github.com/trufflesecurity/trufflehog/pull/5194
     linter_banner_image_url: https://storage.googleapis.com/trufflehog-static-sources/pixel_pig.png
     linter_icon_png_url: https://raw.githubusercontent.com/oxsecurity/megalinter/main/docs/assets/icons/linters/trufflehog.png
     linter_rules_configuration_url: https://github.com/trufflesecurity/trufflehog#regex-detector-alpha
@@ -1156,6 +1165,7 @@ linters:
       - **Built-in Report Viewer:** Visualize and triage findings locally with kingfisher view ./report-file.json
     linter_url: https://github.com/mongodb/kingfisher
     linter_repo: https://github.com/mongodb/kingfisher
+    linter_megalinter_ref_url: https://github.com/mongodb/kingfisher/pull/471
     linter_spdx_license: Apache-2.0
     linter_rules_url: https://mongodb.github.io/kingfisher/rules/builtin-rules
     linter_rules_inline_disable_url: https://mongodb.github.io/kingfisher/usage/advanced/?h=inline#inline-ignore-directives

--- a/megalinter/descriptors/robotframework.megalinter-descriptor.yml
+++ b/megalinter/descriptors/robotframework.megalinter-descriptor.yml
@@ -25,6 +25,7 @@ linters:
     can_output_sarif: true
     linter_url: https://github.com/MarketSquare/robotframework-robocop
     linter_repo: https://github.com/MarketSquare/robotframework-robocop
+    linter_megalinter_ref_url: https://robocop.dev/stable/integrations/megalinter/
     linter_spdx_license: Apache-2.0
     linter_rules_url: https://robocop.dev/stable/rules_list/
     linter_rules_configuration_url: https://robocop.dev/stable/configuration/

--- a/megalinter/descriptors/rst.megalinter-descriptor.yml
+++ b/megalinter/descriptors/rst.megalinter-descriptor.yml
@@ -131,7 +131,7 @@ linters:
     linter_url: https://github.com/dzhu/rstfmt
     linter_spdx_license: MIT
     linter_rules_configuration_url: https://github.com/dzhu/rstfmt#usage
-    linter_megalinter_ref_url: https://github.com/dzhu/rstfmt/pull/1
+    linter_megalinter_ref_url: https://github.com/dzhu/rstfmt/pull/45
     cli_lint_mode: list_of_files
     supported_cli_lint_modes:
       - file

--- a/megalinter/descriptors/snakemake.megalinter-descriptor.yml
+++ b/megalinter/descriptors/snakemake.megalinter-descriptor.yml
@@ -88,6 +88,7 @@ linters:
     name: SNAKEMAKE_SNAKEFMT
     linter_url: https://github.com/snakemake/snakefmt
     linter_repo: https://github.com/snakemake/snakefmt
+    linter_megalinter_ref_url: https://github.com/snakemake/snakefmt/pull/314
     linter_rules_configuration_url: https://github.com/snakemake/snakefmt#configuration
     linter_spdx_license: MIT
     config_file_name: .snakefmt.toml

--- a/megalinter/descriptors/spell.megalinter-descriptor.yml
+++ b/megalinter/descriptors/spell.megalinter-descriptor.yml
@@ -184,7 +184,7 @@ linters:
       MegaLinter analyze markdown and restructuredText files by default, you can change that using SPELL_VALE_FILE_EXTENSIONS variable.
     linter_url: https://vale.sh/
     linter_repo: https://github.com/errata-ai/vale
-    linter_megalinter_ref_url: https://github.com/vale-cli/vale.sh/blob/main/docs/SUMMARY.md
+    linter_megalinter_ref_url: https://vale.sh/docs
     linter_rules_url: https://vale.sh/hub/
     linter_rules_configuration_url: https://vale.sh/explorer/
     linter_rules_inline_disable_url: https://vale.sh/docs/topics/vocab/

--- a/megalinter/descriptors/spell.megalinter-descriptor.yml
+++ b/megalinter/descriptors/spell.megalinter-descriptor.yml
@@ -93,6 +93,7 @@ linters:
     linter_speed: 2
     linter_url: https://github.com/amperser/proselint
     linter_repo: https://github.com/amperser/proselint
+    linter_megalinter_ref_url: https://github.com/amperser/proselint#readme
     linter_banner_image_url: https://raw.githubusercontent.com/amperser/proselint/main/logo.png
     linter_rules_url: https://github.com/amperser/proselint#checks
     linter_rules_configuration_url: https://github.com/amperser/proselint#checks
@@ -183,6 +184,7 @@ linters:
       MegaLinter analyze markdown and restructuredText files by default, you can change that using SPELL_VALE_FILE_EXTENSIONS variable.
     linter_url: https://vale.sh/
     linter_repo: https://github.com/errata-ai/vale
+    linter_megalinter_ref_url: https://github.com/vale-cli/vale.sh/pull/116
     linter_rules_url: https://vale.sh/hub/
     linter_rules_configuration_url: https://vale.sh/explorer/
     linter_rules_inline_disable_url: https://vale.sh/docs/topics/vocab/
@@ -262,6 +264,7 @@ linters:
       - documentation
     linter_url: https://lychee.cli.rs
     linter_repo: https://github.com/lycheeverse/lychee
+    linter_megalinter_ref_url: https://github.com/lycheeverse/lychee/pull/2277
     linter_banner_image_url: https://raw.githubusercontent.com/lycheeverse/lychee/master/assets/banner.svg
     linter_image_url: https://raw.githubusercontent.com/lycheeverse/lychee/master/assets/logo.svg
     linter_rules_url: https://lychee.cli.rs/guides/cli/
@@ -340,6 +343,7 @@ linters:
       - documentation
     linter_url: https://github.com/codespell-project/codespell
     linter_repo: https://github.com/codespell-project/codespell
+    linter_megalinter_ref_url: https://github.com/codespell-project/codespell/pull/3991
     linter_rules_configuration_url: https://github.com/codespell-project/codespell?tab=readme-ov-file#using-a-config-file
     linter_rules_inline_disable_url: https://github.com/codespell-project/codespell?tab=readme-ov-file#inline-ignore
     linter_speed: 3

--- a/megalinter/descriptors/spell.megalinter-descriptor.yml
+++ b/megalinter/descriptors/spell.megalinter-descriptor.yml
@@ -184,7 +184,7 @@ linters:
       MegaLinter analyze markdown and restructuredText files by default, you can change that using SPELL_VALE_FILE_EXTENSIONS variable.
     linter_url: https://vale.sh/
     linter_repo: https://github.com/errata-ai/vale
-    linter_megalinter_ref_url: https://github.com/vale-cli/vale.sh/pull/116
+    linter_megalinter_ref_url: https://github.com/vale-cli/vale.sh/blob/main/docs/SUMMARY.md
     linter_rules_url: https://vale.sh/hub/
     linter_rules_configuration_url: https://vale.sh/explorer/
     linter_rules_inline_disable_url: https://vale.sh/docs/topics/vocab/

--- a/megalinter/descriptors/swift.megalinter-descriptor.yml
+++ b/megalinter/descriptors/swift.megalinter-descriptor.yml
@@ -25,6 +25,7 @@ linters:
       - **Multiple Output Formats**: Supports various report formats including JSON, HTML, and checkstyle for tool integration
     linter_url: https://github.com/realm/SwiftLint
     linter_repo: https://github.com/realm/SwiftLint
+    linter_megalinter_ref_url: https://github.com/realm/SwiftLint/pull/6867
     linter_rules_url: https://realm.github.io/SwiftLint/rule-directory.html
     linter_rules_configuration_url: https://github.com/realm/SwiftLint#configuration
     linter_rules_inline_disable_url: https://github.com/realm/SwiftLint#disable-rules-in-code

--- a/megalinter/descriptors/swift.megalinter-descriptor.yml
+++ b/megalinter/descriptors/swift.megalinter-descriptor.yml
@@ -25,7 +25,7 @@ linters:
       - **Multiple Output Formats**: Supports various report formats including JSON, HTML, and checkstyle for tool integration
     linter_url: https://github.com/realm/SwiftLint
     linter_repo: https://github.com/realm/SwiftLint
-    linter_megalinter_ref_url: https://github.com/realm/SwiftLint/pull/6867
+    linter_megalinter_ref_url: https://github.com/realm/SwiftLint#megalinter
     linter_rules_url: https://realm.github.io/SwiftLint/rule-directory.html
     linter_rules_configuration_url: https://github.com/realm/SwiftLint#configuration
     linter_rules_inline_disable_url: https://github.com/realm/SwiftLint#disable-rules-in-code

--- a/megalinter/descriptors/tekton.megalinter-descriptor.yml
+++ b/megalinter/descriptors/tekton.megalinter-descriptor.yml
@@ -25,6 +25,7 @@ linters:
       - **Comprehensive Rule Set**: Covers common Tekton anti-patterns and configuration mistakes
     linter_url: https://github.com/IBM/tekton-lint
     linter_repo: https://github.com/IBM/tekton-lint
+    linter_megalinter_ref_url: https://github.com/IBM/tekton-lint/pull/127
     linter_rules_url: https://github.com/IBM/tekton-lint#rules
     linter_rules_configuration_url: https://github.com/IBM/tekton-lint#configuring-tekton-lint
     linter_spdx_license: Apache-2.0

--- a/megalinter/descriptors/terraform.megalinter-descriptor.yml
+++ b/megalinter/descriptors/terraform.megalinter-descriptor.yml
@@ -20,6 +20,7 @@ linters:
       - security
     linter_url: https://github.com/terraform-linters/tflint
     linter_repo: https://github.com/terraform-linters/tflint
+    linter_megalinter_ref_url: https://github.com/terraform-linters/tflint/pull/2624
     linter_rules_url: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/README.md
     linter_rules_configuration_url: https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/config.md
     linter_rules_inline_disable_url: https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/annotations.md
@@ -109,6 +110,7 @@ linters:
       - security
     linter_url: https://docs.terragrunt.com/reference/cli/commands/hcl/fmt/
     linter_repo: https://github.com/gruntwork-io/terragrunt
+    linter_megalinter_ref_url: https://github.com/gruntwork-io/terragrunt/pull/6657
     linter_rules_configuration_url: https://terragrunt.gruntwork.io/docs/getting-started/quick-start/#add-terragrunthcl-to-your-project
     linter_image_url: https://github.com/gruntwork-io/terragrunt/blob/master/docs/assets/img/favicon/ms-icon-310x310.png
     linter_icon_png_url: https://raw.githubusercontent.com/oxsecurity/megalinter/main/docs/assets/icons/linters/terragrunt.png

--- a/megalinter/descriptors/typescript.megalinter-descriptor.yml
+++ b/megalinter/descriptors/typescript.megalinter-descriptor.yml
@@ -296,6 +296,7 @@ linters:
         default_value: ts-standard
     linter_url: https://standardjs.com/
     linter_repo: https://github.com/standard/ts-standard
+    linter_megalinter_ref_url: https://github.com/standard/ts-standard/pull/298
     linter_rules_url: https://standardjs.com/rules.html
     linter_rules_configuration_url: https://github.com/standard/ts-standard#readme
     linter_rules_inline_disable_url: https://standardjs.com/#how-do-i-disable-a-rule
@@ -356,6 +357,7 @@ linters:
         default_value: standard
     linter_url: https://prettier.io/
     linter_repo: https://github.com/prettier/prettier
+    linter_megalinter_ref_url: https://github.com/prettier/prettier/pull/19818
     linter_rules_url: https://prettier.io/docs/en/options.html
     linter_rules_configuration_url: https://prettier.io/docs/en/configuration.html
     linter_rules_inline_disable_url: https://prettier.io/docs/en/ignore.html#javascript

--- a/megalinter/descriptors/yaml.megalinter-descriptor.yml
+++ b/megalinter/descriptors/yaml.megalinter-descriptor.yml
@@ -27,6 +27,7 @@ linters:
     is_formatter: true
     linter_url: https://prettier.io/
     linter_repo: https://github.com/prettier/prettier
+    linter_megalinter_ref_url: https://github.com/prettier/prettier/pull/19818
     linter_spdx_license: MIT
     linter_rules_url: https://prettier.io/docs/en/options.html
     linter_rules_configuration_url: https://prettier.io/docs/en/configuration.html


### PR DESCRIPTION
Audit of all `linter_megalinter_ref_url` values across the 124 linter descriptors, plus a campaign of suggestion PRs on the repos of embedded linters that didn't mention MegaLinter yet.

**Existing references fixed** (pages that moved):

- ktlint → https://ktlint.github.io/ktlint/latest/install/integrations/
- robocop → https://robocop.dev/stable/integrations/megalinter/
- ruff → README "Who's Using Ruff" anchor

**New references to already-published mentions**: zizmor, csharpier, proselint, markdown-table-formatter, kubeconform (pre-existing open PRs)

**47 suggestion PRs opened** on linters repositories (recorded as `/pull/` refs, shown as "Awaiting publication" in docs): actionlint, ansible-lint, arm-ttk, bicep, cppcheck, cpplint, cfn-lint, Roslynator, gherkin-lint, kubescape, revive, jsonlint, standard, prettier, phplint, psalm, Perl-Critic, phpstan, PHP-CS-Fixer, PSScriptAnalyzer, pylint, isort, pyright, nbQA, rumdl, protolint, dustilock, betterleaks, grype, syft, trivy, trufflehog, kingfisher, semgrep-docs, DevSkim, snakefmt, lychee, codespell, tekton-lint, tflint, terragrunt, ts-standard, SwiftLint, cljstyle, detekt, rstfmt, vale.sh

**Marked as refused** (`no`): bandit and black (suggestion PRs closed by their maintainers)

Some repos were deliberately not PRed: repos with AI-contribution policies (ls-lint, stylelint, markdownlint, PHP_CodeSniffer, osv-scanner, snakemake, sqlfluff), archived/no-external-contribution repos (coffeelint, code-analyzer), and giant products where the linter is a small subcommand (clang-format, dotnet-format, helm, terraform fmt, raku, clippy).