### PR TITLE
Factorize duplicated linter definitions with shared linter files and extends property

### DIFF
--- a/.automation/build.py
+++ b/.automation/build.py
@@ -4,6 +4,7 @@ Automatically generate source code ,descriptive files Dockerfiles and documentat
 """
 
 # pylint: disable=import-error
+import glob
 import json
 import logging
 import os
@@ -196,14 +197,13 @@ def generate_flavor(flavor, flavor_info):
     # Get install instructions at descriptor level
     descriptor_files = megalinter.linter_factory.list_descriptor_files()
     for descriptor_file in descriptor_files:
-        with open(descriptor_file, "r", encoding="utf-8") as f:
-            descriptor = yaml.safe_load(f)
-            if (
-                match_flavor(descriptor, flavor, flavor_info) is True
-                and "install" in descriptor
-            ):
-                descriptor_and_linters += [descriptor]
-                flavor_descriptors += [descriptor["descriptor_id"]]
+        descriptor = megalinter.linter_factory.build_descriptor_info(descriptor_file)
+        if (
+            match_flavor(descriptor, flavor, flavor_info) is True
+            and "install" in descriptor
+        ):
+            descriptor_and_linters += [descriptor]
+            flavor_descriptors += [descriptor["descriptor_id"]]
     # Get install instructions at linter level
     linters = megalinter.linter_factory.list_all_linters(({"request_id": "build"}))
     for linter in linters:
@@ -810,8 +810,7 @@ def generate_linter_dockerfiles():
     active_linter_list_lower_arm = []
     for descriptor_file in descriptor_files:
         descriptor_items = []
-        with open(descriptor_file, "r", encoding="utf-8") as f:
-            descriptor = yaml.safe_load(f)
+        descriptor = megalinter.linter_factory.build_descriptor_info(descriptor_file)
         if "install" in descriptor:
             descriptor_items += [descriptor]
         descriptor_linters = megalinter.linter_factory.build_descriptor_linters(
@@ -2979,12 +2978,11 @@ def _collect_descriptor_ids_sorted() -> list[str]:
     descriptor_ids: set[str] = set()
     descriptor_files = megalinter.linter_factory.list_descriptor_files()
     for descriptor_file in descriptor_files:
-        with open(descriptor_file, "r", encoding="utf-8") as f:
-            descriptor = yaml.safe_load(f)
-            if isinstance(descriptor, dict):
-                descriptor_id = descriptor.get("descriptor_id")
-                if isinstance(descriptor_id, str) and descriptor_id:
-                    descriptor_ids.add(descriptor_id)
+        descriptor = megalinter.linter_factory.build_descriptor_info(descriptor_file)
+        if isinstance(descriptor, dict):
+            descriptor_id = descriptor.get("descriptor_id")
+            if isinstance(descriptor_id, str) and descriptor_id:
+                descriptor_ids.add(descriptor_id)
 
     sorted_ids = sorted(descriptor_ids, key=len, reverse=True)
     _CONFIG_SCHEMA_IDS_CACHE["descriptor_ids_sorted"] = sorted_ids
@@ -3418,6 +3416,31 @@ def validate_descriptors():
                 except jsonschema.exceptions.ValidationError as validation_error:
                     logging.error(
                         f"{os.path.basename(descriptor_file)} is not compliant with JSON schema"
+                    )
+                    logging.error(f"reason: {str(validation_error)}")
+                    errors = errors + 1
+        # Shared linter definitions must be complete standalone linter definitions
+        descriptor_schema_data = yaml.safe_load(descriptor_schema)
+        shared_linter_schema = {
+            "$schema": "http://json-schema.org/draft-07/schema",
+            "definitions": descriptor_schema_data.get("definitions", {}),
+            **descriptor_schema_data["properties"]["linters"]["items"],
+        }
+        shared_linter_schema.pop("$id", None)
+        shared_linter_files = sorted(
+            glob.glob(f"{REPO_HOME}/megalinter/descriptors/shared/*.megalinter-linter.yml")
+        )
+        for shared_linter_file in shared_linter_files:
+            with open(shared_linter_file, "r", encoding="utf-8") as shared_file1:
+                logging.info("Validating " + os.path.basename(shared_linter_file))
+                try:
+                    jsonschema.validate(
+                        instance=yaml.safe_load(shared_file1.read()),
+                        schema=shared_linter_schema,
+                    )
+                except jsonschema.exceptions.ValidationError as validation_error:
+                    logging.error(
+                        f"{os.path.basename(shared_linter_file)} is not compliant with JSON schema"
                     )
                     logging.error(f"reason: {str(validation_error)}")
                     errors = errors + 1

--- a/.automation/build.py
+++ b/.automation/build.py
@@ -3428,7 +3428,9 @@ def validate_descriptors():
         }
         shared_linter_schema.pop("$id", None)
         shared_linter_files = sorted(
-            glob.glob(f"{REPO_HOME}/megalinter/descriptors/shared/*.megalinter-linter.yml")
+            glob.glob(
+                f"{REPO_HOME}/megalinter/descriptors/shared/*.megalinter-linter.yml"
+            )
         )
         for shared_linter_file in shared_linter_files:
             with open(shared_linter_file, "r", encoding="utf-8") as shared_file1:

--- a/.claude/agents/descriptor-expert.md
+++ b/.claude/agents/descriptor-expert.md
@@ -11,6 +11,8 @@ You are a MegaLinter descriptor specialist. You have deep expertise in the YAML 
 
 Descriptors live in `megalinter/descriptors/*.megalinter-descriptor.yml` and conform to `megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json`.
 
+Linters defined in **several descriptors** (eslint, prettier, v8r, dotnet-format, cpplint, cppcheck, clang-format, biome…) are factorized in `megalinter/descriptors/shared/<name>.megalinter-linter.yml` — a complete standalone linter definition — and referenced from each descriptor with the linter-level `extends: <name>` property (shallow merge, entry keys override, no chaining, resolved by `linter_factory.resolve_linter_extends`). Edit the shared file for behavior common to all descriptors; keep only the per-descriptor differences (`test_folder`, `examples`, `linter_text`, `file_extensions`, `name`, key-prefixed `common_linter_errors`…) in the entries. See `.claude/rules/descriptors.md` → "Shared Linter Definitions".
+
 ## Descriptor-Level Properties
 
 Fill in as many as applicable when creating or reviewing a descriptor:

--- a/.claude/rules/descriptors.md
+++ b/.claude/rules/descriptors.md
@@ -6,7 +6,28 @@ globs: ["megalinter/descriptors/*.megalinter-descriptor.yml"]
 # Descriptor File Rules
 
 ## Schema
-Descriptor files conform to `megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json`. Only `descriptor_id`, `descriptor_type`, `linters` are required at descriptor level, and only `linter_name`, `linter_url`, `examples` at linter level — but **aim to fill every applicable property**.
+Descriptor files conform to `megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json`. Only `descriptor_id`, `descriptor_type`, `linters` are required at descriptor level, and only `linter_name`, `linter_url`, `examples` at linter level (`linter_url`/`examples` may come from an extended shared definition instead) — but **aim to fill every applicable property**.
+
+## Shared Linter Definitions (extends)
+
+A linter defined in **several descriptors** (eslint, prettier, v8r, dotnet-format, cpplint, cppcheck, clang-format, biome…) is factorized in `megalinter/descriptors/shared/<name>.megalinter-linter.yml` and referenced from each descriptor with the linter-level `extends` property:
+
+```yaml
+linters:
+  - extends: biome
+    linter_name: biome        # always repeated in the entry
+    test_folder: json_biome   # per-descriptor overrides only
+    examples:
+      - "biome check myfile.json"
+```
+
+Rules:
+
+- **Shallow merge**: descriptor entry keys override the shared ones wholesale (no nested-dict merging, no list merging, no chaining between shared files). Resolution happens in `linter_factory.resolve_linter_extends`, used by runtime, build system and plugins
+- Shared files are **complete standalone linter definitions** (schema-validated during build): `linter_name`, `linter_url` and generic `examples` must be present even when every entry overrides them
+- **Edit the shared file, not the per-descriptor copies**, when changing behavior common to all descriptors; put in the entry only what genuinely differs (`linter_text`, `test_folder`, `examples`, per-language URLs, `name` overrides, `common_linter_errors` whose identifiers are linter-key-prefixed…)
+- Version pins in shared `install` blocks are still renovate-managed (`.megalinter-linter.ya?ml` is in the renovate custom manager patterns)
+- Shared files must stay **prettier-formatted** (YAML_PRETTIER blocks CI on descriptors)
 
 ## Maximize Property Coverage
 

--- a/.claude/skills/add-linter/SKILL.md
+++ b/.claude/skills/add-linter/SKILL.md
@@ -33,6 +33,8 @@ Guide me through adding the linter `$ARGUMENTS` to MegaLinter. If no linter name
 
 Check if a descriptor exists in `megalinter/descriptors/` for this language. If not, create a new `<lang>.megalinter-descriptor.yml`.
 
+If the linter covers **several descriptors** (like eslint, prettier or biome), define it once in `megalinter/descriptors/shared/<linter_name>.megalinter-linter.yml` (a complete standalone linter definition) and add a thin `extends: <linter_name>` entry in each descriptor with only the per-descriptor overrides (`test_folder`, `examples`, `file_extensions`…) — see `.claude/rules/descriptors.md` → "Shared Linter Definitions".
+
 Add the linter entry with **as many properties as possible**. Even though the JSON schema only requires `linter_name`, `linter_url`, and `examples`, aim for maximum completeness. Fill in ALL of these when applicable:
 
 **Identity (required):**

--- a/.claude/skills/review-descriptor/SKILL.md
+++ b/.claude/skills/review-descriptor/SKILL.md
@@ -10,6 +10,8 @@ metadata:
 
 Review the descriptor for `$ARGUMENTS`. If a linter name is given, find its descriptor in `megalinter/descriptors/`.
 
+If a linter entry declares `extends: <name>`, audit the **resolved** definition: read `megalinter/descriptors/shared/<name>.megalinter-linter.yml` and apply the entry's overrides on top (shallow merge). Report gaps against the shared file when the property is common to all descriptors, against the entry when it is descriptor-specific.
+
 For each linter entry, audit against the **full property list** below. Report a checklist with status for each category.
 
 ## 1. Identity (required)

--- a/.claude/skills/update-linter-version/SKILL.md
+++ b/.claude/skills/update-linter-version/SKILL.md
@@ -15,7 +15,7 @@ Update the version of linter `$linter` to `$version`.
 
 Steps:
 
-1. Search `megalinter/descriptors/*.megalinter-descriptor.yml` for the linter by name
+1. Search `megalinter/descriptors/*.megalinter-descriptor.yml` **and** `megalinter/descriptors/shared/*.megalinter-linter.yml` for the linter by name (multi-descriptor linters like eslint, prettier or biome keep their `install` block in the shared file)
 2. Find the version ARG in the `install.dockerfile` section (e.g., `ARG PIP_TOOL_VERSION=X.Y.Z`) or version pin in pip/npm arrays
 3. Update the version, preserving the renovate comment format:
    ```yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - mega-linter-runner
 
 - Dev
+  - **Shared linter definitions**: linter entries duplicated across several descriptors (eslint, prettier, v8r, dotnet-format, cpplint, cppcheck, clang-format) are now factorized in `megalinter/descriptors/shared/*.megalinter-linter.yml` files, referenced from descriptors with the new linter-level `extends` property (shallow merge, descriptor entry properties override the shared ones)
   - **Docker pulls monthly chart**: the auto-update workflow now regenerates `docs/assets/images/docker-pulls-monthly.svg` (new pulls per month since October 2020, all images and registries), via the new `.automation/docker_pulls_chart.py` called by `build.py` after the pull counters update
     - Historical monthly points are frozen in `.automation/generated/docker-pulls-monthly.json` (built once from the tracked stats plus a Web Archive reconstruction of the collection gaps); the script only appends newly completed months computed from `flavors-stats.json`
   - Docker pull counters now also track the **standalone `megalinter-only-*` images**: their download counts are stored in `flavors-stats.json` and included in the README badge total

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ uv pip install -e .             # Install in editable mode
 
 ### Descriptor-Driven Design
 
-The core pattern: each linter is defined in a YAML descriptor file (`megalinter/descriptors/<lang>.megalinter-descriptor.yml`). The build system (`.automation/build.py`) reads these descriptors and generates:
+The core pattern: each linter is defined in a YAML descriptor file (`megalinter/descriptors/<lang>.megalinter-descriptor.yml`). Linters shared by several descriptors (eslint, prettier, biome...) are defined once in `megalinter/descriptors/shared/<name>.megalinter-linter.yml` and referenced with the linter-level `extends` property (shallow merge, entry keys override — see `.claude/rules/descriptors.md`). The build system (`.automation/build.py`) reads these descriptors and generates:
 - Dockerfiles (per-linter in `linters/`, per-flavor in `flavors/`)
 - Documentation pages (in `docs/`)
 - Test class skeletons

--- a/megalinter/descriptors/c.megalinter-descriptor.yml
+++ b/megalinter/descriptors/c.megalinter-descriptor.yml
@@ -12,7 +12,8 @@ file_extensions:
   - ".h"
 linters:
   # Cppcheck
-  - linter_name: cppcheck
+  - extends: cppcheck
+    linter_name: cppcheck
     linter_text: |
       **Cppcheck** is a static analysis tool for C/C++ code that provides unique code analysis to detect bugs and focuses on detecting undefined behaviour and dangerous coding constructs. The goal is to have very few false positives.
 
@@ -35,36 +36,7 @@ linters:
 
       Cppcheck helps ensure your C/C++ code is secure, reliable, and follows best practices for memory management and undefined behavior prevention.
     name: C_CPPCHECK
-    linter_url: https://cppcheck.sourceforge.io/
-    linter_repo: https://cppcheck.sourceforge.io/
-    linter_megalinter_ref_url: https://github.com/cppcheck-opensource/cppcheck/pull/8786
-    linter_spdx_license: GPL-3.0
-    linter_rules_url: https://sourceforge.net/p/cppcheck/wiki/ListOfChecks/
-    linter_rules_configuration_url: https://cppcheck.sourceforge.io/manual.html#configuration
-    cli_lint_errors_count: regex_count
-    cli_lint_errors_regex: "error:"
-    cli_lint_mode: list_of_files
-    supported_cli_lint_modes:
-      - file
-      - list_of_files
-      - project
-    cli_lint_extra_args:
-      - --error-exitcode=1
-    cli_lint_mode_project_exclude_arg_name: "-i"
-    cli_lint_mode_project_exclude_arg_value: "**/{{DIR}}/**"
-    cli_lint_mode_project_extra_args_after:
-      - .
-    examples:
-      - "cppcheck myfile.cpp"
-    install:
-      apk:
-        - cppcheck
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-  # CPPLINT
-  - class: CppLintLinter
+  - extends: cpplint
     linter_name: cpplint
     linter_text: |
       **Cpplint** is a command-line tool to check C/C++ files for style issues according to **Google's C++ style guide**. Originally developed by Google, this community-maintained fork aims to update cpplint to modern specifications and be more open to fixes and features.
@@ -88,33 +60,8 @@ linters:
 
       Cpplint helps maintain consistent, readable C++ code that follows industry-standard style guidelines, making code easier to review, maintain, and collaborate on.
     name: C_CPPLINT
-    linter_url: https://github.com/cpplint/cpplint
-    linter_repo: https://github.com/cpplint/cpplint
-    linter_megalinter_ref_url: https://github.com/cpplint/cpplint/pull/462
-    linter_spdx_license: BSD-3-Clause
-    linter_rules_url: https://google.github.io/styleguide/cppguide.html
-    cli_lint_mode: list_of_files
-    supported_cli_lint_modes:
-      - file
-      - list_of_files
-    cli_help_arg_name: "--help"
-    cli_lint_errors_count: regex_number
-    cli_lint_errors_regex: "Total errors found: ([0-9]+)"
-    examples:
-      - "cpplint myfile.cpp"
-    install:
-      dockerfile:
-        - |-
-          # renovate: datasource=pypi depName=cpplint
-          ARG PIP_CPPLINT_VERSION=2.0.2
-      pip:
-        - cpplint==${PIP_CPPLINT_VERSION}
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-  # clang-format
-  - linter_name: clang-format
+  - extends: clang-format
+    linter_name: clang-format
     linter_text: |
       **clang-format** is a comprehensive code formatter for C/C++/Objective-C code that automatically enforces consistent coding style according to configurable rules and heuristics. As part of the LLVM project, it provides industry-leading formatting capabilities for complex C++ codebases.
 
@@ -129,43 +76,5 @@ linters:
       - **Incremental Formatting**: Can format specific ranges or files without affecting the entire codebase
       - **Cross-Platform Support**: Works consistently across different operating systems and development environments
     name: C_CLANG_FORMAT
-    descriptor_flavors:
-      - c_cpp
-    linter_url: https://releases.llvm.org/21.1.0/tools/clang/docs/ClangFormat.html
-    linter_repo: https://github.com/llvm/llvm-project
-    linter_spdx_license: Apache-2.0
-    linter_rules_url: https://releases.llvm.org/21.1.0/tools/clang/docs/ClangFormat.html
-    linter_rules_configuration_url: https://releases.llvm.org/21.1.0/tools/clang/docs/ClangFormatStyleOptions.html
-    linter_rules_inline_disable_url: https://releases.llvm.org/21.1.0/tools/clang/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code
-    cli_lint_mode: list_of_files
-    supported_cli_lint_modes:
-      - file
-      - list_of_files
-    cli_help_arg_name: "--help"
-    cli_lint_extra_args:
-      - "--Werror"
-      - "--dry-run"
-    cli_lint_fix_arg_name: "-i"
-    cli_lint_fix_remove_args:
-      - "--Werror"
-      - "--dry-run"
-    config_file_name: .clang-format
-    cli_config_arg_name: "--style=file:"
-    cli_lint_errors_count: regex_count
-    cli_lint_errors_regex: "code should be clang-formatted"
     examples:
       - "clang-format --Werror --dry-run myfile.c"
-    install:
-      apk:
-        - "cmd:clang-format"
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-    ide:
-      vscode:
-        - name: Clang-Format
-          url: https://marketplace.visualstudio.com/items?itemName=xaver.clang-format
-      emacs:
-        - name: clang-format
-          url: https://releases.llvm.org/21.1.0/tools/clang/docs/ClangFormat.html#emacs-integration

--- a/megalinter/descriptors/cpp.megalinter-descriptor.yml
+++ b/megalinter/descriptors/cpp.megalinter-descriptor.yml
@@ -22,7 +22,8 @@ file_extensions:
   - ".cuh"
 linters:
   # Cppcheck
-  - linter_name: cppcheck
+  - extends: cppcheck
+    linter_name: cppcheck
     linter_text: |
       **Cppcheck** is a powerful static analysis tool for C and C++ code that detects bugs and undefined behavior that compilers typically miss. It performs deep code analysis without requiring code execution or special build configurations.
 
@@ -35,36 +36,7 @@ linters:
       - **Low False Positives**: Focuses on finding real bugs with minimal false alarms
       - **Extensive Checks**: Covers over 200 different types of errors and suspicious code patterns
     name: CPP_CPPCHECK
-    linter_url: https://cppcheck.sourceforge.io/
-    linter_repo: https://cppcheck.sourceforge.io/
-    linter_megalinter_ref_url: https://github.com/cppcheck-opensource/cppcheck/pull/8786
-    linter_spdx_license: GPL-3.0
-    linter_rules_url: https://sourceforge.net/p/cppcheck/wiki/ListOfChecks/
-    linter_rules_configuration_url: https://cppcheck.sourceforge.io/manual.html#configuration
-    cli_lint_errors_count: regex_count
-    cli_lint_errors_regex: "error:"
-    cli_lint_mode: list_of_files
-    supported_cli_lint_modes:
-      - file
-      - list_of_files
-      - project
-    cli_lint_extra_args:
-      - --error-exitcode=1
-    cli_lint_mode_project_exclude_arg_name: "-i"
-    cli_lint_mode_project_exclude_arg_value: "**/{{DIR}}/**"
-    cli_lint_mode_project_extra_args_after:
-      - .
-    examples:
-      - "cppcheck myfile.cpp"
-    install:
-      apk:
-        - cppcheck
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-  # CPPLINT
-  - class: CppLintLinter
+  - extends: cpplint
     linter_name: cpplint
     linter_text: |
       **cpplint** is a command-line tool that enforces Google's C++ Style Guide, helping teams maintain consistent and readable C++ code. It focuses on style, formatting, and best practice compliance rather than logic errors.
@@ -79,33 +51,8 @@ linters:
       - **Configurable Rules**: Allows filtering and customization of specific style checks
       - **Incremental Checking**: Can be run on individual files or as part of code quality validation
     name: CPP_CPPLINT
-    linter_url: https://github.com/cpplint/cpplint
-    linter_repo: https://github.com/cpplint/cpplint
-    linter_megalinter_ref_url: https://github.com/cpplint/cpplint/pull/462
-    linter_spdx_license: BSD-3-Clause
-    linter_rules_url: https://google.github.io/styleguide/cppguide.html
-    cli_lint_mode: list_of_files
-    supported_cli_lint_modes:
-      - file
-      - list_of_files
-    cli_help_arg_name: "--help"
-    cli_lint_errors_count: regex_number
-    cli_lint_errors_regex: "Total errors found: ([0-9]+)"
-    examples:
-      - "cpplint myfile.cpp"
-    install:
-      dockerfile:
-        - |-
-          # renovate: datasource=pypi depName=cpplint
-          ARG PIP_CPPLINT_VERSION=2.0.2
-      pip:
-        - cpplint==${PIP_CPPLINT_VERSION}
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-  # clang-format
-  - linter_name: clang-format
+  - extends: clang-format
+    linter_name: clang-format
     linter_text: |
       **clang-format** is a powerful code formatter for C, C++, Java, JavaScript, JSON, Objective-C, Protobuf, and C# that automatically formats code according to configurable style guidelines. It's part of the LLVM project and provides consistent, automated formatting.
 
@@ -118,43 +65,5 @@ linters:
       - **Git Integration**: Built-in tools for formatting only changed lines in git commits and diffs
       - **In-Place Editing**: Can modify files directly or output formatted code to stdout
     name: CPP_CLANG_FORMAT
-    descriptor_flavors:
-      - c_cpp
-    linter_url: https://releases.llvm.org/21.1.0/tools/clang/docs/ClangFormat.html
-    linter_repo: https://github.com/llvm/llvm-project
-    linter_spdx_license: Apache-2.0
-    linter_rules_url: https://releases.llvm.org/21.1.0/tools/clang/docs/ClangFormat.html
-    linter_rules_configuration_url: https://releases.llvm.org/21.1.0/tools/clang/docs/ClangFormatStyleOptions.html
-    linter_rules_inline_disable_url: https://releases.llvm.org/21.1.0/tools/clang/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code
-    cli_lint_mode: list_of_files
-    supported_cli_lint_modes:
-      - file
-      - list_of_files
-    cli_help_arg_name: "--help"
-    cli_lint_extra_args:
-      - "--Werror"
-      - "--dry-run"
-    cli_lint_fix_arg_name: "-i"
-    cli_lint_fix_remove_args:
-      - "--Werror"
-      - "--dry-run"
-    config_file_name: .clang-format
-    cli_config_arg_name: "--style=file:"
-    cli_lint_errors_count: regex_count
-    cli_lint_errors_regex: "code should be clang-formatted"
     examples:
       - "clang-format --Werror --dry-run myfile.cpp"
-    install:
-      apk:
-        - "cmd:clang-format"
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-    ide:
-      vscode:
-        - name: Clang-Format
-          url: https://marketplace.visualstudio.com/items?itemName=xaver.clang-format
-      emacs:
-        - name: clang-format
-          url: https://releases.llvm.org/21.1.0/tools/clang/docs/ClangFormat.html#emacs-integration

--- a/megalinter/descriptors/csharp.megalinter-descriptor.yml
+++ b/megalinter/descriptors/csharp.megalinter-descriptor.yml
@@ -14,9 +14,8 @@ install:
     - ENV PATH="${PATH}:/usr/local/dotnet-tools"
 linters:
   # DOTNET FORMAT
-  - class: DotnetFormatLinter
+  - extends: dotnet-format
     linter_name: dotnet-format
-    is_formatter: true
     linter_text: |
       **dotnet format** is the official .NET code formatter that automatically applies consistent code styling and formatting rules to C# and VB.NET projects. It integrates directly with the .NET SDK and uses EditorConfig settings and analyzer rules to ensure uniform code appearance.
 
@@ -31,41 +30,16 @@ linters:
       - **Verification Mode**: Verify mode ensures code is properly formatted without making changes
 
       **Note**: dotnet-format requires a `.sln` or `.csproj` file to run correctly.
-    linter_url: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-format
-    linter_repo: https://github.com/dotnet/sdk
-    linter_spdx_license: MIT
-    linter_rules_configuration_url: https://github.com/dotnet/sdk/tree/main/documentation/format/docs
-    linter_rules_inline_disable_url: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings
-    linter_image_url: https://user-images.githubusercontent.com/9797472/61659851-6bbdc880-ac7d-11e9-95f7-d30c7de1a18a.png
-    cli_lint_errors_count: regex_count
     cli_lint_errors_regex: ".cs\\([0-9]+,[0-9]+\\):\\s(?:warning|error)"
-    cli_executable: dotnet
-    cli_lint_mode: project
-    supported_cli_lint_modes:
-      - project
-    cli_lint_extra_args:
-      - "format"
-    cli_lint_mode_project_exclude_arg_name: "--exclude"
-    cli_lint_mode_project_exclude_arg_value: "./{{DIR}}/"
     cli_lint_mode_project_extra_args_after:
       - "--include **/*.cs"
       - "--verify-no-changes"
-    cli_lint_fix_arg_name: "--megalinter-fix-flag" # Workaround for DotnetFormatLinter class behavior
-    cli_lint_fix_remove_args:
-      - "--verify-no-changes"
-    cli_help_extra_args:
-      - format
     examples:
       - "dotnet format --verify-no-changes"
       - "dotnet format Solution.sln --verify-no-changes"
       - "dotnet format Folder/Solution.sln --verify-no-changes"
       - "dotnet format Project.csproj --verify-no-changes"
       - "dotnet format" # Fix
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-  # CSharpier
   - linter_name: csharpier
     linter_text: |
       **CSharpier** is the definitive opinionated code formatter for C# that eliminates formatting debates by automatically standardizing code style across entire projects. Inspired by Prettier's philosophy, it provides zero-configuration formatting that just works.

--- a/megalinter/descriptors/javascript.megalinter-descriptor.yml
+++ b/megalinter/descriptors/javascript.megalinter-descriptor.yml
@@ -10,11 +10,9 @@ file_extensions:
   - ".js"
 linters:
   # ESLINT
-  - class: EslintLinter
+  - extends: eslint
     linter_name: eslint
     name: JAVASCRIPT_ES
-    can_output_sarif: true
-    linter_spdx_license: MIT
     file_extensions:
       - ".js"
       - ".vue"
@@ -102,40 +100,8 @@ linters:
     linter_rules_url: https://eslint.org/docs/latest/rules/
     linter_banner_image_url: https://d33wubrfki0l68.cloudfront.net/3b5ac7586466159bb6f237b633bfc4f5a8d5acf8/ee0a1/assets/img/posts/eslint-collective.png
     linter_rules_configuration_url: https://eslint.org/docs/latest/use/configure
-    linter_rules_inline_disable_url: https://eslint.org/docs/latest/use/configure/rules#disabling-rules
     linter_rules_ignore_config_url: https://eslint.org/docs/latest/use/configure/ignore#the-eslintignore-file
-    linter_megalinter_ref_url: https://eslint.org/docs/latest/use/integrations#source-control
-    active_only_if_file_found:
-      - "eslint.config.js"
-      - "eslint.config.mjs"
-      - "eslint.config.cjs"
-      - "eslint.config.ts"
-      - "eslint.config.mts"
-      - "eslint.config.cts"
-      - ".eslintrc.json"
-      - ".eslintrc.yml"
-      - ".eslintrc.yaml"
-      - ".eslintrc.js"
-      - ".eslintrc.cjs"
-      - "package.json:eslintConfig"
-    cli_lint_mode: list_of_files
-    supported_cli_lint_modes:
-      - file
-      - list_of_files
-      - project
     config_file_name: eslint.config.js
-    cli_lint_extra_args:
-      - "--no-ignore"
-    cli_lint_mode_project_extra_args_after:
-      - .
-    cli_lint_fix_arg_name: "--fix"
-    cli_sarif_args:
-      - --format
-      - "@microsoft/eslint-formatter-sarif"
-      - -o
-      - "{{SARIF_OUTPUT_FILE}}"
-    cli_lint_errors_count: regex_sum
-    cli_lint_errors_regex: "✖ ([0-9]+) problem"
     common_linter_errors:
       - identifier: JAVASCRIPT_ES_ERROR_PLUGIN_NOT_FOUND
         regex: '(Failed to load plugin ''|ESLint couldn''t find the plugin "|Cannot find module ''eslint-plugin-)'
@@ -246,36 +212,6 @@ linters:
         - eslint-plugin-promise@${NPM_ESLINT_PLUGIN_PROMISE_VERSION}
         - eslint-plugin-vue@${NPM_ESLINT_PLUGIN_VUE_VERSION}
         - "@microsoft/eslint-formatter-sarif@${NPM_MICROSOFT_ESLINT_FORMATTER_SARIF_VERSION}"
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-    ide:
-      brackets:
-        - name: brackets-eslint
-          url: https://github.com/brackets-userland/brackets-eslint
-      eclipse:
-        - name: Tern-Linter-ESLint
-          url: https://github.com/angelozerr/tern.java/wiki/Tern-Linter-ESLint
-      emacs:
-        - name: flycheck
-          url: http://www.flycheck.org/en/latest/languages.html#javascript
-      idea:
-        - name: ESLint Plugin
-          url: https://plugins.jetbrains.com/plugin/7494-eslint
-          id: com.wix.eslint
-      sublime:
-        - name: SublimeLinter-eslint
-          url: https://github.com/roadhump/SublimeLinter-eslint
-      vim:
-        - name: ale
-          url: https://github.com/w0rp/ale
-        - name: Syntastic
-          url: https://github.com/vim-syntastic/syntastic/tree/master/syntax_checkers/javascript
-      vscode:
-        - name: vscode-eslint
-          url: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
-  # STANDARD
   - class: JavaScriptStandardLinter
     linter_name: standard
     linter_text: |
@@ -344,7 +280,8 @@ linters:
         - name: vscode-standard
           url: https://marketplace.visualstudio.com/items?itemName=standard.vscode-standard
   # PRETTIER
-  - linter_name: prettier
+  - extends: prettier
+    linter_name: prettier
     linter_text: |
       **Prettier** is the industry-leading opinionated code formatter that brings consistency to JavaScript and many other languages by automatically reformatting code according to proven formatting principles. It eliminates formatting debates and ensures uniform code style across entire development teams.
 
@@ -358,36 +295,12 @@ linters:
       - **Fast Performance**: High-speed formatting suitable for large codebases
       - **Configuration Flexibility**: Supports project-specific settings through .prettierrc files when customization is needed
       - **Git Integration**: Reduces merge conflicts by maintaining consistent formatting across branches
-    is_formatter: true
-    linter_spdx_license: MIT
     activation_rules:
       - type: variable
         variable: JAVASCRIPT_DEFAULT_STYLE
         expected_value: prettier
         default_value: standard
-    linter_url: https://prettier.io/
-    linter_repo: https://github.com/prettier/prettier
-    linter_megalinter_ref_url: https://prettier.io/docs/related-projects
-    linter_rules_url: https://prettier.io/docs/en/options.html
-    linter_rules_configuration_url: https://prettier.io/docs/en/configuration.html
     linter_rules_inline_disable_url: https://prettier.io/docs/en/ignore.html#javascript
-    linter_banner_image_url: https://unpkg.com/prettier-logo@1.0.3/images/prettier-banner-light.svg
-    config_file_name: ".prettierrc.json"
-    cli_lint_mode: list_of_files
-    supported_cli_lint_modes:
-      - file
-      - list_of_files
-      - project
-    cli_config_arg_name: "--config"
-    cli_lint_extra_args:
-      - "--check"
-    cli_lint_mode_project_exclude_ignore_file_arg_name: "--ignore-path"
-    cli_lint_mode_project_exclude_ignore_file_pass_existing: [".gitignore", ".prettierignore"]
-    cli_lint_mode_project_extra_args_after:
-      - .
-    cli_lint_fix_arg_name: "--write" # Workaround for MegaLinter
-    cli_lint_fix_remove_args:
-      - "--check"
     test_folder: javascript_prettier
     test_variables:
       JAVASCRIPT_DEFAULT_STYLE: prettier
@@ -395,38 +308,3 @@ linters:
       - "prettier --check myfile.js"
       - "prettier --config .prettierrc.json --check myfile.js"
       - "prettier --config .prettierrc.json --write myfile.js" # format
-    install:
-      dockerfile:
-        - |-
-          # renovate: datasource=npm depName=prettier
-          ARG NPM_PRETTIER_VERSION=3.9.6
-      npm:
-        - "prettier@${NPM_PRETTIER_VERSION}"
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-    ide:
-      emacs:
-        - name: prettier-emacs
-          url: https://github.com/prettier/prettier-emacs
-        - name: prettier.el
-          url: https://github.com/jscheid/prettier.el
-        - name: apheleia
-          url: https://github.com/raxod502/apheleia
-      idea:
-        - name: Prettier
-          url: https://plugins.jetbrains.com/plugin/10456-prettier
-          id: intellij.prettierJS
-      sublime:
-        - name: JsPrettier
-          url: https://packagecontrol.io/packages/JsPrettier
-      vim:
-        - name: vim-prettier
-          url: https://github.com/prettier/vim-prettier
-      visual_studio:
-        - name: JavaScriptPrettier
-          url: https://github.com/madskristensen/JavaScriptPrettier
-      vscode:
-        - name: prettier-vscode
-          url: https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode

--- a/megalinter/descriptors/json.megalinter-descriptor.yml
+++ b/megalinter/descriptors/json.megalinter-descriptor.yml
@@ -58,12 +58,8 @@ linters:
         - linux/amd64
         - linux/arm64
   # V8R
-  - class: V8rLinter
+  - extends: v8r
     linter_name: v8r
-    linter_url: https://github.com/chris48s/v8r
-    linter_repo: https://github.com/chris48s/v8r
-    linter_spdx_license: MIT
-    linter_speed: 1
     linter_text: |
       **v8r** is a command-line validator for JSON, YAML, and TOML files that automatically detects and applies appropriate schemas from the Schema Store based on filename patterns, providing intelligent validation without manual schema configuration.
 
@@ -74,20 +70,8 @@ linters:
       - **Zero Configuration**: Works out-of-the-box for common configuration files without requiring explicit schema specification
       - **Schema Store Integration**: Leverages the extensive collection of schemas from schemastore.org for popular tools and frameworks
       - **Detailed Error Reporting**: Provides clear, actionable validation error messages with line and column information
-    linter_rules_url: https://www.schemastore.org/
-    linter_megalinter_ref_url: "no"
-    config_file_name: ".v8rrc.yml"
-    cli_config_arg_name: ""
-    cli_lint_mode: list_of_files
-    supported_cli_lint_modes:
-      - file
-      - list_of_files
-      - project
-    cli_lint_extra_args:
-      - "--ignore-errors"
     cli_lint_mode_project_extra_args_after:
       - "**/*.json"
-    cli_help_arg_name: "--help"
     common_linter_errors:
       - identifier: JSON_V8R_ERROR_SCHEMASTORE_UNREACHABLE
         regex: "(ENOTFOUND|ECONNREFUSED|ETIMEDOUT|getaddrinfo|fetch failed).*(schemastore|json\\.schemastore\\.org)"
@@ -103,32 +87,8 @@ linters:
     test_folder: json_schema
     examples:
       - "v8r --ignore-errors myfile.json"
-    install:
-      dockerfile:
-        - |-
-          # renovate: datasource=npm depName=v8r
-          ARG NPM_V8R_VERSION=6.1.0
-      npm:
-        - v8r@${NPM_V8R_VERSION}
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-    ide:
-      eclipse:
-        - name: native support
-          url: https://www.eclipse.org/
-      idea:
-        - name: native support
-          url: https://www.jetbrains.com/products/#type=ide
-      vim:
-        - name: vison
-          url: https://github.com/Quramy/vison
-      vscode:
-        - name: native support
-          url: https://code.visualstudio.com/
-  # PRETTIER
-  - linter_name: prettier
+  - extends: prettier
+    linter_name: prettier
     linter_text: |
       **Prettier** is the industry-standard opinionated code formatter with excellent JSON support that automatically formats JSON files for consistency and readability. It brings professional formatting standards to JSON data across configuration files, APIs, and data structures.
 
@@ -142,72 +102,12 @@ linters:
       - **Nested Structure Handling**: Intelligent formatting of complex nested objects and arrays for optimal readability
       - **Team Standardization**: Eliminates JSON formatting debates and ensures uniform data structure presentation
       - **Configuration Flexibility**: Supports project-specific formatting rules through .prettierrc when customization is needed
-    is_formatter: true
-    linter_url: https://prettier.io/
-    linter_repo: https://github.com/prettier/prettier
-    linter_megalinter_ref_url: https://prettier.io/docs/related-projects
-    linter_spdx_license: MIT
-    linter_rules_url: https://prettier.io/docs/en/options.html
-    linter_rules_configuration_url: https://prettier.io/docs/en/configuration.html
     linter_rules_inline_disable_url: https://prettier.io/docs/en/ignore.html#javascript
-    linter_banner_image_url: https://unpkg.com/prettier-logo@1.0.3/images/prettier-banner-light.svg
-    config_file_name: ".prettierrc.json"
-    cli_config_arg_name: "--config"
-    cli_lint_mode: list_of_files
-    supported_cli_lint_modes:
-      - file
-      - list_of_files
-      - project
-    cli_lint_extra_args:
-      - "--check"
-    cli_lint_mode_project_exclude_ignore_file_arg_name: "--ignore-path"
-    cli_lint_mode_project_exclude_ignore_file_pass_existing: [".gitignore", ".prettierignore"]
-    cli_lint_mode_project_extra_args_after:
-      - .
-    cli_lint_fix_arg_name: "--write" # Workaround for MegaLinter
-    cli_lint_fix_remove_args:
-      - "--check"
     test_folder: json_prettier
     examples:
       - "prettier --check myfile.json"
       - "prettier --config .prettierrc.json --check myfile.json"
       - "prettier --config .prettierrc.json --write myfile.json" # format
-    install:
-      dockerfile:
-        - |-
-          # renovate: datasource=npm depName=prettier
-          ARG NPM_PRETTIER_VERSION=3.9.6
-      npm:
-        - "prettier@${NPM_PRETTIER_VERSION}"
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-    ide:
-      emacs:
-        - name: prettier-emacs
-          url: https://github.com/prettier/prettier-emacs
-        - name: prettier.el
-          url: https://github.com/jscheid/prettier.el
-        - name: apheleia
-          url: https://github.com/raxod502/apheleia
-      idea:
-        - name: Prettier
-          url: https://plugins.jetbrains.com/plugin/10456-prettier
-          id: intellij.prettierJS
-      sublime:
-        - name: JsPrettier
-          url: https://packagecontrol.io/packages/JsPrettier
-      vim:
-        - name: vim-prettier
-          url: https://github.com/prettier/vim-prettier
-      visual_studio:
-        - name: JavaScriptPrettier
-          url: https://github.com/madskristensen/JavaScriptPrettier
-      vscode:
-        - name: prettier-vscode
-          url: https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode
-  # npm-package-json-lint
   - linter_name: npm-package-json-lint
     linter_text: |
       **npm-package-json-lint** is a specialized linter designed specifically for npm package.json files that ensures consistency, correctness, and adherence to best practices in Node.js project configuration. It serves as an essential tool for maintaining professional npm package standards.

--- a/megalinter/descriptors/jsx.megalinter-descriptor.yml
+++ b/megalinter/descriptors/jsx.megalinter-descriptor.yml
@@ -9,9 +9,8 @@ file_extensions:
   - ".jsx"
 linters:
   # ESLINT
-  - class: EslintLinter
+  - extends: eslint
     linter_name: eslint
-    can_output_sarif: true
     linter_text: |
       **ESLint with React Plugin** provides comprehensive linting for JSX files, combining ESLint's powerful static analysis with React-specific rules to ensure high-quality React applications written in JavaScript.
 
@@ -76,44 +75,11 @@ linters:
       To add a single package with pnpm instead of installing the full tree, run `corepack enable pnpm` first, then `pnpm add --ignore-workspace --no-save <package>`.
     linter_url: https://github.com/Rel1cx/eslint-react
     linter_repo: https://github.com/Rel1cx/eslint-react
-    linter_spdx_license: MIT
     linter_rules_url: https://eslint-react.xyz/docs/rules/overview
     linter_banner_image_url: https://d33wubrfki0l68.cloudfront.net/3b5ac7586466159bb6f237b633bfc4f5a8d5acf8/ee0a1/assets/img/posts/eslint-collective.png
     linter_rules_configuration_url: https://eslint-react.xyz/docs/getting-started/installation
-    linter_rules_inline_disable_url: https://eslint.org/docs/latest/use/configure/rules#disabling-rules
     linter_rules_ignore_config_url: https://eslint.org/docs/latest/user-guide/configuring/ignoring-code#the-eslintignore-file
-    linter_megalinter_ref_url: https://eslint.org/docs/latest/use/integrations#source-control
-    active_only_if_file_found:
-      - eslint.config.js
-      - eslint.config.mjs
-      - eslint.config.cjs
-      - eslint.config.ts
-      - eslint.config.mts
-      - eslint.config.cts
-      - ".eslintrc.json"
-      - ".eslintrc.yml"
-      - ".eslintrc.yaml"
-      - ".eslintrc.js"
-      - ".eslintrc.cjs"
-      - "package.json:eslintConfig"
-    cli_lint_mode: list_of_files
-    supported_cli_lint_modes:
-      - file
-      - list_of_files
-      - project
     config_file_name: eslint.config.cjs
-    cli_lint_extra_args:
-      - "--no-ignore"
-    cli_lint_mode_project_extra_args_after:
-      - .
-    cli_lint_fix_arg_name: "--fix"
-    cli_sarif_args:
-      - --format
-      - "@microsoft/eslint-formatter-sarif"
-      - -o
-      - "{{SARIF_OUTPUT_FILE}}"
-    cli_lint_errors_count: regex_sum
-    cli_lint_errors_regex: "✖ ([0-9]+) problem"
     common_linter_errors:
       - identifier: JSX_ESLINT_ERROR_PLUGIN_NOT_FOUND
         regex: '(Failed to load plugin ''|ESLint couldn''t find the plugin "|Cannot find module ''eslint-plugin-)'
@@ -173,32 +139,3 @@ linters:
         - eslint@${NPM_ESLINT_VERSION}
         - "@eslint-react/eslint-plugin@${NPM_ESLINT_REACT_ESLINT_PLUGIN_VERSION}"
         - "@microsoft/eslint-formatter-sarif@${NPM_MICROSOFT_ESLINT_FORMATTER_SARIF_VERSION}"
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-    ide:
-      brackets:
-        - name: brackets-eslint
-          url: https://github.com/brackets-userland/brackets-eslint
-      eclipse:
-        - name: Tern-Linter-ESLint
-          url: https://github.com/angelozerr/tern.java/wiki/Tern-Linter-ESLint
-      emacs:
-        - name: flycheck
-          url: http://www.flycheck.org/en/latest/languages.html#javascript
-      idea:
-        - name: ESLint Plugin
-          url: https://plugins.jetbrains.com/plugin/7494-eslint
-          id: com.wix.eslint
-      sublime:
-        - name: SublimeLinter-eslint
-          url: https://github.com/roadhump/SublimeLinter-eslint
-      vim:
-        - name: ale
-          url: https://github.com/w0rp/ale
-        - name: Syntastic
-          url: https://github.com/vim-syntastic/syntastic/tree/master/syntax_checkers/javascript
-      vscode:
-        - name: vscode-eslint
-          url: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint

--- a/megalinter/descriptors/php.megalinter-descriptor.yml
+++ b/megalinter/descriptors/php.megalinter-descriptor.yml
@@ -142,7 +142,7 @@ linters:
     linter_spdx_license: MIT
     linter_url: https://phpstan.org/
     linter_repo: https://github.com/phpstan/phpstan
-    linter_megalinter_ref_url: no
+    linter_megalinter_ref_url: "no"
     linter_image_url: https://i.imgur.com/WaRKPlC.png
     linter_rules_configuration_url: https://phpstan.org/config-reference#neon-format
     linter_rules_inline_disable_url: https://phpstan.org/user-guide/ignoring-errors#ignoring-in-code-using-phpdocs

--- a/megalinter/descriptors/python.megalinter-descriptor.yml
+++ b/megalinter/descriptors/python.megalinter-descriptor.yml
@@ -179,7 +179,7 @@ linters:
         default_value: black
     linter_url: https://black.readthedocs.io/en/stable/
     linter_repo: https://github.com/psf/black
-    linter_megalinter_ref_url: no
+    linter_megalinter_ref_url: "no"
     linter_spdx_license: MIT
     linter_speed: 3
     linter_banner_image_url: https://raw.githubusercontent.com/psf/black/master/docs/_static/logo2-readme.png
@@ -436,7 +436,7 @@ linters:
       Bandit is essential for maintaining secure Python codebases and is widely used in security-conscious development environments.
     linter_url: https://bandit.readthedocs.io/en/latest/
     linter_repo: https://github.com/PyCQA/bandit
-    linter_megalinter_ref_url: no
+    linter_megalinter_ref_url: "no"
     linter_spdx_license: Apache-2.0
     linter_rules_url: https://bandit.readthedocs.io/en/latest/plugins/index.html#complete-test-plugin-listing
     linter_banner_image_url: https://github.com/PyCQA/bandit/raw/main/logo/logotype-sm.png

--- a/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json
@@ -449,6 +449,19 @@
       "items": {
         "$id": "#/properties/linters/items",
         "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "extends"
+            ]
+          },
+          {
+            "required": [
+              "linter_url",
+              "examples"
+            ]
+          }
+        ],
         "description": "Parameters defining behaviour and installation of a linter",
         "examples": [
           {
@@ -1070,6 +1083,16 @@
             },
             "title": "Linter CLI commands examples",
             "type": "array"
+          },
+          "extends": {
+            "$id": "#/properties/linters/items/properties/extends",
+            "description": "Name of a shared linter definition file located in megalinter/descriptors/shared/<name>.megalinter-linter.yml. Properties defined in the descriptor linter entry override the shared ones (shallow merge, no chaining)",
+            "examples": [
+              "eslint",
+              "prettier"
+            ],
+            "title": "Shared linter definition to extend",
+            "type": "string"
           },
           "file_extensions": {
             "$id": "#/properties/linters/items/file_extensions",
@@ -1752,9 +1775,7 @@
           }
         },
         "required": [
-          "linter_name",
-          "linter_url",
-          "examples"
+          "linter_name"
         ],
         "title": "Linter definition",
         "type": "object"

--- a/megalinter/descriptors/schemas/megalinter-linter.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-linter.jsonschema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "http://github.com/oxsecurity/megalinter-linter.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$ref": "megalinter-descriptor.jsonschema.json#/properties/linters/items",
+  "description": "Shared linter definition, extendable from megalinter descriptor files with the linter-level extends property",
+  "title": "MegaLinter shared linter definition"
+}

--- a/megalinter/descriptors/shared/clang-format.megalinter-linter.yml
+++ b/megalinter/descriptors/shared/clang-format.megalinter-linter.yml
@@ -1,0 +1,42 @@
+---
+linter_name: clang-format
+descriptor_flavors:
+  - c_cpp
+linter_url: https://releases.llvm.org/21.1.0/tools/clang/docs/ClangFormat.html
+linter_repo: https://github.com/llvm/llvm-project
+linter_spdx_license: Apache-2.0
+linter_rules_url: https://releases.llvm.org/21.1.0/tools/clang/docs/ClangFormat.html
+linter_rules_configuration_url: https://releases.llvm.org/21.1.0/tools/clang/docs/ClangFormatStyleOptions.html
+linter_rules_inline_disable_url: https://releases.llvm.org/21.1.0/tools/clang/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code
+cli_lint_mode: list_of_files
+supported_cli_lint_modes:
+  - file
+  - list_of_files
+cli_help_arg_name: --help
+cli_lint_extra_args:
+  - --Werror
+  - --dry-run
+cli_lint_fix_arg_name: -i
+cli_lint_fix_remove_args:
+  - --Werror
+  - --dry-run
+config_file_name: .clang-format
+cli_config_arg_name: "--style=file:"
+cli_lint_errors_count: regex_count
+cli_lint_errors_regex: code should be clang-formatted
+install:
+  apk:
+    - cmd:clang-format
+supported_platforms:
+  platform:
+    - linux/amd64
+    - linux/arm64
+ide:
+  vscode:
+    - name: Clang-Format
+      url: https://marketplace.visualstudio.com/items?itemName=xaver.clang-format
+  emacs:
+    - name: clang-format
+      url: https://releases.llvm.org/21.1.0/tools/clang/docs/ClangFormat.html#emacs-integration
+examples:
+  - clang-format --Werror --dry-run myfile.c

--- a/megalinter/descriptors/shared/cppcheck.megalinter-linter.yml
+++ b/megalinter/descriptors/shared/cppcheck.megalinter-linter.yml
@@ -1,0 +1,30 @@
+---
+linter_name: cppcheck
+linter_url: https://cppcheck.sourceforge.io/
+linter_repo: https://cppcheck.sourceforge.io/
+linter_megalinter_ref_url: https://github.com/cppcheck-opensource/cppcheck/pull/8786
+linter_spdx_license: GPL-3.0
+linter_rules_url: https://sourceforge.net/p/cppcheck/wiki/ListOfChecks/
+linter_rules_configuration_url: https://cppcheck.sourceforge.io/manual.html#configuration
+cli_lint_errors_count: regex_count
+cli_lint_errors_regex: "error:"
+cli_lint_mode: list_of_files
+supported_cli_lint_modes:
+  - file
+  - list_of_files
+  - project
+cli_lint_extra_args:
+  - --error-exitcode=1
+cli_lint_mode_project_exclude_arg_name: -i
+cli_lint_mode_project_exclude_arg_value: "**/{{DIR}}/**"
+cli_lint_mode_project_extra_args_after:
+  - .
+examples:
+  - cppcheck myfile.cpp
+install:
+  apk:
+    - cppcheck
+supported_platforms:
+  platform:
+    - linux/amd64
+    - linux/arm64

--- a/megalinter/descriptors/shared/cpplint.megalinter-linter.yml
+++ b/megalinter/descriptors/shared/cpplint.megalinter-linter.yml
@@ -1,0 +1,28 @@
+---
+class: CppLintLinter
+linter_name: cpplint
+linter_url: https://github.com/cpplint/cpplint
+linter_repo: https://github.com/cpplint/cpplint
+linter_megalinter_ref_url: https://github.com/cpplint/cpplint/pull/462
+linter_spdx_license: BSD-3-Clause
+linter_rules_url: https://google.github.io/styleguide/cppguide.html
+cli_lint_mode: list_of_files
+supported_cli_lint_modes:
+  - file
+  - list_of_files
+cli_help_arg_name: --help
+cli_lint_errors_count: regex_number
+cli_lint_errors_regex: "Total errors found: ([0-9]+)"
+examples:
+  - cpplint myfile.cpp
+install:
+  dockerfile:
+    - |-
+      # renovate: datasource=pypi depName=cpplint
+      ARG PIP_CPPLINT_VERSION=2.0.2
+  pip:
+    - cpplint==${PIP_CPPLINT_VERSION}
+supported_platforms:
+  platform:
+    - linux/amd64
+    - linux/arm64

--- a/megalinter/descriptors/shared/dotnet-format.megalinter-linter.yml
+++ b/megalinter/descriptors/shared/dotnet-format.megalinter-linter.yml
@@ -1,0 +1,34 @@
+---
+class: DotnetFormatLinter
+linter_name: dotnet-format
+is_formatter: true
+linter_url: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-format
+linter_repo: https://github.com/dotnet/sdk
+linter_spdx_license: MIT
+linter_rules_configuration_url: https://github.com/dotnet/sdk/tree/main/documentation/format/docs
+linter_rules_inline_disable_url: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings
+linter_image_url: https://user-images.githubusercontent.com/9797472/61659851-6bbdc880-ac7d-11e9-95f7-d30c7de1a18a.png
+cli_lint_errors_count: regex_count
+cli_executable: dotnet
+cli_lint_mode: project
+supported_cli_lint_modes:
+  - project
+cli_lint_extra_args:
+  - format
+cli_lint_mode_project_exclude_arg_name: --exclude
+cli_lint_mode_project_exclude_arg_value: ./{{DIR}}/
+cli_lint_fix_arg_name: --megalinter-fix-flag
+cli_lint_fix_remove_args:
+  - --verify-no-changes
+cli_help_extra_args:
+  - format
+supported_platforms:
+  platform:
+    - linux/amd64
+    - linux/arm64
+examples:
+  - dotnet format --verify-no-changes
+  - dotnet format Solution.sln --verify-no-changes
+  - dotnet format Folder/Solution.sln --verify-no-changes
+  - dotnet format Project.csproj --verify-no-changes
+  - dotnet format

--- a/megalinter/descriptors/shared/eslint.megalinter-linter.yml
+++ b/megalinter/descriptors/shared/eslint.megalinter-linter.yml
@@ -1,0 +1,71 @@
+---
+class: EslintLinter
+linter_name: eslint
+can_output_sarif: true
+linter_spdx_license: MIT
+linter_rules_inline_disable_url: https://eslint.org/docs/latest/use/configure/rules#disabling-rules
+linter_megalinter_ref_url: https://eslint.org/docs/latest/use/integrations#source-control
+active_only_if_file_found:
+  - eslint.config.js
+  - eslint.config.mjs
+  - eslint.config.cjs
+  - eslint.config.ts
+  - eslint.config.mts
+  - eslint.config.cts
+  - .eslintrc.json
+  - .eslintrc.yml
+  - .eslintrc.yaml
+  - .eslintrc.js
+  - .eslintrc.cjs
+  - package.json:eslintConfig
+cli_lint_mode: list_of_files
+supported_cli_lint_modes:
+  - file
+  - list_of_files
+  - project
+cli_lint_extra_args:
+  - --no-ignore
+cli_lint_mode_project_extra_args_after:
+  - .
+cli_lint_fix_arg_name: --fix
+cli_sarif_args:
+  - --format
+  - "@microsoft/eslint-formatter-sarif"
+  - -o
+  - "{{SARIF_OUTPUT_FILE}}"
+cli_lint_errors_count: regex_sum
+cli_lint_errors_regex: ✖ ([0-9]+) problem
+supported_platforms:
+  platform:
+    - linux/amd64
+    - linux/arm64
+ide:
+  brackets:
+    - name: brackets-eslint
+      url: https://github.com/brackets-userland/brackets-eslint
+  eclipse:
+    - name: Tern-Linter-ESLint
+      url: https://github.com/angelozerr/tern.java/wiki/Tern-Linter-ESLint
+  emacs:
+    - name: flycheck
+      url: http://www.flycheck.org/en/latest/languages.html#javascript
+  idea:
+    - name: ESLint Plugin
+      url: https://plugins.jetbrains.com/plugin/7494-eslint
+      id: com.wix.eslint
+  sublime:
+    - name: SublimeLinter-eslint
+      url: https://github.com/roadhump/SublimeLinter-eslint
+  vim:
+    - name: ale
+      url: https://github.com/w0rp/ale
+    - name: Syntastic
+      url: https://github.com/vim-syntastic/syntastic/tree/master/syntax_checkers/javascript
+  vscode:
+    - name: vscode-eslint
+      url: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
+linter_url: https://eslint.org
+examples:
+  - eslint myfile.js
+  - eslint -c eslint.config.js --no-ignore myfile.js
+  - eslint --fix -c eslint.config.js --no-ignore myfile.js

--- a/megalinter/descriptors/shared/prettier.megalinter-linter.yml
+++ b/megalinter/descriptors/shared/prettier.megalinter-linter.yml
@@ -1,0 +1,67 @@
+---
+linter_name: prettier
+is_formatter: true
+linter_spdx_license: MIT
+linter_url: https://prettier.io/
+linter_repo: https://github.com/prettier/prettier
+linter_megalinter_ref_url: https://prettier.io/docs/related-projects
+linter_rules_url: https://prettier.io/docs/en/options.html
+linter_rules_configuration_url: https://prettier.io/docs/en/configuration.html
+linter_banner_image_url: https://unpkg.com/prettier-logo@1.0.3/images/prettier-banner-light.svg
+config_file_name: .prettierrc.json
+cli_lint_mode: list_of_files
+supported_cli_lint_modes:
+  - file
+  - list_of_files
+  - project
+cli_config_arg_name: --config
+cli_lint_extra_args:
+  - --check
+cli_lint_mode_project_exclude_ignore_file_arg_name: --ignore-path
+cli_lint_mode_project_exclude_ignore_file_pass_existing:
+  - .gitignore
+  - .prettierignore
+cli_lint_mode_project_extra_args_after:
+  - .
+cli_lint_fix_arg_name: --write
+cli_lint_fix_remove_args:
+  - --check
+install:
+  dockerfile:
+    - |-
+      # renovate: datasource=npm depName=prettier
+      ARG NPM_PRETTIER_VERSION=3.9.6
+  npm:
+    - prettier@${NPM_PRETTIER_VERSION}
+supported_platforms:
+  platform:
+    - linux/amd64
+    - linux/arm64
+ide:
+  emacs:
+    - name: prettier-emacs
+      url: https://github.com/prettier/prettier-emacs
+    - name: prettier.el
+      url: https://github.com/jscheid/prettier.el
+    - name: apheleia
+      url: https://github.com/raxod502/apheleia
+  idea:
+    - name: Prettier
+      url: https://plugins.jetbrains.com/plugin/10456-prettier
+      id: intellij.prettierJS
+  sublime:
+    - name: JsPrettier
+      url: https://packagecontrol.io/packages/JsPrettier
+  vim:
+    - name: vim-prettier
+      url: https://github.com/prettier/vim-prettier
+  visual_studio:
+    - name: JavaScriptPrettier
+      url: https://github.com/madskristensen/JavaScriptPrettier
+  vscode:
+    - name: prettier-vscode
+      url: https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode
+examples:
+  - prettier --check myfile.js
+  - prettier --config .prettierrc.json --check myfile.js
+  - prettier --config .prettierrc.json --write myfile.js

--- a/megalinter/descriptors/shared/v8r.megalinter-linter.yml
+++ b/megalinter/descriptors/shared/v8r.megalinter-linter.yml
@@ -1,0 +1,45 @@
+---
+class: V8rLinter
+linter_name: v8r
+linter_url: https://github.com/chris48s/v8r
+linter_repo: https://github.com/chris48s/v8r
+linter_spdx_license: MIT
+linter_speed: 1
+linter_rules_url: https://www.schemastore.org/
+linter_megalinter_ref_url: "no"
+config_file_name: .v8rrc.yml
+cli_config_arg_name: ""
+cli_lint_mode: list_of_files
+supported_cli_lint_modes:
+  - file
+  - list_of_files
+  - project
+cli_lint_extra_args:
+  - --ignore-errors
+cli_help_arg_name: --help
+install:
+  dockerfile:
+    - |-
+      # renovate: datasource=npm depName=v8r
+      ARG NPM_V8R_VERSION=6.1.0
+  npm:
+    - v8r@${NPM_V8R_VERSION}
+supported_platforms:
+  platform:
+    - linux/amd64
+    - linux/arm64
+ide:
+  eclipse:
+    - name: native support
+      url: https://www.eclipse.org/
+  idea:
+    - name: native support
+      url: https://www.jetbrains.com/products/#type=ide
+  vim:
+    - name: vison
+      url: https://github.com/Quramy/vison
+  vscode:
+    - name: native support
+      url: https://code.visualstudio.com/
+examples:
+  - v8r --ignore-errors myfile.json

--- a/megalinter/descriptors/tsx.megalinter-descriptor.yml
+++ b/megalinter/descriptors/tsx.megalinter-descriptor.yml
@@ -9,9 +9,8 @@ file_extensions:
   - ".tsx"
 linters:
   # ESLINT
-  - class: EslintLinter
+  - extends: eslint
     linter_name: eslint
-    can_output_sarif: true
     linter_text: |
       **ESLint with React Plugin** provides comprehensive linting for TSX (TypeScript React) files, combining ESLint's powerful static analysis with React-specific rules to ensure high-quality React applications written in TypeScript.
 
@@ -80,41 +79,8 @@ linters:
     linter_rules_url: https://eslint-react.xyz/docs/rules/overview
     linter_banner_image_url: https://d33wubrfki0l68.cloudfront.net/3b5ac7586466159bb6f237b633bfc4f5a8d5acf8/ee0a1/assets/img/posts/eslint-collective.png
     linter_rules_configuration_url: https://eslint-react.xyz/docs/getting-started/installation
-    linter_rules_inline_disable_url: https://eslint.org/docs/latest/use/configure/rules#disabling-rules
     linter_rules_ignore_config_url: https://eslint.org/docs/latest/use/configure/ignore#the-eslintignore-file
-    linter_megalinter_ref_url: https://eslint.org/docs/latest/use/integrations#source-control
-    linter_spdx_license: MIT
-    active_only_if_file_found:
-      - "eslint.config.js"
-      - "eslint.config.mjs"
-      - "eslint.config.cjs"
-      - "eslint.config.ts"
-      - "eslint.config.mts"
-      - "eslint.config.cts"
-      - ".eslintrc.json"
-      - ".eslintrc.yml"
-      - ".eslintrc.yaml"
-      - ".eslintrc.js"
-      - ".eslintrc.cjs"
-      - "package.json:eslintConfig"
-    cli_lint_mode: list_of_files
-    supported_cli_lint_modes:
-      - file
-      - list_of_files
-      - project
     config_file_name: eslint.config.cjs
-    cli_lint_extra_args:
-      - "--no-ignore"
-    cli_lint_mode_project_extra_args_after:
-      - .
-    cli_lint_fix_arg_name: "--fix"
-    cli_sarif_args:
-      - --format
-      - "@microsoft/eslint-formatter-sarif"
-      - -o
-      - "{{SARIF_OUTPUT_FILE}}"
-    cli_lint_errors_count: regex_sum
-    cli_lint_errors_regex: "✖ ([0-9]+) problem"
     common_linter_errors:
       - identifier: TSX_ESLINT_ERROR_PLUGIN_NOT_FOUND
         regex: '(Failed to load plugin ''|ESLint couldn''t find the plugin "|Cannot find module ''eslint-plugin-)'
@@ -218,32 +184,3 @@ linters:
         - "@typescript-eslint/eslint-plugin@${NPM_TYPESCRIPT_ESLINT_ESLINT_PLUGIN_VERSION}"
         - "@typescript-eslint/parser@${NPM_TYPESCRIPT_ESLINT_PARSER_VERSION}"
         - "@microsoft/eslint-formatter-sarif@${NPM_MICROSOFT_ESLINT_FORMATTER_SARIF_VERSION}"
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-    ide:
-      brackets:
-        - name: brackets-eslint
-          url: https://github.com/brackets-userland/brackets-eslint
-      eclipse:
-        - name: Tern-Linter-ESLint
-          url: https://github.com/angelozerr/tern.java/wiki/Tern-Linter-ESLint
-      emacs:
-        - name: flycheck
-          url: http://www.flycheck.org/en/latest/languages.html#javascript
-      idea:
-        - name: ESLint Plugin
-          url: https://plugins.jetbrains.com/plugin/7494-eslint
-          id: com.wix.eslint
-      sublime:
-        - name: SublimeLinter-eslint
-          url: https://github.com/roadhump/SublimeLinter-eslint
-      vim:
-        - name: ale
-          url: https://github.com/w0rp/ale
-        - name: Syntastic
-          url: https://github.com/vim-syntastic/syntastic/tree/master/syntax_checkers/javascript
-      vscode:
-        - name: vscode-eslint
-          url: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint

--- a/megalinter/descriptors/typescript.megalinter-descriptor.yml
+++ b/megalinter/descriptors/typescript.megalinter-descriptor.yml
@@ -17,11 +17,9 @@ install:
     - typescript@${NPM_TYPESCRIPT_VERSION}
 linters:
   # ESLINT
-  - class: EslintLinter
+  - extends: eslint
     linter_name: eslint
     name: TYPESCRIPT_ES
-    can_output_sarif: true
-    linter_spdx_license: MIT
     linter_text: |
       **TypeScript ESLint** enables ESLint to run on TypeScript code, bringing together the best of both tools to help you write high-quality TypeScript applications.
 
@@ -90,40 +88,8 @@ linters:
     linter_rules_url: https://typescript-eslint.io/rules/
     linter_banner_image_url: https://typescript-eslint.io/img/logo.svg
     linter_rules_configuration_url: https://typescript-eslint.io/getting-started/#configuration-values
-    linter_rules_inline_disable_url: https://eslint.org/docs/latest/use/configure/rules#disabling-rules
     linter_rules_ignore_config_url: https://eslint.org/docs/latest/use/configure/ignore#the-eslintignore-file
-    linter_megalinter_ref_url: https://eslint.org/docs/latest/use/integrations#source-control
-    active_only_if_file_found:
-      - "eslint.config.js"
-      - "eslint.config.mjs"
-      - "eslint.config.cjs"
-      - "eslint.config.ts"
-      - "eslint.config.mts"
-      - "eslint.config.cts"
-      - ".eslintrc.json"
-      - ".eslintrc.yml"
-      - ".eslintrc.yaml"
-      - ".eslintrc.js"
-      - ".eslintrc.cjs"
-      - "package.json:eslintConfig"
-    cli_lint_mode: list_of_files
-    supported_cli_lint_modes:
-      - file
-      - list_of_files
-      - project
     config_file_name: eslint.config.js
-    cli_lint_extra_args:
-      - "--no-ignore"
-    cli_lint_mode_project_extra_args_after:
-      - .
-    cli_lint_fix_arg_name: "--fix"
-    cli_sarif_args:
-      - --format
-      - "@microsoft/eslint-formatter-sarif"
-      - -o
-      - "{{SARIF_OUTPUT_FILE}}"
-    cli_lint_errors_count: regex_sum
-    cli_lint_errors_regex: "✖ ([0-9]+) problem"
     common_linter_errors:
       - identifier: TYPESCRIPT_ES_ERROR_PLUGIN_NOT_FOUND
         regex: '(Failed to load plugin ''|ESLint couldn''t find the plugin "|Cannot find module ''eslint-plugin-)'
@@ -242,36 +208,6 @@ linters:
         - prettyjson@${NPM_PRETTYJSON_VERSION}
         - typescript-eslint@${NPM_TYPESCRIPT_ESLINT_VERSION}
         - "@microsoft/eslint-formatter-sarif@${NPM_MICROSOFT_ESLINT_FORMATTER_SARIF_VERSION}"
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-    ide:
-      brackets:
-        - name: brackets-eslint
-          url: https://github.com/brackets-userland/brackets-eslint
-      eclipse:
-        - name: Tern-Linter-ESLint
-          url: https://github.com/angelozerr/tern.java/wiki/Tern-Linter-ESLint
-      emacs:
-        - name: flycheck
-          url: http://www.flycheck.org/en/latest/languages.html#javascript
-      idea:
-        - name: ESLint Plugin
-          url: https://plugins.jetbrains.com/plugin/7494-eslint
-          id: com.wix.eslint
-      sublime:
-        - name: SublimeLinter-eslint
-          url: https://github.com/roadhump/SublimeLinter-eslint
-      vim:
-        - name: ale
-          url: https://github.com/w0rp/ale
-        - name: Syntastic
-          url: https://github.com/vim-syntastic/syntastic/tree/master/syntax_checkers/javascript
-      vscode:
-        - name: vscode-eslint
-          url: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
-  # STANDARD
   - class: TypeScriptStandardLinter
     linter_name: ts-standard
     linter_text: |
@@ -334,7 +270,8 @@ linters:
         - name: https://marketplace.visualstudio.com/items?itemName=standard.vscode-standard
           url: vscode-standard
   # PRETTIER
-  - linter_name: prettier
+  - extends: prettier
+    linter_name: prettier
     linter_text: |
       **Prettier** is the industry-leading opinionated code formatter with first-class TypeScript support that automatically formats TypeScript code to ensure consistency and readability. It handles TypeScript's complex syntax including generics, decorators, and type annotations with intelligent formatting rules.
 
@@ -348,36 +285,12 @@ linters:
       - **Consistent Output**: Deterministic formatting produces identical results across different development environments
       - **Fast Performance**: High-speed formatting suitable for large TypeScript codebases
       - **Team Standardization**: Eliminates formatting debates and ensures uniform TypeScript code style across teams
-    is_formatter: true
-    linter_spdx_license: MIT
     activation_rules:
       - type: variable
         variable: TYPESCRIPT_DEFAULT_STYLE
         expected_value: prettier
         default_value: standard
-    linter_url: https://prettier.io/
-    linter_repo: https://github.com/prettier/prettier
-    linter_megalinter_ref_url: https://prettier.io/docs/related-projects
-    linter_rules_url: https://prettier.io/docs/en/options.html
-    linter_rules_configuration_url: https://prettier.io/docs/en/configuration.html
     linter_rules_inline_disable_url: https://prettier.io/docs/en/ignore.html#javascript
-    linter_banner_image_url: https://unpkg.com/prettier-logo@1.0.3/images/prettier-banner-light.svg
-    config_file_name: ".prettierrc.json"
-    cli_lint_mode: list_of_files
-    supported_cli_lint_modes:
-      - file
-      - list_of_files
-      - project
-    cli_config_arg_name: "--config"
-    cli_lint_extra_args:
-      - "--check"
-    cli_lint_mode_project_exclude_ignore_file_arg_name: "--ignore-path"
-    cli_lint_mode_project_exclude_ignore_file_pass_existing: [".gitignore", ".prettierignore"]
-    cli_lint_mode_project_extra_args_after:
-      - .
-    cli_lint_fix_arg_name: "--write" # Workaround for MegaLinter
-    cli_lint_fix_remove_args:
-      - "--check"
     test_folder: typescript_prettier
     test_variables:
       TYPESCRIPT_DEFAULT_STYLE: prettier
@@ -385,38 +298,3 @@ linters:
       - "prettier --check myfile.ts"
       - "prettier --config .prettierrc.json --check myfile.ts"
       - "prettier --config .prettierrc.json --write myfile.ts" # format
-    install:
-      dockerfile:
-        - |-
-          # renovate: datasource=npm depName=prettier
-          ARG NPM_PRETTIER_VERSION=3.9.6
-      npm:
-        - "prettier@${NPM_PRETTIER_VERSION}"
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-    ide:
-      emacs:
-        - name: prettier-emacs
-          url: https://github.com/prettier/prettier-emacs
-        - name: prettier.el
-          url: https://github.com/jscheid/prettier.el
-        - name: apheleia
-          url: https://github.com/raxod502/apheleia
-      idea:
-        - name: Prettier
-          url: https://plugins.jetbrains.com/plugin/10456-prettier
-          id: intellij.prettierJS
-      sublime:
-        - name: JsPrettier
-          url: https://packagecontrol.io/packages/JsPrettier
-      vim:
-        - name: vim-prettier
-          url: https://github.com/prettier/vim-prettier
-      visual_studio:
-        - name: JavaScriptPrettier
-          url: https://github.com/madskristensen/JavaScriptPrettier
-      vscode:
-        - name: prettier-vscode
-          url: https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode

--- a/megalinter/descriptors/vbdotnet.megalinter-descriptor.yml
+++ b/megalinter/descriptors/vbdotnet.megalinter-descriptor.yml
@@ -14,9 +14,8 @@ install:
     - ENV PATH="${PATH}:/usr/local/dotnet-tools"
 linters:
   # DOTNET FORMAT
-  - class: DotnetFormatLinter
+  - extends: dotnet-format
     linter_name: dotnet-format
-    is_formatter: true
     linter_text: |
       **dotnet format** is the official .NET code formatter that automatically applies style preferences and static analysis recommendations to enforce consistent formatting across .NET projects.
 
@@ -30,37 +29,13 @@ linters:
       - **MSBuild Integration**: Seamlessly works with .NET projects and solutions without additional configuration
 
       **Note**: Requires a `.sln` or `.vbproj` file to run correctly.
-    linter_url: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-format
-    linter_repo: https://github.com/dotnet/sdk
-    linter_rules_configuration_url: https://github.com/dotnet/sdk/tree/main/documentation/format/docs
-    linter_rules_inline_disable_url: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings
-    linter_image_url: https://user-images.githubusercontent.com/9797472/61659851-6bbdc880-ac7d-11e9-95f7-d30c7de1a18a.png
-    linter_spdx_license: MIT
-    cli_lint_errors_count: regex_count
     cli_lint_errors_regex: ".vb\\([0-9]+,[0-9]+\\):\\s(?:warning|error)"
-    cli_executable: dotnet
-    cli_lint_mode: project
-    supported_cli_lint_modes:
-      - project
-    cli_lint_extra_args:
-      - "format"
-    cli_lint_mode_project_exclude_arg_name: "--exclude"
-    cli_lint_mode_project_exclude_arg_value: "./{{DIR}}/"
     cli_lint_mode_project_extra_args_after:
       - "--include **/*.vb"
       - "--verify-no-changes"
-    cli_lint_fix_arg_name: "--megalinter-fix-flag" # Workaround to allow fix
-    cli_lint_fix_remove_args:
-      - "--verify-no-changes"
-    cli_help_extra_args:
-      - format
     examples:
       - "dotnet format --verify-no-changes"
       - "dotnet format Solution.sln --verify-no-changes"
       - "dotnet format Folder/Solution.sln --verify-no-changes"
       - "dotnet format Project.vbproj --verify-no-changes"
       - "dotnet format" # Fix
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64

--- a/megalinter/descriptors/yaml.megalinter-descriptor.yml
+++ b/megalinter/descriptors/yaml.megalinter-descriptor.yml
@@ -10,7 +10,8 @@ file_extensions:
   - ".yaml"
 linters:
   # PRETTIER
-  - linter_name: prettier
+  - extends: prettier
+    linter_name: prettier
     linter_text: |
       **Prettier** is the industry-standard opinionated code formatter that brings consistency to YAML files by enforcing a unified style across projects. It eliminates formatting debates by automatically reformatting code according to its proven formatting principles.
 
@@ -24,75 +25,15 @@ linters:
       - **Configuration Flexibility**: Supports project-specific settings through .prettierrc files when customization is needed
       - **Fast Performance**: High-speed formatting suitable for large YAML files
       - **Team Standardization**: Eliminates style discussions and ensures consistent formatting across team members
-    is_formatter: true
-    linter_url: https://prettier.io/
-    linter_repo: https://github.com/prettier/prettier
-    linter_megalinter_ref_url: https://prettier.io/docs/related-projects
-    linter_spdx_license: MIT
-    linter_rules_url: https://prettier.io/docs/en/options.html
-    linter_rules_configuration_url: https://prettier.io/docs/en/configuration.html
     linter_rules_inline_disable_url: https://prettier.io/docs/en/ignore.html#yaml
-    linter_banner_image_url: https://unpkg.com/prettier-logo@1.0.3/images/prettier-banner-light.svg
-    config_file_name: ".prettierrc.json"
-    cli_config_arg_name: "--config"
-    cli_lint_mode: list_of_files
-    supported_cli_lint_modes:
-      - file
-      - list_of_files
-      - project
     cli_lint_errors_count: regex_count
     cli_lint_errors_regex: "\\[error\\]"
     cli_lint_warnings_count: regex_count
     cli_lint_warnings_regex: "\\[warn\\]"
-    cli_lint_extra_args:
-      - "--check"
-    cli_lint_mode_project_exclude_ignore_file_arg_name: "--ignore-path"
-    cli_lint_mode_project_exclude_ignore_file_pass_existing: [".gitignore", ".prettierignore"]
-    cli_lint_mode_project_extra_args_after:
-      - .
-    cli_lint_fix_arg_name: "--write"
-    cli_lint_fix_remove_args:
-      - "--check"
     examples:
       - "prettier --check myfile.yml"
       - "prettier --config .prettierrc.json --check myfile.yml"
       - "prettier --config .prettierrc.json --write myfile.yml" # format
-    install:
-      dockerfile:
-        - |-
-          # renovate: datasource=npm depName=prettier
-          ARG NPM_PRETTIER_VERSION=3.9.6
-      npm:
-        - "prettier@${NPM_PRETTIER_VERSION}"
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-    ide:
-      emacs:
-        - name: prettier-emacs
-          url: https://github.com/prettier/prettier-emacs
-        - name: prettier.el
-          url: https://github.com/jscheid/prettier.el
-        - name: apheleia
-          url: https://github.com/raxod502/apheleia
-      idea:
-        - name: Prettier
-          url: https://plugins.jetbrains.com/plugin/10456-prettier
-          id: intellij.prettierJS
-      sublime:
-        - name: JsPrettier
-          url: https://packagecontrol.io/packages/JsPrettier
-      vim:
-        - name: vim-prettier
-          url: https://github.com/prettier/vim-prettier
-      visual_studio:
-        - name: JavaScriptPrettier
-          url: https://github.com/madskristensen/JavaScriptPrettier
-      vscode:
-        - name: prettier-vscode
-          url: https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode
-  # YAMLLINT
   - class: YamllintLinter
     linter_name: yamllint
     linter_text: |
@@ -165,12 +106,8 @@ linters:
         - name: ale
           url: https://github.com/w0rp/ale
   # V8R
-  - linter_name: v8r
-    class: V8rLinter
-    linter_url: https://github.com/chris48s/v8r
-    linter_repo: https://github.com/chris48s/v8r
-    linter_spdx_license: MIT
-    linter_speed: 1
+  - extends: v8r
+    linter_name: v8r
     linter_text: |
       **v8r** is a command-line validator for JSON, YAML, and TOML files that automatically detects and applies appropriate schemas from the Schema Store based on filename patterns, providing intelligent validation without manual schema configuration.
 
@@ -181,48 +118,12 @@ linters:
       - **Zero Configuration**: Works out-of-the-box for common configuration files without requiring explicit schema specification
       - **Schema Store Integration**: Leverages the extensive collection of schemas from schemastore.org for popular tools and frameworks
       - **Detailed Error Reporting**: Provides clear, actionable validation error messages with line and column information
-    linter_rules_url: https://www.schemastore.org/
-    linter_megalinter_ref_url: "no"
-    config_file_name: ".v8rrc.yml"
-    cli_config_arg_name: ""
-    cli_lint_mode: list_of_files
-    supported_cli_lint_modes:
-      - file
-      - list_of_files
-      - project
-    cli_lint_extra_args:
-      - "--ignore-errors"
     cli_lint_mode_project_exclude_ignore_file_arg_name: "--ignore-pattern-files="
     cli_lint_mode_project_exclude_arg_value: "{{DIR}}/**"
     cli_lint_mode_project_exclude_ignore_file_pass_existing: [".v8rignore", ".gitignore"]
     cli_lint_mode_project_extra_args_after:
       - "**/*.{yml,yaml}"
-    cli_help_arg_name: "--help"
     test_folder: yaml_schema
     examples:
       - "v8r --ignore-errors myfile.yml"
       - "v8r --ignore-errors myfile.yaml"
-    install:
-      dockerfile:
-        - |-
-          # renovate: datasource=npm depName=v8r
-          ARG NPM_V8R_VERSION=6.1.0
-      npm:
-        - v8r@${NPM_V8R_VERSION}
-    supported_platforms:
-      platform:
-        - linux/amd64
-        - linux/arm64
-    ide:
-      eclipse:
-        - name: native support
-          url: https://www.eclipse.org/
-      idea:
-        - name: native support
-          url: https://www.jetbrains.com/products/#type=ide
-      vim:
-        - name: vison
-          url: https://github.com/Quramy/vison
-      vscode:
-        - name: native support
-          url: https://code.visualstudio.com/

--- a/megalinter/linter_factory.py
+++ b/megalinter/linter_factory.py
@@ -61,6 +61,37 @@ def list_linters_by_name(linters_init_params=None, linter_names=[]):
     return linters
 
 
+SHARED_LINTER_FILE_SUFFIX = ".megalinter-linter.yml"
+shared_linter_definitions_cache: dict[str, dict] = {}
+
+
+def resolve_linter_extends(linter_descriptor):
+    if "extends" not in linter_descriptor:
+        return linter_descriptor
+    shared_name = linter_descriptor["extends"]
+    shared_file = os.path.join(
+        get_descriptor_dir(), "shared", shared_name + SHARED_LINTER_FILE_SUFFIX
+    )
+    if shared_file not in shared_linter_definitions_cache:
+        assert os.path.isfile(shared_file), (
+            f"Unable to find shared linter definition {shared_file} "
+            f"(referenced by extends: {shared_name})"
+        )
+        with open(shared_file, "r", encoding="utf-8") as f:
+            shared_linter_definitions_cache[shared_file] = yaml.safe_load(f)
+    shared_definition = shared_linter_definitions_cache[shared_file]
+    resolved = {
+        **shared_definition,
+        **{key: value for key, value in linter_descriptor.items() if key != "extends"},
+    }
+    for required_key in ["linter_name", "linter_url", "examples"]:
+        assert required_key in resolved, (
+            f"Missing {required_key} in linter extending {shared_name} "
+            f"(not defined in {shared_file} nor in the descriptor entry)"
+        )
+    return resolved
+
+
 # List all descriptor files (one by language)
 def list_descriptor_files():
     descriptors_dir = get_descriptor_dir()
@@ -75,6 +106,10 @@ def list_descriptor_files():
 def build_descriptor_info(file):
     with open(file, "r", encoding="utf-8") as f:
         language_descriptor = yaml.safe_load(f)
+    language_descriptor["linters"] = [
+        resolve_linter_extends(linter_descriptor)
+        for linter_descriptor in language_descriptor.get("linters", [])
+    ]
     return language_descriptor
 
 
@@ -102,6 +137,7 @@ def build_descriptor_linters(file, linter_init_params=None, linter_names=None):
                 and linter_descriptor["linter_name"] not in linter_names
             ):
                 continue
+            linter_descriptor = resolve_linter_extends(linter_descriptor)
 
             # Use custom class if defined in file
             linter_class = Linter

--- a/renovate.json5
+++ b/renovate.json5
@@ -142,10 +142,11 @@
     },
     {
       customType: 'regex',
-      description: 'Update dockerfile sections in .megalinter-descriptor.yml files',
+      description: 'Update dockerfile sections in .megalinter-descriptor.yml and shared .megalinter-linter.yml files',
       managerFilePatterns: [
         '/(^|/).*\\.devcontainer(\\\\|/)Dockerfile$/',
         '/(^|/).*\\.megalinter-descriptor\\.ya?ml$/',
+        '/(^|/).*\\.megalinter-linter\\.ya?ml$/',
       ],
       matchStrings: [
         '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s(?:ENV|ARG)\\s+[A-Za-z0-9_]+?_VERSION[ =]["\']?(?<currentValue>.+?)["\']?\\s',


### PR DESCRIPTION
## Summary

Linter entries duplicated across several descriptors (**eslint** ×4, **prettier** ×4, **v8r** ×2, **dotnet-format** ×2, **cpplint** ×2, **cppcheck** ×2, **clang-format** ×2) are now factorized in shared linter definition files (`megalinter/descriptors/shared/*.megalinter-linter.yml`), referenced from descriptors with a new linter-level `extends` property.

Net **-396 lines** of descriptor duplication.

## How it works

- A linter entry can declare `extends: <name>`, resolving to `megalinter/descriptors/shared/<name>.megalinter-linter.yml`
- **Shallow merge**: properties defined in the descriptor entry override the shared ones; no nested-dict merging, no chaining
- Shared files are **complete standalone linter definitions** (validated against the linter items schema during build)
- Resolution lives in a single place (`linter_factory.resolve_linter_extends`), applied in `build_descriptor_linters` and `build_descriptor_info`, so runtime, build system and plugins all benefit
- Renovate keeps bumping pinned versions moved into shared files (added `.megalinter-linter.ya?ml` to the descriptor custom manager pattern)

## Validation

- Full resolved-descriptor dump is **strictly identical** before/after the refactor
- `make megalinter-build` regenerates all Dockerfiles, flavors, test classes and schemas with **zero diff**
- Descriptor JSON schema updated: `extends` property added; `linter_url`/`examples` only required when `extends` is absent

## Also fixed

Pre-existing unquoted `no` values for `linter_megalinter_ref_url` in php/python descriptors (YAML parses them as boolean `False`), surfaced by descriptor schema validation.