### PR TITLE
Strengthen supply-chain security: remove replaceable dependencies and add 7-day update cooldowns

### DIFF
--- a/.automation/build.py
+++ b/.automation/build.py
@@ -24,7 +24,6 @@ import jsonschema
 import markdown
 import megalinter
 import requests
-import terminaltables
 import webpreview
 import yaml
 from bs4 import BeautifulSoup
@@ -3752,22 +3751,10 @@ def generate_documentation_all_linters():
             duplicate.descriptor_id_list.sort()
             linters[index] = duplicate
     linters.sort(key=lambda x: x.linter_name)
-    table_header = [
-        "Linter",
-        "Supported Platforms",
-        "Version",
-        "License",
-        "Popularity",
-        "Descriptors",
-        "Status",
-        "URL",
-    ]
     md_table_lines = []
-    table_data = [table_header]
     hearth_linters_md = []
     leave = False
     for linter in linters:
-        status = "Not submitted"
         md_status = ":white_circle:"
         # url
         url = (
@@ -3801,22 +3788,16 @@ def generate_documentation_all_linters():
             if linter.linter_megalinter_ref_url not in ["no", "never"]:
                 md_url = f"[MegaLinter reference]({linter.linter_megalinter_ref_url}){{target=_blank}}"
             if linter.linter_megalinter_ref_url == "no":
-                status = "❌ Refused"
                 md_status = ":no_entry_sign:"
             elif linter.linter_megalinter_ref_url == "never":
-                status = "Θ Not applicable"
                 md_status = "<!-- -->"
             elif "/pull/" in str(url):
                 if url.endswith("#ok"):
-                    status = "✅ Awaiting publication"
                     md_status = ":love_letter:"
                 else:
-                    status = "Ω Pending"
                     md_status = ":hammer_and_wrench:"
                 md_url = f"[Pull Request]({url}){{target=_blank}}"
-                url = "PR: " + url
             else:
-                status = "✅ Published"
                 md_status = ":heart:"
                 hearth_linters_md += [
                     f"- [{linter.linter_name}]({linter.linter_megalinter_ref_url}){{target=_blank}}"
@@ -3952,19 +3933,6 @@ def generate_documentation_all_linters():
             and "platform" in linter.supported_platforms
         ):
             supported_platforms += linter.supported_platforms["platform"]
-        # line
-        table_line = [
-            linter.linter_name,
-            ", ".join(supported_platforms),
-            linter_version,
-            license,
-            "N/A",
-            ", ".join(linter.descriptor_id_list),
-            status,
-            url,
-        ]
-        table_data += [table_line]
-
         linter_doc_links = []
         for descriptor_id in linter.descriptor_id_list:
             linter_doc_url = f"descriptors/{descriptor_id.lower()}_{linter.linter_name.lower().replace('-', '_')}.md"
@@ -3994,15 +3962,6 @@ def generate_documentation_all_linters():
         "<!-- referring-linters-end -->",
         hearth_linters_md_str,
     )
-
-    # Display results (disabled)
-    table = terminaltables.AsciiTable(table_data)
-    table.title = "----Reference to MegaLinter in linters documentation summary"
-    # Output table in console
-    logging.info("")
-    # for table_line in table.table.splitlines():
-    #    logging.info(table_line)
-    logging.info("")
 
     # Write in file
     with open(REPO_HOME + "/docs/all_linters.md", "w", encoding="utf-8") as outfile:

--- a/.config/python/dev/requirements.txt
+++ b/.config/python/dev/requirements.txt
@@ -2,11 +2,9 @@
 aiofiles==25.1.0
 aiohttp==3.14.3
 beautifulsoup4==4.15.0
-commentjson==0.9.0
 fastapi==0.141.1
 gitpython==3.1.58
 giturlparse==0.15.0
-importlib-metadata==9.0.0
 json-schema-for-humans==1.5.1
 jsonpickle==4.1.2
 jsonschema==4.26.0
@@ -16,7 +14,6 @@ mike==2.2.0
 mkdocs==1.6.1
 mkdocs-glightbox==0.5.2
 mkdocs-material==9.7.7
-multiprocessing_logging==0.3.4
 pygithub==2.9.1
 pymdown-extensions==11.0.1
 pytablewriter==1.2.1
@@ -28,10 +25,7 @@ python-gitlab==8.5.0
 python-multipart==0.0.32
 pyyaml==6.0.3
 redis==8.1.0
-regex==2026.7.19
 requests==2.34.2
-terminaltables==3.1.10
-termcolor==3.3.0
 urllib3==2.7.0
 webpreview==1.7.2
 yq==4.1.2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@
 #################################
 # GitHub Dependabot Config info #
 #################################
+# Supply-chain hardening: every version-update block waits until a release is
+# at least 7 days old (cooldown) before opening a PR, so compromised releases
+# can be caught by the community first. Dependabot SECURITY updates are not
+# subject to cooldown and still open immediately.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -9,6 +13,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
 
   # Maintain dependencies for js with npm
   - package-ecosystem: "npm"
@@ -16,6 +22,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
 
   # Skip npm test fixtures: files under .automation/test intentionally ship
   # outdated / vulnerable dependencies so MegaLinter's own security scanners
@@ -40,6 +48,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
 
   # Maintain dependencies for docker
   - package-ecosystem: "docker"
@@ -47,21 +57,29 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
   - package-ecosystem: "docker"
     directory: "/flavors"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
   - package-ecosystem: "docker"
     directory: "/linters"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
   - package-ecosystem: "docker"
     directory: "/server"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
 
   # Maintain dependencies for python with pip
   - package-ecosystem: "pip"
@@ -69,19 +87,27 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
   - package-ecosystem: "pip"
     directory: "/megalinter"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
   - package-ecosystem: "pip"
     directory: "/server"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,14 +41,19 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - Refreshed the **MegaLinter references in linters documentation** (`linter_megalinter_ref_url`): verified all existing links, updated moved pages (ktlint, robocop, csharpier, zizmor, ruff, proselint), and opened 47 suggestion PRs on linters repositories that did not mention MegaLinter yet
 
 - mega-linter-runner
+  - **Node.js 22 or higher** is now required (was 20)
+  - **8 npm dependencies removed** (`chalk`, `fs-extra`, `which`, `uuid`, `find-package-json`, `simple-git`, `mem-fs`, `assert`), replaced by Node.js built-in modules: faster `npx mega-linter-runner` startup and a smaller supply-chain attack surface
+  - Fixed `mega-linter-runner --version` displaying `error` instead of the version when the `npm_package_version` environment variable is not set
 
 - Dev
+  - **6 Python dependencies removed** from the MegaLinter runtime, replaced by standard library equivalents: `commentjson`, `terminaltables` and `multiprocessing_logging` (unmaintained), plus `termcolor`, `regex` and the obsolete `importlib-metadata` backport
   - **Shared linter definitions**: linter entries duplicated across several descriptors (eslint, prettier, v8r, dotnet-format, cpplint, cppcheck, clang-format) are now factorized in `megalinter/descriptors/shared/*.megalinter-linter.yml` files, referenced from descriptors with the new linter-level `extends` property (shallow merge, descriptor entry properties override the shared ones)
   - **Docker pulls monthly chart**: the auto-update workflow now regenerates `docs/assets/images/docker-pulls-monthly.svg` (new pulls per month since October 2020, all images and registries), via the new `.automation/docker_pulls_chart.py` called by `build.py` after the pull counters update
     - Historical monthly points are frozen in `.automation/generated/docker-pulls-monthly.json` (built once from the tracked stats plus a Web Archive reconstruction of the collection gaps); the script only appends newly completed months computed from `flavors-stats.json`
   - Docker pull counters now also track the **standalone `megalinter-only-*` images**: their download counts are stored in `flavors-stats.json` and included in the README badge total
 
 - CI
+  - **Supply-chain hardening of dependency updates**: Renovate (`minimumReleaseAge`) and Dependabot (`cooldown`) now wait until a release is at least **7 days old** before proposing an upgrade, so compromised releases can be caught by the community first. Security fixes are not delayed and still open immediately
 
 - Linter versions upgrades (N)
   - [editorconfig-checker](https://editorconfig-checker.github.io/) from 3.10.0 to **3.11.1** on 2026-08-09

--- a/mega-linter-runner/generators/mega-linter-custom-flavor/index.js
+++ b/mega-linter-runner/generators/mega-linter-custom-flavor/index.js
@@ -1,7 +1,7 @@
 import { asciiArt } from "../../lib/ascii.js";
 import Generator from 'yeoman-generator';
 import { simpleGit } from 'simple-git';
-import c from 'chalk';
+import c from "../../lib/colors.js";
 import fs from "fs"
 import { load as yamlLoad } from "js-yaml";
 

--- a/mega-linter-runner/generators/mega-linter-custom-flavor/index.js
+++ b/mega-linter-runner/generators/mega-linter-custom-flavor/index.js
@@ -1,9 +1,21 @@
 import { asciiArt } from "../../lib/ascii.js";
 import Generator from 'yeoman-generator';
-import { simpleGit } from 'simple-git';
+import { execFileSync } from "child_process";
 import c from "../../lib/colors.js";
 import fs from "fs"
 import { load as yamlLoad } from "js-yaml";
+
+function gitOutput(args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function getFirstRemoteFetchUrl() {
+  const remoteNames = gitOutput(["remote"]).split(/\r?\n/).filter(Boolean);
+  if (remoteNames.length === 0) {
+    return "";
+  }
+  return gitOutput(["remote", "get-url", remoteNames[0]]);
+}
 
 export default class GeneratorMegaLinter extends Generator {
   async prompting() {
@@ -14,9 +26,7 @@ When you don't know what option to select, please use default values`
     ));
 
     // Verify that the repo name contains "megalinter-custom-flavor"
-    const git = simpleGit();
-    const remote = await git.getRemotes(true);
-    if (!remote[0].refs.fetch.includes("megalinter-custom-flavor")) {
+    if (!getFirstRemoteFetchUrl().includes("megalinter-custom-flavor")) {
       const errorMessage = `
 ERROR: This generator must be run in a repository whose name includes 'megalinter-custom-flavor'
 Example: 'megalinter-custom-flavor-python-light'
@@ -111,12 +121,15 @@ Example: 'megalinter-custom-flavor-python-light'
       return `- [${linter}](${linterUrl})`;
     }).join("\n");
     // Custom flavor author is git username
-    const git = simpleGit();
-    const user = await git.getConfig('user.name');
-    this.customFlavorAuthor = user.value;
+    let author = "";
+    try {
+      author = gitOutput(["config", "user.name"]);
+    } catch {
+      // user.name not set in git config: leave author empty
+    }
+    this.customFlavorAuthor = author;
     // Get remote repo
-    const remote = await git.getRemotes(true);
-    const remoteUrl = remote[0].refs.fetch;
+    const remoteUrl = getFirstRemoteFetchUrl();
     
     // Handle both HTTPS and SSH git origins
     let repoPath, repoUrl;

--- a/mega-linter-runner/lib/codetotal.js
+++ b/mega-linter-runner/lib/codetotal.js
@@ -1,10 +1,10 @@
 import { spawnSync, spawn } from "child_process";
-import { default as c } from 'chalk';
-import { default as fs } from "fs-extra";
+import { default as c } from "./colors.js";
+import { default as fs } from "fs";
 import * as https from 'https';
 import { default as open } from 'open';
 import * as path from "path";
-import which from "which";
+import { which } from "./which.js";
 import { asciiArtCodeTotal } from "./ascii.js";
 
 export class CodeTotalRunner {

--- a/mega-linter-runner/lib/colors.js
+++ b/mega-linter-runner/lib/colors.js
@@ -1,0 +1,16 @@
+// Minimal replacement of the chalk dependency, based on node:util styleText
+import { styleText } from "util";
+
+const style = (format) => (text) => styleText(format, String(text));
+
+export default {
+  red: style("red"),
+  green: style("green"),
+  yellow: style("yellow"),
+  cyan: style("cyan"),
+  grey: style("grey"),
+  bold: style("bold"),
+  blueBright: style("blueBright"),
+  whiteBright: style("whiteBright"),
+  bgGray: style("bgGray"),
+};

--- a/mega-linter-runner/lib/list-vars.js
+++ b/mega-linter-runner/lib/list-vars.js
@@ -1,4 +1,4 @@
-import { default as fs } from "fs-extra";
+import { default as fs } from "fs";
 import * as path from "path";
 import { dirname } from "path";
 import { fileURLToPath } from "url";
@@ -14,7 +14,7 @@ function loadVars() {
       `Bundled variables file not found at ${VARS_FILE}. Re-run \`make megalinter-build\` to regenerate it.`,
     );
   }
-  return fs.readJsonSync(VARS_FILE);
+  return JSON.parse(fs.readFileSync(VARS_FILE, "utf8"));
 }
 
 function matches(variable, pattern) {

--- a/mega-linter-runner/lib/ox-setup.js
+++ b/mega-linter-runner/lib/ox-setup.js
@@ -1,4 +1,3 @@
-// const uuid = require("uuid");
 import { OX_HOMEPAGE_URL } from "./config.js";
 import { default as open } from "open";
 

--- a/mega-linter-runner/lib/runner.js
+++ b/mega-linter-runner/lib/runner.js
@@ -6,13 +6,13 @@ import {
 import { expandEnvEntries } from "./env-parser.js";
 import { listVars } from "./list-vars.js";
 import { spawnSync } from "child_process";
-import { default as c } from "chalk";
+import { default as c } from "./colors.js";
 import * as path from "path";
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import os from "os";
-import which from "which";
-import { default as fs } from "fs-extra";
+import { which } from "./which.js";
+import { default as fs } from "fs";
 import { MegaLinterUpgrader } from "./upgrade.js";
 import { CodeTotalRunner } from "./codetotal.js";
 import {
@@ -22,7 +22,6 @@ import {
 import prompts from "prompts";
 import { DEFAULT_RELEASE } from "./config.js";
 import { createEnv } from "yeoman-environment";
-import { default as FindPackageJson } from "find-package-json";
 import { load as yamlLoad } from "js-yaml";
 
 function isSElinuxOn() {
@@ -62,8 +61,12 @@ export class MegaLinterRunner {
       let v = process.env.npm_package_version;
       if (!v) {
         try {
-          const finder = FindPackageJson(__dirname);
-          v = finder.next().value.version;
+          const packageJsonFile = path.join(
+            dirname(fileURLToPath(import.meta.url)),
+            "..",
+            "package.json"
+          );
+          v = JSON.parse(fs.readFileSync(packageJsonFile, "utf8")).version;
         } catch (e) {
           v = "error";
         }
@@ -265,7 +268,7 @@ export class MegaLinterRunner {
     const envVarsFromDotenv = [];
     let emptyEnvFile = null;
     if (fs.existsSync(dotenvPath)) {
-      const dotenvContent = await fs.readFile(dotenvPath, "utf8");
+      const dotenvContent = await fs.promises.readFile(dotenvPath, "utf8");
       dotenvContent.split(/\r?\n/).forEach((line) => {
         const trimmedLine = line.trim();
         if (!trimmedLine || trimmedLine.startsWith("#")) {
@@ -282,9 +285,9 @@ export class MegaLinterRunner {
         }
         envVarsFromDotenv.push(`${key}=${value}`);
       });
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "megalinter-"));
+      const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "megalinter-"));
       emptyEnvFile = path.join(tmpDir, "empty.env");
-      await fs.writeFile(emptyEnvFile, "");
+      await fs.promises.writeFile(emptyEnvFile, "");
     }
     const commandArgs = ["run", "--platform", imagePlatform];
     const removeContainer = options["removeContainer"] ? true : options["noRemoveContainer"] ? false : true;
@@ -417,7 +420,7 @@ export class MegaLinterRunner {
         options.prerun === true ? "prerun-report.json" : "mega-linter-report.json"
       );
       if (fs.existsSync(jsonOutputFile)) {
-        const jsonRaw = await fs.readFile(jsonOutputFile, "utf8");
+        const jsonRaw = await fs.promises.readFile(jsonOutputFile, "utf8");
         console.log(JSON.stringify(JSON.parse(jsonRaw)));
       }
     }
@@ -580,7 +583,9 @@ export class MegaLinterRunner {
     for (const target of targets) {
       const targetPath = path.join(baseDir, target);
       if (fs.existsSync(targetPath)) {
-        fs.copySync(targetPath, `${targetPath}.megalinter-setup.bak`);
+        fs.cpSync(targetPath, `${targetPath}.megalinter-setup.bak`, {
+          recursive: true,
+        });
         backedUp.push(target);
       }
     }

--- a/mega-linter-runner/lib/upgrade.js
+++ b/mega-linter-runner/lib/upgrade.js
@@ -1,7 +1,7 @@
 import { glob } from "glob";
-import { default as fs } from "fs-extra";
+import { default as fs } from "fs";
 import * as path from "path";
-import { default as c } from 'chalk';
+import { default as c } from "./colors.js";
 import prompts from "prompts";
 import { OXSecuritySetup } from "./ox-setup.js";
 import { asciiArt } from "./ascii.js";
@@ -679,7 +679,7 @@ jobs:
     let updatedFiles = 0;
     for (const file of allFiles) {
       console.log(c.grey("Processing file " + file));
-      const initialFileContent = await fs.readFile(file, "utf8");
+      const initialFileContent = await fs.promises.readFile(file, "utf8");
       let updatedFileContent = initialFileContent.slice();
       for (const replacementItem of this.replacements) {
         const newFileContent = updatedFileContent.replace(
@@ -695,7 +695,7 @@ jobs:
         }
       }
       if (updatedFileContent !== initialFileContent) {
-        await fs.writeFile(file, updatedFileContent);
+        await fs.promises.writeFile(file, updatedFileContent);
         console.log(c.cyan(`UPDATED: ${file}`));
         updatedFiles++;
       }

--- a/mega-linter-runner/lib/upload-dashboards.js
+++ b/mega-linter-runner/lib/upload-dashboards.js
@@ -6,7 +6,7 @@
  * MEGALINTER_DASHBOARDS_DIR is defined).
  */
 
-import fs from "fs-extra";
+import fs from "fs";
 import path from "path";
 
 const DASHBOARDS_BASE_URL =
@@ -53,7 +53,7 @@ export class DashboardUploader {
   async readDashboardFile(relativePath) {
     const localDir = this.env.MEGALINTER_DASHBOARDS_DIR;
     if (localDir) {
-      return await fs.readFile(path.join(localDir, relativePath), "utf8");
+      return await fs.promises.readFile(path.join(localDir, relativePath), "utf8");
     }
     const response = await fetch(`${DASHBOARDS_BASE_URL}/${relativePath}`);
     if (!response.ok) {

--- a/mega-linter-runner/lib/which.js
+++ b/mega-linter-runner/lib/which.js
@@ -1,0 +1,24 @@
+// Minimal replacement of the which dependency: resolve a command against PATH
+import { constants as fsConstants } from "fs";
+import { access } from "fs/promises";
+import * as path from "path";
+
+export async function which(command) {
+  const isWindows = process.platform === "win32";
+  const extensions = isWindows
+    ? (process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD").split(";")
+    : [""];
+  const directories = (process.env.PATH || "").split(path.delimiter).filter(Boolean);
+  for (const directory of directories) {
+    for (const extension of extensions) {
+      const candidate = path.join(directory, command + extension);
+      try {
+        await access(candidate, isWindows ? fsConstants.F_OK : fsConstants.X_OK);
+        return candidate;
+      } catch {
+        // Not found here: try next candidate
+      }
+    }
+  }
+  throw new Error(`Command not found in PATH: ${command}`);
+}

--- a/mega-linter-runner/package.json
+++ b/mega-linter-runner/package.json
@@ -13,7 +13,7 @@
     "generators"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "bin": {
     "mega-linter-runner": "lib/index.js"
@@ -82,23 +82,15 @@
   "author": "Nicolas Vuillamy",
   "license": "MIT",
   "dependencies": {
-    "chalk": "^6.0.0",
-    "find-package-json": "^1.2.0",
-    "fs-extra": "^11.1.1",
     "glob": "^13.0.0",
     "js-yaml": "^5.2.2",
-    "mem-fs": "^4.0.0",
     "open": "^11.0.0",
     "optionator": "^0.9.3",
     "prompts": "^2.4.2",
-    "simple-git": "^3.28.0",
-    "uuid": "^14.0.0",
-    "which": "^7.0.0",
     "yeoman-environment": "^6.0.0",
     "yeoman-generator": "^8.0.0"
   },
   "devDependencies": {
-    "assert": "^2.1.0",
     "eslint": "^10.0.0",
     "mocha": "^11.0.0"
   },

--- a/mega-linter-runner/test/agent-runner.test.js
+++ b/mega-linter-runner/test/agent-runner.test.js
@@ -1,7 +1,7 @@
 import assert from "assert";
 import * as path from "path";
 import os from "os";
-import fs from "fs-extra";
+import fs from "fs";
 import { MegaLinterRunner } from "../lib/runner.js";
 import { optionsDefinition } from "../lib/options.js";
 import { DEFAULT_RELEASE } from "../lib/config.js";
@@ -189,13 +189,13 @@ describe("Standalone linter env args", () => {
 
 describe("Local .mega-linter.yml config reading", () => {
   it("returns an empty object when the file is missing", async () => {
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "ml-cfg-"));
+    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "ml-cfg-"));
     assert.deepStrictEqual(runner.readLocalConfig(tmpDir), {});
   });
 
   it("reads flavor, version and fixes properties", async () => {
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "ml-cfg-"));
-    await fs.writeFile(
+    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "ml-cfg-"));
+    await fs.promises.writeFile(
       path.join(tmpDir, ".mega-linter.yml"),
       "MEGALINTER_FLAVOR: python\nMEGALINTER_VERSION: v9\nAPPLY_FIXES: all\n"
     );
@@ -206,8 +206,8 @@ describe("Local .mega-linter.yml config reading", () => {
   });
 
   it("ignores an unparsable file", async () => {
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "ml-cfg-"));
-    await fs.writeFile(
+    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "ml-cfg-"));
+    await fs.promises.writeFile(
       path.join(tmpDir, ".mega-linter.yml"),
       "invalid: [unclosed\n  - :::\n"
     );
@@ -217,10 +217,12 @@ describe("Local .mega-linter.yml config reading", () => {
 
 describe("Setup targets backup", () => {
   it("backs up pre-existing generator targets", async () => {
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "ml-bak-"));
-    await fs.writeFile(path.join(tmpDir, ".mega-linter.yml"), "APPLY_FIXES: all\n");
-    await fs.mkdirp(path.join(tmpDir, ".github", "workflows"));
-    await fs.writeFile(
+    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "ml-bak-"));
+    await fs.promises.writeFile(path.join(tmpDir, ".mega-linter.yml"), "APPLY_FIXES: all\n");
+    await fs.promises.mkdir(path.join(tmpDir, ".github", "workflows"), {
+      recursive: true,
+    });
+    await fs.promises.writeFile(
       path.join(tmpDir, ".github", "workflows", "mega-linter.yml"),
       "name: custom\n"
     );
@@ -230,7 +232,7 @@ describe("Setup targets backup", () => {
       path.join(".github", "workflows", "mega-linter.yml"),
     ]);
     assert.strictEqual(
-      await fs.readFile(
+      await fs.promises.readFile(
         path.join(tmpDir, ".mega-linter.yml.megalinter-setup.bak"),
         "utf8"
       ),
@@ -249,7 +251,7 @@ describe("Setup targets backup", () => {
   });
 
   it("returns an empty list when nothing pre-exists", async () => {
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "ml-bak-"));
+    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "ml-bak-"));
     assert.deepStrictEqual(runner.backupExistingSetupTargets(tmpDir), []);
   });
 });
@@ -274,7 +276,7 @@ describe("Timeout handling", () => {
   }
 
   async function makeTmpLintDir() {
-    return await fs.mkdtemp(path.join(os.tmpdir(), "ml-timeout-"));
+    return await fs.promises.mkdtemp(path.join(os.tmpdir(), "ml-timeout-"));
   }
 
   it("resolveTimeoutSeconds returns null when --timeout is not set", () => {

--- a/mega-linter-runner/test/custom-flavor-generator.test.js
+++ b/mega-linter-runner/test/custom-flavor-generator.test.js
@@ -3,7 +3,7 @@ import { createEnv } from "yeoman-environment";
 import { TestAdapter } from "@yeoman/adapter/testing";
 import * as path from "path";
 import os from "os";
-import fs from "fs-extra";
+import fs from "fs";
 import { execSync } from "child_process";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
@@ -14,7 +14,7 @@ const GENERATOR_PATH = path.resolve(
 );
 
 async function makeGitRepo(remoteUrl) {
-  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "ml-cf-"));
+  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "ml-cf-"));
   execSync("git init", { cwd: tmpDir });
   execSync(`git remote add origin ${remoteUrl}`, { cwd: tmpDir });
   execSync("git config user.email test@example.com", { cwd: tmpDir });
@@ -101,7 +101,7 @@ describe("Custom flavor generator (--custom-flavor-setup)", function () {
         ),
         "builder workflow should be created",
       );
-      const flavorYml = await fs.readFile(
+      const flavorYml = await fs.promises.readFile(
         path.join(tmpDir, "megalinter-custom-flavor.yml"),
         "utf8",
       );
@@ -118,7 +118,7 @@ describe("Custom flavor generator (--custom-flavor-setup)", function () {
         customFlavorLabel: "MyPythonFlavor",
         selectedLinters: ["PYTHON_RUFF"],
       });
-      const readme = await fs.readFile(
+      const readme = await fs.promises.readFile(
         path.join(tmpDir, "README.md"),
         "utf8",
       );
@@ -146,7 +146,7 @@ describe("Custom flavor generator (--custom-flavor-setup)", function () {
         customFlavorLabel: "SeededFlavor",
         selectedLinters: ["YAML_PRETTIER"],
       });
-      const flavorYml = await fs.readFile(
+      const flavorYml = await fs.promises.readFile(
         path.join(tmpDir, "megalinter-custom-flavor.yml"),
         "utf8",
       );

--- a/mega-linter-runner/test/install-generator.test.js
+++ b/mega-linter-runner/test/install-generator.test.js
@@ -3,7 +3,7 @@ import { createEnv } from "yeoman-environment";
 import { TestAdapter } from "@yeoman/adapter/testing";
 import * as path from "path";
 import os from "os";
-import fs from "fs-extra";
+import fs from "fs";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
 
@@ -28,7 +28,7 @@ const DEFAULT_ANSWERS = {
 
 async function runGenerator(answers, generatorOptions = undefined) {
   const originalCwd = process.cwd();
-  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "ml-gen-"));
+  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "ml-gen-"));
   const adapter = new TestAdapter({ mockedAnswers: { ...DEFAULT_ANSWERS, ...answers } });
   try {
     process.chdir(tmpDir);
@@ -59,7 +59,7 @@ describe("Install generator (--install)", function () {
       fs.existsSync(path.join(tmpDir, ".gitignore")),
       ".gitignore should be created",
     );
-    const gitignore = await fs.readFile(path.join(tmpDir, ".gitignore"), "utf8");
+    const gitignore = await fs.promises.readFile(path.join(tmpDir, ".gitignore"), "utf8");
     assert.match(gitignore, /megalinter-reports\//);
   });
 
@@ -119,7 +119,7 @@ describe("Install generator (--install)", function () {
 
   it("uses python flavor in generated GitHub Actions workflow", async () => {
     const tmpDir = await runGenerator({ flavor: "python" });
-    const workflow = await fs.readFile(
+    const workflow = await fs.promises.readFile(
       path.join(tmpDir, ".github", "workflows", "mega-linter.yml"),
       "utf8",
     );
@@ -160,7 +160,7 @@ describe("Install generator (--install)", function () {
 
   it("reflects applyFixes=true in the generated workflow", async () => {
     const tmpDir = await runGenerator({ applyFixes: true });
-    const workflow = await fs.readFile(
+    const workflow = await fs.promises.readFile(
       path.join(tmpDir, ".github", "workflows", "mega-linter.yml"),
       "utf8",
     );
@@ -169,7 +169,7 @@ describe("Install generator (--install)", function () {
 
   it("reflects applyFixes=false in the generated workflow", async () => {
     const tmpDir = await runGenerator({ applyFixes: false });
-    const workflow = await fs.readFile(
+    const workflow = await fs.promises.readFile(
       path.join(tmpDir, ".github", "workflows", "mega-linter.yml"),
       "utf8",
     );
@@ -178,7 +178,7 @@ describe("Install generator (--install)", function () {
 
   it("writes MEGALINTER_FLAVOR and MEGALINTER_VERSION in .mega-linter.yml", async () => {
     const tmpDir = await runGenerator({ flavor: "python" });
-    const config = await fs.readFile(
+    const config = await fs.promises.readFile(
       path.join(tmpDir, ".mega-linter.yml"),
       "utf8",
     );
@@ -196,7 +196,7 @@ describe("Install generator (--install)", function () {
       fs.existsSync(path.join(tmpDir, ".gitlab-ci.yml")),
       ".gitlab-ci.yml should be created",
     );
-    const config = await fs.readFile(
+    const config = await fs.promises.readFile(
       path.join(tmpDir, ".mega-linter.yml"),
       "utf8",
     );
@@ -217,7 +217,7 @@ describe("Install generator (--install)", function () {
       fs.existsSync(path.join(tmpDir, "azure-pipelines.yml")),
       "azure-pipelines.yml should be created from CLI answer",
     );
-    const config = await fs.readFile(
+    const config = await fs.promises.readFile(
       path.join(tmpDir, ".mega-linter.yml"),
       "utf8",
     );

--- a/mega-linter-runner/test/megalinter-cli.test.js
+++ b/mega-linter-runner/test/megalinter-cli.test.js
@@ -3,7 +3,7 @@ import assert from 'assert';
 import { exec as childProcessExec } from "child_process";
 import os from "os";
 import path from "path";
-import fs from "fs-extra";
+import fs from "fs";
 import { fileURLToPath } from "url";
 import * as  util from "util";
 const exec = util.promisify(childProcessExec);
@@ -63,11 +63,11 @@ describe("CLI", function () {
           stdout.includes("mega-linter-runner applied"),
           'stdout should contains "mega-linter-runner applied"'
         );
-        fs.removeSync(tempDir);
+        fs.rmSync(tempDir, { recursive: true, force: true });
         done();
       })
       .catch((err) => {
-        fs.removeSync(tempDir);
+        fs.rmSync(tempDir, { recursive: true, force: true });
         done(err);
         throw err;
       });

--- a/mega-linter-runner/test/runtime-image.test.js
+++ b/mega-linter-runner/test/runtime-image.test.js
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { spawnSync } from "child_process";
-import fs from "fs-extra";
+import fs from "fs";
 import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -81,22 +81,24 @@ function cleanupPathWithDocker(targetPath) {
 }
 
 async function prepareFixtureDir(prefix, sourceRelativeDir) {
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  await fs.copy(path.join(repoRoot, sourceRelativeDir), tempDir);
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), prefix));
+  await fs.promises.cp(path.join(repoRoot, sourceRelativeDir), tempDir, {
+    recursive: true,
+  });
   return tempDir;
 }
 
 async function preparePhpFixture() {
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "megalinter-php-"));
-  await fs.copy(
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "megalinter-php-"));
+  await fs.promises.cp(
     path.join(repoRoot, ".automation", "test", "php", ".php-cs-fixer.risky.php"),
     path.join(tempDir, ".php-cs-fixer.risky.php"),
   );
-  await fs.copy(
+  await fs.promises.cp(
     path.join(repoRoot, ".automation", "test", "php", "good", "php_good_1.php"),
     path.join(tempDir, "php_good_1.php"),
   );
-  await fs.copy(
+  await fs.promises.cp(
     path.join(repoRoot, ".automation", "test", "php", "good", "php_good_2.php"),
     path.join(tempDir, "php_good_2.php"),
   );
@@ -165,7 +167,7 @@ async function withFixtureDir(prepare, callback) {
     await callback(tempDir);
   } finally {
     cleanupPathWithDocker(tempDir);
-    await fs.remove(tempDir);
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
   }
 }
 
@@ -255,7 +257,7 @@ describe("Runtime image", function () {
 
   for (const runtimeMode of runtimeModes) {
     it(`accepts an SSH connection in ${runtimeMode.label} mode`, async () => {
-      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "megalinter-ssh-"));
+      const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "megalinter-ssh-"));
       const containerName = `megalinter-ssh-${runtimeMode.id}-${Date.now()}`;
       const privateKey = path.join(tempDir, "id_rsa");
       const publicKey = path.join(tempDir, "id_rsa.pub");
@@ -356,11 +358,11 @@ describe("Runtime image", function () {
           );
         }
         assert.strictEqual(sshResult.stdout.trim(), runtimeMode.sshExpectedUid);
-        assert(await fs.pathExists(publicKey), "expected SSH public key to exist");
+        assert(fs.existsSync(publicKey), "expected SSH public key to exist");
       } finally {
         runCommand("docker", ["rm", "-f", containerName]);
         cleanupPathWithDocker(tempDir);
-        await fs.remove(tempDir);
+        await fs.promises.rm(tempDir, { recursive: true, force: true });
       }
     }).timeout(180000);
   }

--- a/mega-linter-runner/yarn.lock
+++ b/mega-linter-runner/yarn.lock
@@ -752,24 +752,6 @@ arrify@^3.0.0:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-3.0.0.tgz#ccdefb8eaf2a1d2ab0da1ca2ce53118759fd46bc"
   integrity sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==
 
-assert@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/assert/-/assert-2.1.0.tgz#6d92a238d05dc02e7427c881fb8be81c8448b2dd"
-  integrity sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==
-  dependencies:
-    call-bind "^1.0.2"
-    is-nan "^1.3.2"
-    object-is "^1.1.5"
-    object.assign "^4.1.4"
-    util "^0.12.5"
-
-available-typed-arrays@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
-  integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
-  dependencies:
-    possible-typed-array-names "^1.0.0"
-
 b4a@^1.6.4:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.8.1.tgz#7f16334ca80127aeb26064a28841acbf174840a4"
@@ -862,32 +844,6 @@ cacache@^20.0.0, cacache@^20.0.1:
     p-map "^7.0.2"
     ssri "^13.0.0"
 
-call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
-  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
-  dependencies:
-    es-errors "^1.3.0"
-    function-bind "^1.1.2"
-
-call-bind@^1.0.0, call-bind@^1.0.2, call-bind@^1.0.7, call-bind@^1.0.8, call-bind@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.9.tgz#39a644700c80bc7d0ca9102fc6d1d43b2fd7eee7"
-  integrity sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==
-  dependencies:
-    call-bind-apply-helpers "^1.0.2"
-    es-define-property "^1.0.1"
-    get-intrinsic "^1.3.0"
-    set-function-length "^1.2.2"
-
-call-bound@^1.0.2, call-bound@^1.0.3, call-bound@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
-  integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
-  dependencies:
-    call-bind-apply-helpers "^1.0.2"
-    get-intrinsic "^1.3.0"
-
 camelcase@^6.0.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
@@ -905,11 +861,6 @@ chalk@^5.6.2:
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
   integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
-
-chalk@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-6.0.0.tgz#a3bae843bc8454f41ef66ef3fd584dcf34dd805d"
-  integrity sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==
 
 chardet@^2.1.1:
   version "2.2.0"
@@ -1065,42 +1016,15 @@ default-browser@^5.4.0:
     bundle-name "^4.1.0"
     default-browser-id "^5.0.0"
 
-define-data-property@^1.0.1, define-data-property@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
-  integrity sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==
-  dependencies:
-    es-define-property "^1.0.0"
-    es-errors "^1.3.0"
-    gopd "^1.0.1"
-
 define-lazy-prop@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
   integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
 
-define-properties@^1.1.3, define-properties@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.1.tgz#10781cc616eb951a80a034bafcaa7377f6af2b6c"
-  integrity sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==
-  dependencies:
-    define-data-property "^1.0.1"
-    has-property-descriptors "^1.0.0"
-    object-keys "^1.1.1"
-
 diff@^7.0.0, diff@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-9.0.0.tgz#297c31cd7c280f13dfe335791ec2063bd4a73a6f"
   integrity sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==
-
-dunder-proto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
-  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
-  dependencies:
-    call-bind-apply-helpers "^1.0.1"
-    es-errors "^1.3.0"
-    gopd "^1.2.0"
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
@@ -1138,23 +1062,6 @@ env-paths@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-3.0.0.tgz#2f1e89c2f6dbd3408e1b1711dd82d62e317f58da"
   integrity sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==
-
-es-define-property@^1.0.0, es-define-property@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
-  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
-
-es-errors@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
-  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
-
-es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz#a2d0b373205724dfa525d23b0c3e1b1ca582c99b"
-  integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
-  dependencies:
-    es-errors "^1.3.0"
 
 escalade@^3.1.1:
   version "3.2.0"
@@ -1373,11 +1280,6 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-find-package-json@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/find-package-json/-/find-package-json-1.2.0.tgz#4057d1b943f82d8445fe52dc9cf456f6b8b58083"
-  integrity sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==
-
 find-up-simple@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/find-up-simple/-/find-up-simple-1.0.1.tgz#18fb90ad49e45252c4d7fca56baade04fa3fca1e"
@@ -1433,13 +1335,6 @@ fly-import@^1.0.0:
     registry-auth-token "^5.1.0"
     registry-url "^7.2.0"
 
-for-each@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.5.tgz#d650688027826920feeb0af747ee7b9421a41d47"
-  integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
-  dependencies:
-    is-callable "^1.2.7"
-
 foreground-child@^3.1.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
@@ -1448,31 +1343,12 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
-fs-extra@^11.1.1:
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.4.0.tgz#f88ed6d180ac9e14b61b08e679468f0b1b6b4730"
-  integrity sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
-
 fs-minipass@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-3.0.3.tgz#79a85981c4dc120065e96f62086bf6f9dc26cc54"
   integrity sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==
   dependencies:
     minipass "^7.0.3"
-
-function-bind@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
-  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
-
-generator-function@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/generator-function/-/generator-function-2.0.1.tgz#0e75dd410d1243687a0ba2e951b94eedb8f737a2"
-  integrity sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==
 
 get-caller-file@^2.0.5:
   version "2.0.5"
@@ -1483,30 +1359,6 @@ get-east-asian-width@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz#216900f91df11a8b2c198c3e1d93d6c035a776b9"
   integrity sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==
-
-get-intrinsic@^1.2.4, get-intrinsic@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
-  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
-  dependencies:
-    call-bind-apply-helpers "^1.0.2"
-    es-define-property "^1.0.1"
-    es-errors "^1.3.0"
-    es-object-atoms "^1.1.1"
-    function-bind "^1.1.2"
-    get-proto "^1.0.1"
-    gopd "^1.2.0"
-    has-symbols "^1.1.0"
-    hasown "^2.0.2"
-    math-intrinsics "^1.1.0"
-
-get-proto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
-  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
-  dependencies:
-    dunder-proto "^1.0.1"
-    es-object-atoms "^1.0.0"
 
 get-stream@^9.0.0:
   version "9.0.1"
@@ -1563,17 +1415,12 @@ globby@^16.2.0:
     slash "^5.1.0"
     unicorn-magic "^0.4.0"
 
-gopd@^1.0.1, gopd@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
-  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
-
 graceful-fs@4.2.10:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.6:
+graceful-fs@^4.2.6:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -1587,32 +1434,6 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
-
-has-property-descriptors@^1.0.0, has-property-descriptors@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
-  integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
-  dependencies:
-    es-define-property "^1.0.0"
-
-has-symbols@^1.0.3, has-symbols@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
-  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
-
-has-tostringtag@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
-  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
-  dependencies:
-    has-symbols "^1.0.3"
-
-hasown@^2.0.2:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
-  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
-  dependencies:
-    function-bind "^1.1.2"
 
 he@^1.2.0:
   version "1.2.0"
@@ -1686,11 +1507,6 @@ index-to-position@^1.1.0:
   resolved "https://registry.yarnpkg.com/index-to-position/-/index-to-position-1.2.0.tgz#c800eb34dacf4dbf96b9b06c7eb78d5f704138b4"
   integrity sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==
 
-inherits@^2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
@@ -1724,19 +1540,6 @@ ip-address@^10.1.1:
   resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.4.0.tgz#c5910bc541b6eae287765d1e4846be0308a05d93"
   integrity sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==
 
-is-arguments@^1.0.4:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.2.0.tgz#ad58c6aecf563b78ef2bf04df540da8f5d7d8e1b"
-  integrity sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==
-  dependencies:
-    call-bound "^1.0.2"
-    has-tostringtag "^1.0.2"
-
-is-callable@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
-  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
-
 is-docker@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
@@ -1751,17 +1554,6 @@ is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
-
-is-generator-function@^1.0.7:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.1.2.tgz#ae3b61e3d5ea4e4839b90bad22b02335051a17d5"
-  integrity sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==
-  dependencies:
-    call-bound "^1.0.4"
-    generator-function "^2.0.0"
-    get-proto "^1.0.1"
-    has-tostringtag "^1.0.2"
-    safe-regex-test "^1.1.0"
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
@@ -1786,14 +1578,6 @@ is-interactive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-2.0.0.tgz#40c57614593826da1100ade6059778d597f16e90"
   integrity sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==
-
-is-nan@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
-  integrity sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==
-  dependencies:
-    call-bind "^1.0.0"
-    define-properties "^1.1.3"
 
 is-number@^7.0.0:
   version "7.0.0"
@@ -1820,27 +1604,10 @@ is-plain-obj@^4.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
   integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
 
-is-regex@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.2.1.tgz#76d70a3ed10ef9be48eb577887d74205bf0cad22"
-  integrity sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==
-  dependencies:
-    call-bound "^1.0.2"
-    gopd "^1.2.0"
-    has-tostringtag "^1.0.2"
-    hasown "^2.0.2"
-
 is-stream@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-4.0.1.tgz#375cf891e16d2e4baec250b85926cffc14720d9b"
   integrity sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==
-
-is-typed-array@^1.1.3:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.15.tgz#4bfb4a45b61cee83a5a46fba778e4e8d59c0ce0b"
-  integrity sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==
-  dependencies:
-    which-typed-array "^1.1.16"
 
 is-unicode-supported@^0.1.0:
   version "0.1.0"
@@ -1931,15 +1698,6 @@ json-stringify-nice@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz#2c937962b80181d3f317dd39aa323e14f5a60a67"
   integrity sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==
-
-jsonfile@^6.0.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.2.1.tgz#b6e31717f22cc37330b081ce0051ed5de53af2f6"
-  integrity sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==
-  dependencies:
-    universalify "^2.0.0"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
 
 jsonparse@^1.3.1:
   version "1.3.1"
@@ -2058,11 +1816,6 @@ make-fetch-happen@^15.0.0, make-fetch-happen@^15.0.1, make-fetch-happen@^15.0.4:
     proc-log "^6.0.0"
     ssri "^13.0.0"
 
-math-intrinsics@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
-  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
-
 mem-fs-editor@^12.0.4:
   version "12.0.6"
   resolved "https://registry.yarnpkg.com/mem-fs-editor/-/mem-fs-editor-12.0.6.tgz#62957dc373f3414f1b5936030e2aee1fa8cef9c8"
@@ -2083,7 +1836,7 @@ mem-fs-editor@^12.0.4:
     tinyglobby "^0.2.15"
     vinyl "^3.0.1"
 
-mem-fs@^4.0.0, mem-fs@^4.1.4:
+mem-fs@^4.1.4:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/mem-fs/-/mem-fs-4.1.5.tgz#d242adc7ff75a28d4aa2a7186fcbeeaceaaefb7d"
   integrity sha512-6aWRo1jLo82ngo44tPQXjzINN7gvSNWhMU96I+O5nsJWdPi5vbUJWMTDGZDb/AVpCJRpaLGcFgrIBIpyk0DuUA==
@@ -2348,31 +2101,6 @@ npm-run-path@^6.0.0:
     path-key "^4.0.0"
     unicorn-magic "^0.3.0"
 
-object-is@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.6.tgz#1a6a53aed2dd8f7e6775ff870bea58545956ab07"
-  integrity sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==
-  dependencies:
-    call-bind "^1.0.7"
-    define-properties "^1.2.1"
-
-object-keys@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
-  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
-
-object.assign@^4.1.4:
-  version "4.1.7"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.7.tgz#8c14ca1a424c6a561b0bb2a22f66f5049a945d3d"
-  integrity sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==
-  dependencies:
-    call-bind "^1.0.8"
-    call-bound "^1.0.3"
-    define-properties "^1.2.1"
-    es-object-atoms "^1.0.0"
-    has-symbols "^1.1.0"
-    object-keys "^1.1.1"
-
 onetime@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-7.0.0.tgz#9f16c92d8c9ef5120e3acd9dd9957cceecc1ab60"
@@ -2597,11 +2325,6 @@ picomatch@^4.0.4:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
   integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
 
-possible-typed-array-names@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
-  integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
-
 postcss-selector-parser@^7.0.0:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz#69dc7a526517572ff6b150e352b36a016017b485"
@@ -2789,15 +2512,6 @@ rxjs@^7.8.2:
   dependencies:
     tslib "^2.1.0"
 
-safe-regex-test@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.1.0.tgz#7f87dfb67a3150782eaaf18583ff5d1711ac10c1"
-  integrity sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==
-  dependencies:
-    call-bound "^1.0.2"
-    es-errors "^1.3.0"
-    is-regex "^1.2.1"
-
 "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
@@ -2812,18 +2526,6 @@ serialize-javascript@^6.0.2, serialize-javascript@^7.0.5:
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.7.tgz#06ec40576d4cea96d68010a534520bff1f948a72"
   integrity sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==
-
-set-function-length@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
-  integrity sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==
-  dependencies:
-    define-data-property "^1.1.4"
-    es-errors "^1.3.0"
-    function-bind "^1.1.2"
-    get-intrinsic "^1.2.4"
-    gopd "^1.0.1"
-    has-property-descriptors "^1.0.2"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -2854,7 +2556,7 @@ sigstore@^4.0.0:
     "@sigstore/tuf" "^4.0.2"
     "@sigstore/verify" "^3.1.1"
 
-simple-git@^3.28.0, simple-git@^3.36.0:
+simple-git@^3.36.0:
   version "3.36.0"
   resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.36.0.tgz#019b28c0a35847ee34299c6fb63770ab1b2dffb7"
   integrity sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==
@@ -3184,11 +2886,6 @@ unicorn-magic@^0.4.0:
   resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.4.0.tgz#78c6a090fd6d07abd2468b83b385603e00dfdb24"
   integrity sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==
 
-universalify@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
-  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
-
 untildify@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-6.0.0.tgz#95d532bb8a7f555613deb11c1379d1b7cf5a1755"
@@ -3205,22 +2902,6 @@ util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
-
-util@^0.12.5:
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
-  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
-  dependencies:
-    inherits "^2.0.3"
-    is-arguments "^1.0.4"
-    is-generator-function "^1.0.7"
-    is-typed-array "^1.1.3"
-    which-typed-array "^1.1.2"
-
-uuid@^14.0.0:
-  version "14.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.1.tgz#8a5975b3e038902bfd169a10b5202f5ec0cf3faf"
-  integrity sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==
 
 validate-npm-package-license@^3.0.4:
   version "3.0.4"
@@ -3273,19 +2954,6 @@ which-package-manager@^1.0.1:
     find-up "^7.0.0"
     micromatch "^4.0.8"
 
-which-typed-array@^1.1.16, which-typed-array@^1.1.2:
-  version "1.1.22"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.22.tgz#8f3cc78aefb40b437346dd40a1dbfa5d1da43fe9"
-  integrity sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==
-  dependencies:
-    available-typed-arrays "^1.0.7"
-    call-bind "^1.0.9"
-    call-bound "^1.0.4"
-    for-each "^0.3.5"
-    get-proto "^1.0.1"
-    gopd "^1.2.0"
-    has-tostringtag "^1.0.2"
-
 which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
@@ -3297,13 +2965,6 @@ which@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/which/-/which-6.0.1.tgz#021642443a198fb93b784a5606721cb18cfcbfce"
   integrity sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==
-  dependencies:
-    isexe "^4.0.0"
-
-which@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-7.0.0.tgz#cdfdd7bfc31c5af050b97bc7c02b1844731fb8b2"
-  integrity sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==
   dependencies:
     isexe "^4.0.0"
 

--- a/megalinter/MegaLinter.py
+++ b/megalinter/MegaLinter.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import sys
 import threading
+from logging.handlers import QueueHandler, QueueListener
 from shutil import copytree
 from uuid import uuid1
 
@@ -42,7 +43,6 @@ from megalinter.utils_reporter import (
     log_section_start,
     register_user_notification,
 )
-from multiprocessing_logging import install_mp_handler, uninstall_mp_handler
 
 # Timeout (in seconds) for the "git ls-files" call listing gitignored files.
 # The call normally completes in under a second even on large repos, but it can
@@ -67,12 +67,12 @@ def init_worker(request_config_in):
     # store argument in the global variable for this process
     REQUEST_CONFIG = request_config_in
     # Re-apply the %(message)s formatter in every worker process.
-    # On Linux, fork() inherits the parent logger config, but multiprocessing_logging's
-    # install_mp_handler() replaces handlers with QueueHandlers whose formatter may not
-    # be propagated correctly to forked children, causing the default
-    # "%(levelname)s:%(name)s:%(message)s" format to appear in output instead of the
-    # plain message - which breaks CI annotation commands like "::group::" that must
-    # appear at the very start of a line.
+    # On Linux, fork() inherits the parent logger config, where handlers have been
+    # replaced by a QueueHandler whose formatter may not be propagated correctly to
+    # forked children, causing the default "%(levelname)s:%(name)s:%(message)s"
+    # format to appear in output instead of the plain message - which breaks CI
+    # annotation commands like "::group::" that must appear at the very start of a
+    # line.
     formatter = logging.Formatter("%(message)s")
     for handler in logging.root.handlers:
         handler.setFormatter(formatter)
@@ -469,7 +469,17 @@ class Megalinter:
                 f"Processing linters on [{str(process_number)}] parallel cores… "
                 "(can be decreased with variable PARALLEL_PROCESS_NUMBER in case of performance issues)"
             )
-        install_mp_handler()
+        # Tunnel log records of worker processes through a multiprocessing queue,
+        # so they are emitted by the initial handlers in the main process without
+        # being garbled (stdlib equivalent of the former multiprocessing_logging dep)
+        root_logger = logging.getLogger()
+        initial_handlers = root_logger.handlers[:]
+        log_queue = mp.Queue()
+        log_queue_listener = QueueListener(
+            log_queue, *initial_handlers, respect_handler_level=True
+        )
+        root_logger.handlers = [QueueHandler(log_queue)]
+        log_queue_listener.start()
         pool = mp.Pool(
             process_number,
             initializer=init_worker,
@@ -531,7 +541,9 @@ class Megalinter:
                 idx = linter_index.get(updated_linter.name)
                 if idx is not None:
                     self.linters[idx] = updated_linter
-        uninstall_mp_handler()
+        # Drain pending worker log records, then restore direct logging handlers
+        log_queue_listener.stop()
+        root_logger.handlers = initial_handlers
 
     # noinspection PyMethodMayBeStatic
     def get_workspace(self, params):

--- a/megalinter/reporters/ConfigReporter.py
+++ b/megalinter/reporters/ConfigReporter.py
@@ -9,7 +9,6 @@ import xml.dom.minidom
 from pathlib import Path
 from shutil import copyfile
 
-import commentjson
 from megalinter import Reporter, config, utils
 
 
@@ -104,7 +103,7 @@ IDE EXTENSIONS APPLICABLE TO YOUR PROJECT
             vscode_extensions_file = f"{self.master.workspace}{os.path.sep}.vscode{os.path.sep}extensions.json"
             if os.path.isfile(vscode_extensions_file):
                 with open(vscode_extensions_file, "r", encoding="utf-8") as json_file:
-                    vscode_extensions_config = commentjson.loads(json_file.read())
+                    vscode_extensions_config = utils.parse_jsonc(json_file.read())
             else:
                 vscode_extensions_config = {}
             # Add recommendations

--- a/megalinter/reporters/ConsoleReporter.py
+++ b/megalinter/reporters/ConsoleReporter.py
@@ -5,7 +5,6 @@ Output results in console
 
 import logging
 
-import terminaltables
 from megalinter import Reporter, config
 from megalinter.constants import (
     DEFAULT_RELEASE,
@@ -17,6 +16,7 @@ from megalinter.constants import (
 from megalinter.flavor_factory import is_custom_flavor
 from megalinter.utils import blue
 from megalinter.utils_reporter import (
+    build_ascii_table,
     build_user_notifications,
     get_linter_status_icon,
     log_section_end,
@@ -61,10 +61,8 @@ class ConsoleReporter(Reporter):
                         fixes_col,
                     ]
                 ]
-        table = terminaltables.AsciiTable(table_data)
-        table.title = "----MATCHING LINTERS"
         logging.info("")
-        for table_line in table.table.splitlines():
+        for table_line in build_ascii_table(table_data, title="----MATCHING LINTERS"):
             logging.info(table_line)
         logging.info(log_section_end("megalinter-file-listing"))
 
@@ -113,21 +111,22 @@ class ConsoleReporter(Reporter):
                 if self.master.show_elapsed_time is True:
                     table_line += [str(round(linter.elapsed_time_s, 2)) + "s"]
                 table_data += [table_line]
-        table = terminaltables.AsciiTable(table_data)
-        table.title = "----SUMMARY"
-        table.justify_columns = {
-            0: "left",
-            1: "left",
-            2: "left",
-            3: "right",
-            4: "right",
-            5: "right",
-            6: "right",
-            7: "right",
-        }
         # Output table in console
         logging.info("")
-        for table_line in table.table.splitlines():
+        for table_line in build_ascii_table(
+            table_data,
+            title="----SUMMARY",
+            justify_columns={
+                0: "left",
+                1: "left",
+                2: "left",
+                3: "right",
+                4: "right",
+                5: "right",
+                6: "right",
+                7: "right",
+            },
+        ):
             logging.info(table_line)
         logging.info("")
         user_notifications = build_user_notifications(self.master)

--- a/megalinter/utils.py
+++ b/megalinter/utils.py
@@ -13,10 +13,8 @@ from pathlib import Path
 from typing import Any, Optional, Pattern, Sequence, Union
 
 import git
-import regex
 from megalinter import config, logger
 from megalinter.constants import DEFAULT_DOCKER_WORKSPACE_DIR
-from termcolor import colored
 
 SIZE_MAX_SOURCEFILEHEADER = 1024
 
@@ -653,15 +651,83 @@ def find_json_in_stdout(stdout: str, sarif=True):
             sarif_json = extract_sarif_json(json_unique_line, sarif)
             if sarif_json != "":
                 return sarif_json
-    # Try using regex
-    pattern = regex.compile(r"\{(?:[^{}]|(?R))*\}")
-    json_regex_results = pattern.findall(stdout)
-    for json_regex_result in json_regex_results:
-        sarif_json = extract_sarif_json(json_regex_result, sarif)
+    # Try balanced {...} blocks found anywhere in stdout
+    for json_block in extract_json_blocks(stdout):
+        sarif_json = extract_sarif_json(json_block, sarif)
         if sarif_json != "":
             return sarif_json
     # SARIF json not found in stdout
     return ""
+
+
+# Return top-level balanced {...} blocks, ignoring braces within JSON strings
+def extract_json_blocks(text: str) -> list[str]:
+    blocks = []
+    depth = 0
+    start = -1
+    in_string = False
+    escaped = False
+    for pos, char in enumerate(text):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+        elif char == '"' and depth > 0:
+            in_string = True
+        elif char == "{":
+            if depth == 0:
+                start = pos
+            depth += 1
+        elif char == "}" and depth > 0:
+            depth -= 1
+            if depth == 0:
+                blocks.append(text[start : pos + 1])  # noqa: E203
+    return blocks
+
+
+# Parse JSON tolerating comments and trailing commas (jsonc, like .vscode config files)
+def parse_jsonc(jsonc_text: str):
+    chars: list[str] = []
+    index = 0
+    length = len(jsonc_text)
+    in_string = False
+    escaped = False
+    while index < length:
+        char = jsonc_text[index]
+        if in_string:
+            chars.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+        elif char == '"':
+            in_string = True
+            chars.append(char)
+        elif char == "/" and index + 1 < length and jsonc_text[index + 1] == "/":
+            while index + 1 < length and jsonc_text[index + 1] != "\n":
+                index += 1
+        elif char == "/" and index + 1 < length and jsonc_text[index + 1] == "*":
+            index += 3
+            while index < length and not (
+                jsonc_text[index - 1] == "*" and jsonc_text[index] == "/"
+            ):
+                index += 1
+        elif char in "}]":
+            tail = len(chars) - 1
+            while tail >= 0 and chars[tail] in " \t\r\n":
+                tail -= 1
+            if tail >= 0 and chars[tail] == ",":
+                chars.pop(tail)
+            chars.append(char)
+        else:
+            chars.append(char)
+        index += 1
+    return json.loads("".join(chars))
 
 
 def truncate_json_from_string(string_with_json_inside: str):
@@ -856,20 +922,20 @@ def keep_only_valid_regex_patterns(patterns, fail=False):
 
 
 def yellow(text):
-    return colored(text, "yellow", force_color=True)
+    return f"\033[33m{text}\033[0m"
 
 
 def green(text):
-    return colored(text, "green", force_color=True)
+    return f"\033[32m{text}\033[0m"
 
 
 def red(text):
-    return colored(text, "red", force_color=True)
+    return f"\033[31m{text}\033[0m"
 
 
 def blue(text):
-    return colored(text, "blue", force_color=True)
+    return f"\033[34m{text}\033[0m"
 
 
 def cyan(text):
-    return colored(text, "cyan", force_color=True)
+    return f"\033[36m{text}\033[0m"

--- a/megalinter/utils.py
+++ b/megalinter/utils.py
@@ -660,11 +660,13 @@ def find_json_in_stdout(stdout: str, sarif=True):
     return ""
 
 
-# Return top-level balanced {...} blocks, ignoring braces within JSON strings
+# Return outermost balanced {...} blocks, ignoring braces within JSON strings.
+# Balanced blocks nested under a never-closed "{" are also returned, as the JSON
+# searched for may be preceded by log text containing unmatched braces
 def extract_json_blocks(text: str) -> list[str]:
-    blocks = []
-    depth = 0
-    start = -1
+    blocks: list[str] = []
+    open_positions: list[int] = []
+    open_children: list[list[str]] = []
     in_string = False
     escaped = False
     for pos, char in enumerate(text):
@@ -675,16 +677,23 @@ def extract_json_blocks(text: str) -> list[str]:
                 escaped = True
             elif char == '"':
                 in_string = False
-        elif char == '"' and depth > 0:
+        elif char == '"' and open_positions:
             in_string = True
         elif char == "{":
-            if depth == 0:
-                start = pos
-            depth += 1
-        elif char == "}" and depth > 0:
-            depth -= 1
-            if depth == 0:
-                blocks.append(text[start : pos + 1])  # noqa: E203
+            open_positions.append(pos)
+            open_children.append([])
+        elif char == "}" and open_positions:
+            start = open_positions.pop()
+            # children are dropped: they are contained in this bigger balanced block
+            open_children.pop()
+            block = text[start : pos + 1]  # noqa: E203
+            if open_positions:
+                open_children[-1].append(block)
+            else:
+                blocks.append(block)
+    # Balanced blocks whose parent braces were never closed are candidates too
+    for children in open_children:
+        blocks.extend(children)
     return blocks
 
 

--- a/megalinter/utils_reporter.py
+++ b/megalinter/utils_reporter.py
@@ -25,6 +25,38 @@ from redis import Redis
 _ICON_SEVERITY_ORDER = {"❌": 0, "⚠️": 1, "☑️": 2, "✅": 3}
 
 
+# Render an ascii table (first row = headers) as a list of console lines
+def build_ascii_table(table_data, title=None, justify_columns=None):
+    justify_columns = justify_columns or {}
+    col_number = max(len(row) for row in table_data)
+    widths = [0] * col_number
+    for row in table_data:
+        for col, cell in enumerate(row):
+            widths[col] = max(widths[col], len(str(cell)))
+    border = "+" + "+".join("-" * (width + 2) for width in widths) + "+"
+    top_border = border
+    if title:
+        title_text = str(title)[: max(len(border) - 2, 0)]
+        top_border = "+" + title_text + border[len(title_text) + 1 :]
+
+    def render_row(row):
+        cells = []
+        for col in range(col_number):
+            value = str(row[col]) if col < len(row) else ""
+            if justify_columns.get(col) == "right":
+                cells.append(" " + value.rjust(widths[col]) + " ")
+            else:
+                cells.append(" " + value.ljust(widths[col]) + " ")
+        return "|" + "|".join(cells) + "|"
+
+    lines = [top_border, render_row(table_data[0]), border]
+    for row in table_data[1:]:
+        lines.append(render_row(row))
+    if len(table_data) > 1:
+        lines.append(border)
+    return lines
+
+
 def build_markdown_summary(reporter_self, action_run_url="", max_total_chars=40000):
     markdown_summary_type = config.get(
         reporter_self.master.request_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,22 +19,16 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "commentjson",
   "gitpython",
-  "importlib-metadata>=3.10; python_version < '3.9'",
   "jsonpickle",
   "langchain-core~=1.5.1",
-  "multiprocessing_logging",
   "pygithub",
   "pyjwt>=2.12.0",
   "pytablewriter",
   "python-gitlab",
   "pyyaml",
   "redis",
-  "regex",
   "requests",
-  "terminaltables",
-  "termcolor",
   "urllib3>=2.5.0",
 ]
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,7 +9,6 @@
     ':label(dependencies)',
     ':configMigration',
     ':combinePatchMinorReleases',
-    'security:minimumReleaseAgeNpm',
     'preview:dockerVersions',
     'group:unitTestNonMajor',
     ':enableVulnerabilityAlerts',
@@ -17,8 +16,16 @@
     ':automergeDigest', // enable for PRs updating digests
     ':automergePatch', // enable for lock files, patch and pin
   ],
+  // Supply-chain hardening: wait until a release is at least 7 days old before
+  // proposing it, so compromised releases can be caught and yanked by the
+  // community first. Replaces the npm-only 'security:minimumReleaseAgeNpm'
+  // preset (3 days) with a stricter setting covering every datasource.
+  minimumReleaseAge: '7 days',
   vulnerabilityAlerts: {
     enabled: true,
+    // Security fixes must not wait out the cooldown (this is Renovate's
+    // default for vulnerability alerts, made explicit here on purpose)
+    minimumReleaseAge: null,
   },
   osvVulnerabilityAlerts: true,
   hostRules: [

--- a/skills/megalinter-fix/linters/html_djlint.md
+++ b/skills/megalinter-fix/linters/html_djlint.md
@@ -9,7 +9,7 @@
 - Rules index: <https://djlint.com/docs/linter/>
 - Rules configuration: <https://djlint.com/docs/configuration/>
 - How to disable rules inline: <https://djlint.com/docs/ignoring-code/>
-- Error line format (regex): `[A-Z][0-9]{3} `
+- Error line format (regex): `[A-Z][0-9]{3}`
 - MegaLinter tuning variables (in `.mega-linter.yml`):
   - `DISABLE_LINTERS`: add `HTML_DJLINT` to fully disable this linter
   - `HTML_DJLINT_DISABLE_ERRORS: true`: keep the linter active but non-blocking

--- a/uv.lock
+++ b/uv.lock
@@ -374,15 +374,6 @@ wheels = [
 ]
 
 [[package]]
-name = "commentjson"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "lark-parser" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/76/c4aa9e408dbacee3f4de8e6c5417e5f55de7e62fb5a50300e1233a2c9cb5/commentjson-0.9.0.tar.gz", hash = "sha256:42f9f231d97d93aff3286a4dc0de39bfd91ae823d1d9eba9fa901fe0c7113dd4", size = 8653, upload-time = "2020-10-05T18:49:06.524Z" }
-
-[[package]]
 name = "cryptography"
 version = "50.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1190,12 +1181,6 @@ wheels = [
 ]
 
 [[package]]
-name = "lark-parser"
-version = "0.7.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/b8/aa7d6cf2d5efdd2fcd85cf39b33584fe12a0f7086ed451176ceb7fb510eb/lark-parser-0.7.8.tar.gz", hash = "sha256:26215ebb157e6fb2ee74319aa4445b9f3b7e456e26be215ce19fdaaa901c20a4", size = 276204, upload-time = "2019-11-01T12:45:26.558Z" }
-
-[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1295,21 +1280,16 @@ wheels = [
 name = "megalinter"
 source = { editable = "." }
 dependencies = [
-    { name = "commentjson" },
     { name = "gitpython" },
     { name = "jsonpickle" },
     { name = "langchain-core" },
-    { name = "multiprocessing-logging" },
     { name = "pygithub" },
     { name = "pyjwt" },
     { name = "pytablewriter" },
     { name = "python-gitlab" },
     { name = "pyyaml" },
     { name = "redis" },
-    { name = "regex" },
     { name = "requests" },
-    { name = "termcolor" },
-    { name = "terminaltables" },
     { name = "urllib3" },
 ]
 
@@ -1343,9 +1323,7 @@ llm = [
 
 [package.metadata]
 requires-dist = [
-    { name = "commentjson" },
     { name = "gitpython" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.9'", specifier = ">=3.10" },
     { name = "jsonpickle" },
     { name = "langchain-anthropic", marker = "extra == 'all-llm'", specifier = "~=1.5.2" },
     { name = "langchain-anthropic", marker = "extra == 'llm'", specifier = "~=1.5.2" },
@@ -1364,17 +1342,13 @@ requires-dist = [
     { name = "langchain-ollama", marker = "extra == 'llm'", specifier = "~=1.1.0" },
     { name = "langchain-openai", marker = "extra == 'all-llm'", specifier = "~=1.4.1" },
     { name = "langchain-openai", marker = "extra == 'llm'", specifier = "~=1.4.1" },
-    { name = "multiprocessing-logging" },
     { name = "pygithub" },
     { name = "pyjwt", specifier = ">=2.12.0" },
     { name = "pytablewriter" },
     { name = "python-gitlab" },
     { name = "pyyaml" },
     { name = "redis" },
-    { name = "regex" },
     { name = "requests" },
-    { name = "termcolor" },
-    { name = "terminaltables" },
     { name = "torch", marker = "extra == 'all-llm'" },
     { name = "torch", marker = "extra == 'huggingface'" },
     { name = "transformers", marker = "extra == 'all-llm'" },
@@ -1489,14 +1463,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
     { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
-]
-
-[[package]]
-name = "multiprocessing-logging"
-version = "0.3.4"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/fe/32bd864bcb604b0607924a4cf618ed267a0ef21ac9c3e255109256046e1f/multiprocessing_logging-0.3.4-py2.py3-none-any.whl", hash = "sha256:8a5be02b02edbd6fa6e3e89499af7680db69db9e2d8707fcd28d445fa248f23e", size = 8770, upload-time = "2023-02-05T17:06:20.632Z" },
 ]
 
 [[package]]
@@ -2511,24 +2477,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
-]
-
-[[package]]
-name = "termcolor"
-version = "3.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
-]
-
-[[package]]
-name = "terminaltables"
-version = "3.1.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/fc/0b73d782f5ab7feba8d007573a3773c58255f223c5940a7b7085f02153c3/terminaltables-3.1.10.tar.gz", hash = "sha256:ba6eca5cb5ba02bba4c9f4f985af80c54ec3dccf94cfcd190154386255e47543", size = 12264, upload-time = "2021-12-07T19:03:35.758Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/fb/ea621e0a19733e01fe4005d46087d383693c0f4a8f824b47d8d4122c87e0/terminaltables-3.1.10-py2.py3-none-any.whl", hash = "sha256:e4fdc4179c9e4aab5f674d80f09d76fa436b96fdc698a8505e0a36bf0804a874", size = 15155, upload-time = "2021-12-07T19:03:34.013Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Reduce MegaLinter's supply-chain attack surface:

1. **Fewer third-party dependencies**: every dependency that a core library can replace is one less package that can be compromised or abandoned
2. **Update cooldowns**: freshly published releases are the main vector of npm/PyPI supply-chain attacks; waiting 7 days lets compromised releases get caught and yanked before they reach MegaLinter — while security fixes keep flowing immediately

## Update bots (7-day cooldown, security bypasses)

- **Renovate**: global `minimumReleaseAge: 7 days`, replacing the npm-only `security:minimumReleaseAgeNpm` preset (3 days). `vulnerabilityAlerts.minimumReleaseAge: null` is made explicit so security PRs are never delayed
- **Dependabot**: `cooldown: default-days: 7` on every version-update block. Dependabot security updates are not subject to cooldown by design

## Python: 6 dependencies removed (all replaced by stdlib)

| Dependency | Status | Replacement |
| ---------- | ------ | ----------- |
| `commentjson` | unmaintained since 2020, pulls old `lark-parser` | small JSONC parser in `utils.parse_jsonc` (also tolerates trailing commas) |
| `terminaltables` | archived | `utils_reporter.build_ascii_table` (~30 lines, same output format) |
| `multiprocessing_logging` | stale (last release 2022, targets py2.7-3.10) | stdlib `logging.handlers` `QueueHandler`/`QueueListener` around the linters pool |
| `termcolor` | fine but trivial | inline ANSI codes (identical output, `force_color` was already used) |
| `regex` | only used for one recursive `(?R)` pattern | balanced-brace scanner `utils.extract_json_blocks` (also string-aware, which the regex was not) |
| `importlib-metadata` | dead weight: marker `python_version < '3.9'` while the project requires >= 3.12 | removed |

`uv.lock` drops 5 packages (including transitive `lark-parser`); `.config/python/dev/requirements.txt` updated accordingly. Dead `terminaltables` display code in `.automation/build.py` (already disabled) removed as well.

## mega-linter-runner: 8 npm dependencies removed

| Dependency | Status | Replacement |
| ---------- | ------ | ----------- |
| `chalk` | was in the Sept 2025 npm supply-chain attack | `lib/colors.js` shim on `node:util.styleText` |
| `fs-extra` | replaceable | `node:fs` / `fs.promises` (`cpSync`, `rmSync`, `mkdir recursive`, …) |
| `which` | replaceable | `lib/which.js` PATH scan (~20 lines) |
| `find-package-json` | unmaintained since 2019 | direct read of the package's own `package.json` |
| `uuid` | unused (dead comment only) | removed |
| `simple-git` | unused | removed |
| `mem-fs` | never imported directly; still provided transitively by `yeoman-environment` for the `yeoman-generator` peer | removed |
| `assert` (dev) | Node's builtin always wins in ESM resolution | removed |

**`engines` raised to Node.js >= 22** (Node 20 is EOL since April 2026; `util.styleText` needs >= 20.12 anyway). Repo CI already runs Node 24.

Also fixes a latent bug: the `--version` fallback referenced `__dirname` in ESM code, so it always displayed `mega-linter-runner version error` when `npm_package_version` was unset.

## Kept on purpose

- Python: `jsonpickle`, `pytablewriter`, `gitpython`, `pygithub`, `python-gitlab` (maintained, non-trivial to replace); `pyjwt`/`urllib3` floor pins (security floors)
- npm: `glob` (no stable `fs.glob` before Node 24), `optionator` (help generation), `prompts`, `open`, `js-yaml`, yeoman

## Validation

- New stdlib helpers unit-tested (JSONC edge cases, balanced-brace scanning, table rendering identical to `terminaltables` output)
- `mega-linter-runner`: 131 mocha tests passing locally (Docker-dependent suites excluded); `--version` and `--help` verified via `node lib/index.js`
- `black` / `flake8` clean on changed Python files; `uv.lock` diff is deletions-only with lockfile revision preserved