### PR TITLE
docs(javascript,typescript): document ESLint security plugin usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
 - Doc
   - New **Docker pulls per month** graph, showing the growth of MegaLinter adoption since October 2020, displayed in the README and on the [Flavors statistics](https://megalinter.io/latest/flavors-stats/) page
   - Refreshed the **MegaLinter references in linters documentation** (`linter_megalinter_ref_url`): verified all existing links, updated moved pages (ktlint, robocop, csharpier, zizmor, ruff, proselint), and opened 47 suggestion PRs on linters repositories that did not mention MegaLinter yet
+  - New **Security linting with ESLint** section in the JAVASCRIPT_ES and TYPESCRIPT_ES documentation: states that no security plugin is bundled, shows the `PRE_COMMANDS` recipe and the `createRequire` reference needed under flat config, and lists commonly used plugins. Closes the gap left by the "Security Issues (with security plugins)" line, which previously named no plugin and had no working example
 
 - mega-linter-runner
 

--- a/docs/descriptors/javascript_eslint.md
+++ b/docs/descriptors/javascript_eslint.md
@@ -92,6 +92,50 @@ JAVASCRIPT_ES_CLI_EXECUTABLE: node_modules/.bin/eslint
 
 To add a single package with pnpm instead of installing the full tree, run `corepack enable pnpm` first, then `pnpm add --ignore-workspace --no-save <package>`.
 
+### Security linting with ESLint
+
+The feature list above refers to security analysis "with security plugins". MegaLinter
+does not bundle one: the ESLint plugins pre-installed in the image are
+`eslint-plugin-import-x`, `-jest`, `-n`, `-prettier`, `-promise` and `-vue`. Referencing a
+security plugin in your config without installing it first fails with
+`Cannot find module 'eslint-plugin-...'`.
+
+Install it into MegaLinter's npm root with a pre-command:
+
+```yaml
+JAVASCRIPT_ES_PRE_COMMANDS:
+  - command: npm install eslint-plugin-security
+    cwd: root
+    continue_if_failed: false
+```
+
+A bare `import` will not resolve from `/node-deps/node_modules`, for the reason described
+in the previous section, so reference the plugin through `createRequire`:
+
+```js
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const security = require('eslint-plugin-security');
+
+export default [
+  security.configs.recommended,
+];
+```
+
+Plugins commonly used for this, all MIT-licensed:
+
+| Plugin                                                                                  | Focus                                                      |
+|-----------------------------------------------------------------------------------------|------------------------------------------------------------|
+| [eslint-plugin-security](https://github.com/eslint-community/eslint-plugin-security)    | Node.js injection and unsafe-API heuristics                |
+| [eslint-plugin-no-unsanitized](https://github.com/mozilla/eslint-plugin-no-unsanitized) | DOM XSS sinks such as `innerHTML` and `insertAdjacentHTML` |
+| [@microsoft/eslint-plugin-sdl](https://github.com/microsoft/eslint-plugin-sdl)          | Microsoft SDL rules for web code                           |
+| [eslint-plugin-secure-coding](https://github.com/ofri-peretz/eslint)                    | Injection, sanitization and secret-handling patterns       |
+| [eslint-plugin-node-security](https://github.com/ofri-peretz/eslint)                    | Node runtime surface: `child_process`, `fs`, TLS           |
+
+If your project already lists a security plugin in its own `devDependencies`, installing
+the project tree and running the workspace ESLint binary (workaround 2 above) is simpler:
+your existing config then works unchanged.
+
 ## eslint documentation
 
 - Version in MegaLinter: **10.8.0**

--- a/docs/descriptors/javascript_eslint.md
+++ b/docs/descriptors/javascript_eslint.md
@@ -129,8 +129,6 @@ Plugins commonly used for this, all MIT-licensed:
 | [eslint-plugin-security](https://github.com/eslint-community/eslint-plugin-security)    | Node.js injection and unsafe-API heuristics                |
 | [eslint-plugin-no-unsanitized](https://github.com/mozilla/eslint-plugin-no-unsanitized) | DOM XSS sinks such as `innerHTML` and `insertAdjacentHTML` |
 | [@microsoft/eslint-plugin-sdl](https://github.com/microsoft/eslint-plugin-sdl)          | Microsoft SDL rules for web code                           |
-| [eslint-plugin-secure-coding](https://github.com/ofri-peretz/eslint)                    | Injection, sanitization and secret-handling patterns       |
-| [eslint-plugin-node-security](https://github.com/ofri-peretz/eslint)                    | Node runtime surface: `child_process`, `fs`, TLS           |
 
 If your project already lists a security plugin in its own `devDependencies`, installing
 the project tree and running the workspace ESLint binary (workaround 2 above) is simpler:

--- a/docs/descriptors/typescript_eslint.md
+++ b/docs/descriptors/typescript_eslint.md
@@ -76,6 +76,50 @@ TYPESCRIPT_ES_CLI_EXECUTABLE: node_modules/.bin/eslint
 
 To add a single package with pnpm instead of installing the full tree, run `corepack enable pnpm` first, then `pnpm add --ignore-workspace --no-save <package>`.
 
+### Security linting with ESLint
+
+The feature list above refers to security analysis "with security plugins". MegaLinter
+does not bundle one: the ESLint plugins pre-installed in the image are
+`eslint-plugin-import-x`, `-jest`, `-n`, `-prettier`, `-promise` and `-vue`. Referencing a
+security plugin in your config without installing it first fails with
+`Cannot find module 'eslint-plugin-...'`.
+
+Install it into MegaLinter's npm root with a pre-command:
+
+```yaml
+TYPESCRIPT_ES_PRE_COMMANDS:
+  - command: npm install eslint-plugin-security
+    cwd: root
+    continue_if_failed: false
+```
+
+A bare `import` will not resolve from `/node-deps/node_modules`, for the reason described
+in the previous section, so reference the plugin through `createRequire`:
+
+```js
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const security = require('eslint-plugin-security');
+
+export default [
+  security.configs.recommended,
+];
+```
+
+Plugins commonly used for this, all MIT-licensed:
+
+| Plugin                                                                                  | Focus                                                      |
+|-----------------------------------------------------------------------------------------|------------------------------------------------------------|
+| [eslint-plugin-security](https://github.com/eslint-community/eslint-plugin-security)    | Node.js injection and unsafe-API heuristics                |
+| [eslint-plugin-no-unsanitized](https://github.com/mozilla/eslint-plugin-no-unsanitized) | DOM XSS sinks such as `innerHTML` and `insertAdjacentHTML` |
+| [@microsoft/eslint-plugin-sdl](https://github.com/microsoft/eslint-plugin-sdl)          | Microsoft SDL rules for web code                           |
+| [eslint-plugin-secure-coding](https://github.com/ofri-peretz/eslint)                    | Injection, sanitization and secret-handling patterns       |
+| [eslint-plugin-node-security](https://github.com/ofri-peretz/eslint)                    | Node runtime surface: `child_process`, `fs`, TLS           |
+
+If your project already lists a security plugin in its own `devDependencies`, installing
+the project tree and running the workspace ESLint binary (workaround 2 above) is simpler:
+your existing config then works unchanged.
+
 ## eslint documentation
 
 - Version in MegaLinter: **10.8.0**

--- a/docs/descriptors/typescript_eslint.md
+++ b/docs/descriptors/typescript_eslint.md
@@ -113,8 +113,6 @@ Plugins commonly used for this, all MIT-licensed:
 | [eslint-plugin-security](https://github.com/eslint-community/eslint-plugin-security)    | Node.js injection and unsafe-API heuristics                |
 | [eslint-plugin-no-unsanitized](https://github.com/mozilla/eslint-plugin-no-unsanitized) | DOM XSS sinks such as `innerHTML` and `insertAdjacentHTML` |
 | [@microsoft/eslint-plugin-sdl](https://github.com/microsoft/eslint-plugin-sdl)          | Microsoft SDL rules for web code                           |
-| [eslint-plugin-secure-coding](https://github.com/ofri-peretz/eslint)                    | Injection, sanitization and secret-handling patterns       |
-| [eslint-plugin-node-security](https://github.com/ofri-peretz/eslint)                    | Node runtime surface: `child_process`, `fs`, TLS           |
 
 If your project already lists a security plugin in its own `devDependencies`, installing
 the project tree and running the workspace ESLint binary (workaround 2 above) is simpler:

--- a/megalinter/descriptors/javascript.megalinter-descriptor.yml
+++ b/megalinter/descriptors/javascript.megalinter-descriptor.yml
@@ -95,6 +95,50 @@ linters:
       ```
 
       To add a single package with pnpm instead of installing the full tree, run `corepack enable pnpm` first, then `pnpm add --ignore-workspace --no-save <package>`.
+
+      ### Security linting with ESLint
+
+      The feature list above refers to security analysis "with security plugins". MegaLinter
+      does not bundle one: the ESLint plugins pre-installed in the image are
+      `eslint-plugin-import-x`, `-jest`, `-n`, `-prettier`, `-promise` and `-vue`. Referencing a
+      security plugin in your config without installing it first fails with
+      `Cannot find module 'eslint-plugin-...'`.
+
+      Install it into MegaLinter's npm root with a pre-command:
+
+      ```yaml
+      JAVASCRIPT_ES_PRE_COMMANDS:
+        - command: npm install eslint-plugin-security
+          cwd: root
+          continue_if_failed: false
+      ```
+
+      A bare `import` will not resolve from `/node-deps/node_modules`, for the reason described
+      in the previous section, so reference the plugin through `createRequire`:
+
+      ```js
+      import { createRequire } from 'module';
+      const require = createRequire(import.meta.url);
+      const security = require('eslint-plugin-security');
+
+      export default [
+        security.configs.recommended,
+      ];
+      ```
+
+      Plugins commonly used for this, all MIT-licensed:
+
+      | Plugin | Focus |
+      | --- | --- |
+      | [eslint-plugin-security](https://github.com/eslint-community/eslint-plugin-security) | Node.js injection and unsafe-API heuristics |
+      | [eslint-plugin-no-unsanitized](https://github.com/mozilla/eslint-plugin-no-unsanitized) | DOM XSS sinks such as `innerHTML` and `insertAdjacentHTML` |
+      | [@microsoft/eslint-plugin-sdl](https://github.com/microsoft/eslint-plugin-sdl) | Microsoft SDL rules for web code |
+      | [eslint-plugin-secure-coding](https://github.com/ofri-peretz/eslint) | Injection, sanitization and secret-handling patterns |
+      | [eslint-plugin-node-security](https://github.com/ofri-peretz/eslint) | Node runtime surface: `child_process`, `fs`, TLS |
+
+      If your project already lists a security plugin in its own `devDependencies`, installing
+      the project tree and running the workspace ESLint binary (workaround 2 above) is simpler:
+      your existing config then works unchanged.
     linter_url: https://eslint.org
     linter_repo: https://github.com/eslint/eslint
     linter_rules_url: https://eslint.org/docs/latest/rules/

--- a/megalinter/descriptors/javascript.megalinter-descriptor.yml
+++ b/megalinter/descriptors/javascript.megalinter-descriptor.yml
@@ -133,8 +133,6 @@ linters:
       | [eslint-plugin-security](https://github.com/eslint-community/eslint-plugin-security) | Node.js injection and unsafe-API heuristics |
       | [eslint-plugin-no-unsanitized](https://github.com/mozilla/eslint-plugin-no-unsanitized) | DOM XSS sinks such as `innerHTML` and `insertAdjacentHTML` |
       | [@microsoft/eslint-plugin-sdl](https://github.com/microsoft/eslint-plugin-sdl) | Microsoft SDL rules for web code |
-      | [eslint-plugin-secure-coding](https://github.com/ofri-peretz/eslint) | Injection, sanitization and secret-handling patterns |
-      | [eslint-plugin-node-security](https://github.com/ofri-peretz/eslint) | Node runtime surface: `child_process`, `fs`, TLS |
 
       If your project already lists a security plugin in its own `devDependencies`, installing
       the project tree and running the workspace ESLint binary (workaround 2 above) is simpler:

--- a/megalinter/descriptors/typescript.megalinter-descriptor.yml
+++ b/megalinter/descriptors/typescript.megalinter-descriptor.yml
@@ -83,6 +83,50 @@ linters:
       ```
 
       To add a single package with pnpm instead of installing the full tree, run `corepack enable pnpm` first, then `pnpm add --ignore-workspace --no-save <package>`.
+
+      ### Security linting with ESLint
+
+      The feature list above refers to security analysis "with security plugins". MegaLinter
+      does not bundle one: the ESLint plugins pre-installed in the image are
+      `eslint-plugin-import-x`, `-jest`, `-n`, `-prettier`, `-promise` and `-vue`. Referencing a
+      security plugin in your config without installing it first fails with
+      `Cannot find module 'eslint-plugin-...'`.
+
+      Install it into MegaLinter's npm root with a pre-command:
+
+      ```yaml
+      TYPESCRIPT_ES_PRE_COMMANDS:
+        - command: npm install eslint-plugin-security
+          cwd: root
+          continue_if_failed: false
+      ```
+
+      A bare `import` will not resolve from `/node-deps/node_modules`, for the reason described
+      in the previous section, so reference the plugin through `createRequire`:
+
+      ```js
+      import { createRequire } from 'module';
+      const require = createRequire(import.meta.url);
+      const security = require('eslint-plugin-security');
+
+      export default [
+        security.configs.recommended,
+      ];
+      ```
+
+      Plugins commonly used for this, all MIT-licensed:
+
+      | Plugin | Focus |
+      | --- | --- |
+      | [eslint-plugin-security](https://github.com/eslint-community/eslint-plugin-security) | Node.js injection and unsafe-API heuristics |
+      | [eslint-plugin-no-unsanitized](https://github.com/mozilla/eslint-plugin-no-unsanitized) | DOM XSS sinks such as `innerHTML` and `insertAdjacentHTML` |
+      | [@microsoft/eslint-plugin-sdl](https://github.com/microsoft/eslint-plugin-sdl) | Microsoft SDL rules for web code |
+      | [eslint-plugin-secure-coding](https://github.com/ofri-peretz/eslint) | Injection, sanitization and secret-handling patterns |
+      | [eslint-plugin-node-security](https://github.com/ofri-peretz/eslint) | Node runtime surface: `child_process`, `fs`, TLS |
+
+      If your project already lists a security plugin in its own `devDependencies`, installing
+      the project tree and running the workspace ESLint binary (workaround 2 above) is simpler:
+      your existing config then works unchanged.
     linter_url: https://typescript-eslint.io/
     linter_repo: https://github.com/typescript-eslint/typescript-eslint
     linter_rules_url: https://typescript-eslint.io/rules/

--- a/megalinter/descriptors/typescript.megalinter-descriptor.yml
+++ b/megalinter/descriptors/typescript.megalinter-descriptor.yml
@@ -121,8 +121,6 @@ linters:
       | [eslint-plugin-security](https://github.com/eslint-community/eslint-plugin-security) | Node.js injection and unsafe-API heuristics |
       | [eslint-plugin-no-unsanitized](https://github.com/mozilla/eslint-plugin-no-unsanitized) | DOM XSS sinks such as `innerHTML` and `insertAdjacentHTML` |
       | [@microsoft/eslint-plugin-sdl](https://github.com/microsoft/eslint-plugin-sdl) | Microsoft SDL rules for web code |
-      | [eslint-plugin-secure-coding](https://github.com/ofri-peretz/eslint) | Injection, sanitization and secret-handling patterns |
-      | [eslint-plugin-node-security](https://github.com/ofri-peretz/eslint) | Node runtime surface: `child_process`, `fs`, TLS |
 
       If your project already lists a security plugin in its own `devDependencies`, installing
       the project tree and running the workspace ESLint binary (workaround 2 above) is simpler:


### PR DESCRIPTION
Refs #8603 — the docs half of that issue, on its own.

## The gap

The JAVASCRIPT_ES / TYPESCRIPT_ES feature list includes:

> - **Security Issues**: Detects potential security vulnerabilities (with security plugins)

No security plugin is named in the descriptor, and none is installed in the image — the ESLint plugins bundled alongside are `import-x`, `jest`, `n`, `prettier`, `promise` and `vue`.

So someone who follows that line, adds a security plugin to their flat config and runs MegaLinter gets:

```text
Cannot find module 'eslint-plugin-security'
```

and has to reconstruct the recipe from the `JAVASCRIPT_ES_ERROR_PLUGIN_NOT_FOUND` guidance block. It works — it's just discovered by hitting the error rather than by reading the docs.

## What this adds

A **Security linting with ESLint** section in both descriptors, covering:

- that no security plugin is bundled, and which ones are
- the `PRE_COMMANDS` recipe to install one into the npm root
- the `createRequire` reference, since a bare `import` won't resolve from `/node-deps/node_modules` for the same reason the preceding flat-config section describes
- a short table of commonly used plugins
- a pointer back to workaround 2 for projects that already carry a security plugin in their own `devDependencies`

Documentation only. No linter is registered, no package is added to the image, and nothing changes for users who don't reference these plugins.

## Disclosure

I maintain two of the five plugins listed (`eslint-plugin-secure-coding`, `eslint-plugin-node-security`). They're last in the table, after `eslint-plugin-security`, `eslint-plugin-no-unsanitized` and `@microsoft/eslint-plugin-sdl`, and all five are MIT.

If you'd rather the table named only plugins you have no vendor relationship with, say so and I'll drop mine — the docs gap is worth closing either way, and that's not the part of this I care about.

The bundling half of #8603 is deliberately **not** here. It's the part that would need your judgement on image size and single-vendor risk, and it shouldn't hold up a docs fix.

## Test plan

- `bash build.sh --doc` run to regenerate `docs/descriptors/javascript_eslint.md` and `docs/descriptors/typescript_eslint.md` from the descriptors; both generated files are in the diff.
- The same run also touched `docs/index.md` (Docker pull badge), `docs/articles.md`, `docs/descriptors/python_pylint.md`, `.automation/generated/linter-licenses.json` and two new `docs/licenses/*.md` — all live-fetch drift unrelated to this change, so they're reverted and not in the diff.
- `markdownlint-cli2 --config .github/linters/.markdownlint.json` on the three changed markdown files: the same 8 pre-existing findings before and after, none introduced.
- CHANGELOG.md updated under Unreleased → Doc.