### PR TITLE
Explain how to install Prettier plugins when they fail to resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
     - The 4 **Salesforce Code Analyzer** engines (`SALESFORCE_CODE_ANALYZER_APEX`, `_AURA`, `_LWC`, `_FLOW`) also gained SARIF output: their report switches from CSV to SARIF automatically when SARIF reporting is requested
     - `csharp_roslynator` is bumped from 0.12.0 to **0.13.0**, the first release including its SARIF output support
     - `clj-kondo`'s upstream SARIF output currently nests the `region` property one level too deep, which may affect line/column display in strict SARIF consumers (clj-kondo/clj-kondo#2345)
+  - **Prettier** linters (**JSON_PRETTIER**, **YAML_PRETTIER**, **JAVASCRIPT_PRETTIER**, **TYPESCRIPT_PRETTIER**) now tell you how to install a **Prettier plugin** when one declared in your `.prettierrc` fails to load with `Cannot find package ... imported from noop.js` ([#6980](https://github.com/oxsecurity/megalinter/issues/6980))
+    - Prettier v3 resolves plugins with a native ESM `import()` from the workspace and ignores `NODE_PATH`, so plugins installed with the default `cwd: root` land in `/node-deps` where Prettier never looks for them
+    - The guidance surfaced in the log is to install them through `<LINTER_KEY>_PRE_COMMANDS` with **`cwd: workspace`**, which keeps plain package names in `.prettierrc` so the very same config still works when you run Prettier locally without MegaLinter
 
 - Fixes
   - The **API reporter** variables (`API_REPORTER`, `API_REPORTER_URL`…) are not flagged as **deprecated** anymore in the configuration JSON schema: they were collateral damage of the removal of the `API` descriptor in v10.0.0, and IDEs displayed them as obsolete

--- a/megalinter/descriptors/javascript.megalinter-descriptor.yml
+++ b/megalinter/descriptors/javascript.megalinter-descriptor.yml
@@ -346,6 +346,20 @@ linters:
     test_folder: javascript_prettier
     test_variables:
       JAVASCRIPT_DEFAULT_STYLE: prettier
+    common_linter_errors:
+      - identifier: JAVASCRIPT_PRETTIER_ERROR_PLUGIN_NOT_FOUND
+        regex: "(Cannot find (package|module) '[^']+' imported from|Directory import '[^']+' is not supported resolving ES modules)"
+        message: |-
+          Prettier could not load a plugin declared in the `plugins` array of your `.prettierrc.*` (e.g. `prettier-plugin-toml`, `prettier-plugin-sh`, `@prettier/plugin-xml`).
+          Prettier v3 loads plugins with a native ESM `import()` resolved from its current working directory, which MegaLinter sets to the workspace. ESM ignores `NODE_PATH`, so plugins installed in MegaLinter's bundled npm root (`/node-deps/node_modules`) are invisible to Prettier, unlike for ESLint or stylelint.
+          Resolution: install the plugins in the workspace with a pre-command. `cwd: workspace` is required: with the default `cwd: root`, MegaLinter redirects `npm install` to `/node-deps`, where Prettier will not find them.
+              JAVASCRIPT_PRETTIER_PRE_COMMANDS:
+                - command: npm install --no-save prettier-plugin-toml prettier-plugin-sh
+                  cwd: workspace
+                  continue_if_failed: false
+          If the plugins are already listed in your `package.json`, run `npm ci` (or `npm install`) with the same `cwd: workspace` instead.
+          Keep plain package names in the `plugins` array of `.prettierrc.*`, so the very same config keeps working when you run Prettier locally without MegaLinter. Do not replace them with absolute `/node-deps/...` paths: those resolve only inside the MegaLinter image.
+          Also check that each package name matches the published npm package exactly (e.g. `@prettier/plugin-xml`, not `prettier-plugin-xml`).
     examples:
       - "prettier --check myfile.js"
       - "prettier --config .prettierrc.json --check myfile.js"

--- a/megalinter/descriptors/json.megalinter-descriptor.yml
+++ b/megalinter/descriptors/json.megalinter-descriptor.yml
@@ -104,6 +104,20 @@ linters:
       - **Configuration Flexibility**: Supports project-specific formatting rules through .prettierrc when customization is needed
     linter_rules_inline_disable_url: https://prettier.io/docs/en/ignore.html#javascript
     test_folder: json_prettier
+    common_linter_errors:
+      - identifier: JSON_PRETTIER_ERROR_PLUGIN_NOT_FOUND
+        regex: "(Cannot find (package|module) '[^']+' imported from|Directory import '[^']+' is not supported resolving ES modules)"
+        message: |-
+          Prettier could not load a plugin declared in the `plugins` array of your `.prettierrc.*` (e.g. `prettier-plugin-toml`, `prettier-plugin-sh`, `@prettier/plugin-xml`).
+          Prettier v3 loads plugins with a native ESM `import()` resolved from its current working directory, which MegaLinter sets to the workspace. ESM ignores `NODE_PATH`, so plugins installed in MegaLinter's bundled npm root (`/node-deps/node_modules`) are invisible to Prettier, unlike for ESLint or stylelint.
+          Resolution: install the plugins in the workspace with a pre-command. `cwd: workspace` is required: with the default `cwd: root`, MegaLinter redirects `npm install` to `/node-deps`, where Prettier will not find them.
+              JSON_PRETTIER_PRE_COMMANDS:
+                - command: npm install --no-save prettier-plugin-toml prettier-plugin-sh
+                  cwd: workspace
+                  continue_if_failed: false
+          If the plugins are already listed in your `package.json`, run `npm ci` (or `npm install`) with the same `cwd: workspace` instead.
+          Keep plain package names in the `plugins` array of `.prettierrc.*`, so the very same config keeps working when you run Prettier locally without MegaLinter. Do not replace them with absolute `/node-deps/...` paths: those resolve only inside the MegaLinter image.
+          Also check that each package name matches the published npm package exactly (e.g. `@prettier/plugin-xml`, not `prettier-plugin-xml`).
     examples:
       - "prettier --check myfile.json"
       - "prettier --config .prettierrc.json --check myfile.json"

--- a/megalinter/descriptors/typescript.megalinter-descriptor.yml
+++ b/megalinter/descriptors/typescript.megalinter-descriptor.yml
@@ -336,6 +336,20 @@ linters:
     test_folder: typescript_prettier
     test_variables:
       TYPESCRIPT_DEFAULT_STYLE: prettier
+    common_linter_errors:
+      - identifier: TYPESCRIPT_PRETTIER_ERROR_PLUGIN_NOT_FOUND
+        regex: "(Cannot find (package|module) '[^']+' imported from|Directory import '[^']+' is not supported resolving ES modules)"
+        message: |-
+          Prettier could not load a plugin declared in the `plugins` array of your `.prettierrc.*` (e.g. `prettier-plugin-toml`, `prettier-plugin-sh`, `@prettier/plugin-xml`).
+          Prettier v3 loads plugins with a native ESM `import()` resolved from its current working directory, which MegaLinter sets to the workspace. ESM ignores `NODE_PATH`, so plugins installed in MegaLinter's bundled npm root (`/node-deps/node_modules`) are invisible to Prettier, unlike for ESLint or stylelint.
+          Resolution: install the plugins in the workspace with a pre-command. `cwd: workspace` is required: with the default `cwd: root`, MegaLinter redirects `npm install` to `/node-deps`, where Prettier will not find them.
+              TYPESCRIPT_PRETTIER_PRE_COMMANDS:
+                - command: npm install --no-save prettier-plugin-toml prettier-plugin-sh
+                  cwd: workspace
+                  continue_if_failed: false
+          If the plugins are already listed in your `package.json`, run `npm ci` (or `npm install`) with the same `cwd: workspace` instead.
+          Keep plain package names in the `plugins` array of `.prettierrc.*`, so the very same config keeps working when you run Prettier locally without MegaLinter. Do not replace them with absolute `/node-deps/...` paths: those resolve only inside the MegaLinter image.
+          Also check that each package name matches the published npm package exactly (e.g. `@prettier/plugin-xml`, not `prettier-plugin-xml`).
     examples:
       - "prettier --check myfile.ts"
       - "prettier --config .prettierrc.json --check myfile.ts"

--- a/megalinter/descriptors/yaml.megalinter-descriptor.yml
+++ b/megalinter/descriptors/yaml.megalinter-descriptor.yml
@@ -30,6 +30,20 @@ linters:
     cli_lint_errors_regex: "\\[error\\]"
     cli_lint_warnings_count: regex_count
     cli_lint_warnings_regex: "\\[warn\\]"
+    common_linter_errors:
+      - identifier: YAML_PRETTIER_ERROR_PLUGIN_NOT_FOUND
+        regex: "(Cannot find (package|module) '[^']+' imported from|Directory import '[^']+' is not supported resolving ES modules)"
+        message: |-
+          Prettier could not load a plugin declared in the `plugins` array of your `.prettierrc.*` (e.g. `prettier-plugin-toml`, `prettier-plugin-sh`, `@prettier/plugin-xml`).
+          Prettier v3 loads plugins with a native ESM `import()` resolved from its current working directory, which MegaLinter sets to the workspace. ESM ignores `NODE_PATH`, so plugins installed in MegaLinter's bundled npm root (`/node-deps/node_modules`) are invisible to Prettier, unlike for ESLint or stylelint.
+          Resolution: install the plugins in the workspace with a pre-command. `cwd: workspace` is required: with the default `cwd: root`, MegaLinter redirects `npm install` to `/node-deps`, where Prettier will not find them.
+              YAML_PRETTIER_PRE_COMMANDS:
+                - command: npm install --no-save prettier-plugin-toml prettier-plugin-sh
+                  cwd: workspace
+                  continue_if_failed: false
+          If the plugins are already listed in your `package.json`, run `npm ci` (or `npm install`) with the same `cwd: workspace` instead.
+          Keep plain package names in the `plugins` array of `.prettierrc.*`, so the very same config keeps working when you run Prettier locally without MegaLinter. Do not replace them with absolute `/node-deps/...` paths: those resolve only inside the MegaLinter image.
+          Also check that each package name matches the published npm package exactly (e.g. `@prettier/plugin-xml`, not `prettier-plugin-xml`).
     examples:
       - "prettier --check myfile.yml"
       - "prettier --config .prettierrc.json --check myfile.yml"


### PR DESCRIPTION
Fixes #6980

## Problem

Installing a Prettier plugin via `*_PRE_COMMANDS` appears to succeed (`added 3 packages`), but the lint still fails:

```log
Results of prettier linter (version 3.9.6)
❌ [ERROR] for workspace /tmp/lint
[error] Cannot find package 'prettier-plugin-toml' imported from /tmp/lint/noop.js
```

Adding `cwd: root` — the resolution that works for stylelint and ESLint — does not help either.

## Root cause

Prettier v3 resolves plugins declared in `.prettierrc` with a **native ESM `import()`**, from a virtual `noop.js` placed in `process.cwd()` (`src/main/plugins/load-plugin.js`):

```js
function loadPlugin(plugin) {
  const cwd = process.cwd();
  ...
}
function importFromDirectory(specifier, directory) {
  return importFromFile(specifier, path.join(directory, "noop.js"));
}
```

MegaLinter runs linters with `cwd` = the workspace, so ESM resolution walks `/tmp/lint/node_modules` → `/tmp/node_modules` → `/node_modules`.

Two things then collide:

- `pre_post_factory.complete_command()` rewrites any `npm i…` pre-command with the default `cwd: root` into `cd /node-deps && npm i…`, so the plugin lands in `/node-deps/node_modules`.
- The image sets `NODE_PATH=/node-deps/node_modules`, but **`NODE_PATH` is a CommonJS-only mechanism — ESM `import()` ignores it entirely**.

So `/node-deps/node_modules` is invisible to Prettier, which is why the advice that works for stylelint/ESLint (CJS `require`) is exactly wrong for Prettier.

## Fix

Documentation only — a `<LINTER_KEY>_ERROR_PLUGIN_NOT_FOUND` `common_linter_errors` entry on the 4 prettier linters (`JSON_`, `YAML_`, `JAVASCRIPT_`, `TYPESCRIPT_PRETTIER`). It detects the three ESM resolution failure shapes and surfaces the resolution in the failing log, plus a "Known errors and resolutions" section on the generated doc pages.

The recommended resolution installs the plugins in the **workspace**:

```yaml
JSON_PRETTIER_PRE_COMMANDS:
  - command: npm install --no-save prettier-plugin-toml prettier-plugin-sh
    cwd: workspace
    continue_if_failed: false
```

This deliberately keeps **plain package names in `.prettierrc`**, so the very same config keeps working when running Prettier locally without MegaLinter. Referencing plugins by absolute `/node-deps/...` path also works inside the image, but it breaks local runs, so it is explicitly discouraged in the message rather than offered as an alternative.

`--no-save` leaves an existing `package.json` untouched, and `node_modules` is already in MegaLinter's default excluded directories.

## Validation

Run against `ghcr.io/oxsecurity/megalinter-only-json_prettier:beta` with a workspace declaring `"plugins": ["prettier-plugin-toml"]`:

| Config | Result |
| :----- | :----- |
| no pre-command | ❌ `Cannot find package 'prettier-plugin-toml' imported from /tmp/lint/noop.js` (issue reproduced) |
| `cwd: root` | ❌ `added 3 packages` then same error (matches the report) |
| `cwd: workspace` | ✅ `Successfully linted all files without errors` |

The new message was rendered in the real image by mounting the updated descriptor over `/megalinter-descriptors/json.megalinter-descriptor.yml`.

Also checked: the regex matches the 3 real failure strings (`Cannot find package`, `Cannot find module`, `Directory import … is not supported`) and none of normal Prettier output (`Checking formatting...`, `[warn] file`, a genuine `SyntaxError`); all 132 linters still pass the identifier-prefix validation; the 4 descriptors are prettier-clean.

## Notes

- Follows `.claude/rules/descriptors.md`, which puts `common_linter_errors` with linter-key-prefixed identifiers in the per-descriptor entry rather than the shared `prettier.megalinter-linter.yml`.
- No doc regeneration in this PR (auto-update workflows own `docs/`).
- A deeper fix is possible — e.g. having `complete_command()` route `npm i prettier-plugin-*` to the workspace instead of `/node-deps` — but that changes pre-command behaviour for everyone, so it is left out of this documentation-only change.
