### PR TITLE
Update MegaLinter reference URLs after suggestion PRs outcome

### DIFF
--- a/megalinter/descriptors/ansible.megalinter-descriptor.yml
+++ b/megalinter/descriptors/ansible.megalinter-descriptor.yml
@@ -40,7 +40,7 @@ linters:
     can_output_sarif: true
     linter_url: https://ansible-lint.readthedocs.io/
     linter_repo: https://github.com/ansible/ansible-lint
-    linter_megalinter_ref_url: https://github.com/ansible/ansible-lint/pull/5144
+    linter_megalinter_ref_url: "no"
     linter_spdx_license: GPL-3.0-only
     linter_rules_url: https://ansible-lint.readthedocs.io/rules/
     linter_rules_configuration_url: https://ansible-lint.readthedocs.io/configuring/#configuration-file

--- a/megalinter/descriptors/protobuf.megalinter-descriptor.yml
+++ b/megalinter/descriptors/protobuf.megalinter-descriptor.yml
@@ -24,7 +24,7 @@ linters:
       - **Configuration Flexibility**: YAML-based configuration for team-specific linting preferences
     linter_url: https://github.com/yoheimuta/protolint
     linter_repo: https://github.com/yoheimuta/protolint
-    linter_megalinter_ref_url: https://github.com/yoheimuta/protolint/pull/559
+    linter_megalinter_ref_url: https://github.com/yoheimuta/protolint#ci-integration
     linter_rules_url: https://github.com/yoheimuta/protolint#rules
     linter_rules_configuration_url: https://github.com/yoheimuta/protolint#rules
     linter_rules_inline_disable_url: https://github.com/yoheimuta/protolint#configuring

--- a/megalinter/descriptors/python.megalinter-descriptor.yml
+++ b/megalinter/descriptors/python.megalinter-descriptor.yml
@@ -335,7 +335,7 @@ linters:
     is_formatter: true
     linter_url: https://pycqa.github.io/isort/
     linter_repo: https://github.com/PyCQA/isort
-    linter_megalinter_ref_url: https://github.com/PyCQA/isort/pull/2620
+    linter_megalinter_ref_url: "no"
     linter_spdx_license: MIT
     linter_speed: 5
     linter_banner_image_url: https://raw.githubusercontent.com/pycqa/isort/develop/art/logo_large.png
@@ -692,7 +692,7 @@ linters:
       **Note**: This linter only checks `.ipynb` files. Use PYTHON_MYPY for `.py` and `.pyi` files.
     linter_url: https://github.com/nbQA-dev/nbQA
     linter_repo: https://github.com/nbQA-dev/nbQA
-    linter_megalinter_ref_url: https://github.com/nbQA-dev/nbQA/pull/905
+    linter_megalinter_ref_url: https://github.com/nbQA-dev/nbQA#-used-by
     linter_rules_url: https://github.com/nbQA-dev/nbQA
     linter_spdx_license: MIT
     linter_speed: 2
@@ -772,7 +772,7 @@ linters:
     linter_url: https://github.com/Microsoft/pyright
     linter_rules_url: https://github.com/microsoft/pyright#type-checking-features
     linter_repo: https://github.com/microsoft/pyright
-    linter_megalinter_ref_url: https://github.com/microsoft/pyright/pull/11604
+    linter_megalinter_ref_url: https://microsoft.github.io/pyright/#/ci-integration
     linter_spdx_license: MIT
     linter_banner_image_url: https://github.com/microsoft/pyright/raw/main/docs/img/PyrightLarge.png
     linter_speed: 1

--- a/megalinter/descriptors/repository.megalinter-descriptor.yml
+++ b/megalinter/descriptors/repository.megalinter-descriptor.yml
@@ -719,7 +719,7 @@ linters:
       - security
     linter_url: https://semgrep.dev/
     linter_repo: https://github.com/returntocorp/semgrep
-    linter_megalinter_ref_url: https://github.com/semgrep/semgrep-docs/pull/2775
+    linter_megalinter_ref_url: https://semgrep.dev/docs/extensions/overview
     linter_speed: 1
     linter_text: |
       **Semgrep** is a fast, AI-powered static analysis tool that finds bugs, detects security vulnerabilities, and enforces code standards across 30+ programming languages and frameworks. Unlike traditional SAST tools, Semgrep provides high-confidence findings with minimal false positives.
@@ -1164,7 +1164,7 @@ linters:
       - **Built-in Report Viewer:** Visualize and triage findings locally with kingfisher view ./report-file.json
     linter_url: https://github.com/mongodb/kingfisher
     linter_repo: https://github.com/mongodb/kingfisher
-    linter_megalinter_ref_url: https://github.com/mongodb/kingfisher/pull/471
+    linter_megalinter_ref_url: https://github.com/mongodb/kingfisher#installation
     linter_spdx_license: Apache-2.0
     linter_rules_url: https://mongodb.github.io/kingfisher/rules/builtin-rules
     linter_rules_inline_disable_url: https://mongodb.github.io/kingfisher/usage/advanced/?h=inline#inline-ignore-directives

--- a/megalinter/descriptors/shared/cppcheck.megalinter-linter.yml
+++ b/megalinter/descriptors/shared/cppcheck.megalinter-linter.yml
@@ -2,7 +2,7 @@
 linter_name: cppcheck
 linter_url: https://cppcheck.sourceforge.io/
 linter_repo: https://cppcheck.sourceforge.io/
-linter_megalinter_ref_url: https://github.com/cppcheck-opensource/cppcheck/pull/8786
+linter_megalinter_ref_url: https://github.com/cppcheck-opensource/cppcheck-htdocs/pull/32
 linter_spdx_license: GPL-3.0
 linter_rules_url: https://sourceforge.net/p/cppcheck/wiki/ListOfChecks/
 linter_rules_configuration_url: https://cppcheck.sourceforge.io/manual.html#configuration

--- a/megalinter/descriptors/shared/cpplint.megalinter-linter.yml
+++ b/megalinter/descriptors/shared/cpplint.megalinter-linter.yml
@@ -3,7 +3,7 @@ class: CppLintLinter
 linter_name: cpplint
 linter_url: https://github.com/cpplint/cpplint
 linter_repo: https://github.com/cpplint/cpplint
-linter_megalinter_ref_url: https://github.com/cpplint/cpplint/pull/462
+linter_megalinter_ref_url: https://github.com/cpplint/cpplint#installation
 linter_spdx_license: BSD-3-Clause
 linter_rules_url: https://google.github.io/styleguide/cppguide.html
 cli_lint_mode: list_of_files

--- a/megalinter/descriptors/snakemake.megalinter-descriptor.yml
+++ b/megalinter/descriptors/snakemake.megalinter-descriptor.yml
@@ -88,7 +88,7 @@ linters:
     name: SNAKEMAKE_SNAKEFMT
     linter_url: https://github.com/snakemake/snakefmt
     linter_repo: https://github.com/snakemake/snakefmt
-    linter_megalinter_ref_url: https://github.com/snakemake/snakefmt/pull/314
+    linter_megalinter_ref_url: https://github.com/snakemake/snakefmt#github-actions
     linter_rules_configuration_url: https://github.com/snakemake/snakefmt#configuration
     linter_spdx_license: MIT
     config_file_name: .snakefmt.toml

--- a/megalinter/descriptors/spell.megalinter-descriptor.yml
+++ b/megalinter/descriptors/spell.megalinter-descriptor.yml
@@ -264,7 +264,7 @@ linters:
       - documentation
     linter_url: https://lychee.cli.rs
     linter_repo: https://github.com/lycheeverse/lychee
-    linter_megalinter_ref_url: https://github.com/lycheeverse/lychee/pull/2277
+    linter_megalinter_ref_url: https://github.com/lycheeverse/lychee#users
     linter_banner_image_url: https://raw.githubusercontent.com/lycheeverse/lychee/master/assets/banner.svg
     linter_image_url: https://raw.githubusercontent.com/lycheeverse/lychee/master/assets/logo.svg
     linter_rules_url: https://lychee.cli.rs/guides/cli/

--- a/megalinter/descriptors/terraform.megalinter-descriptor.yml
+++ b/megalinter/descriptors/terraform.megalinter-descriptor.yml
@@ -20,7 +20,7 @@ linters:
       - security
     linter_url: https://github.com/terraform-linters/tflint
     linter_repo: https://github.com/terraform-linters/tflint
-    linter_megalinter_ref_url: https://github.com/terraform-linters/tflint/pull/2624
+    linter_megalinter_ref_url: "no"
     linter_rules_url: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/README.md
     linter_rules_configuration_url: https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/config.md
     linter_rules_inline_disable_url: https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/annotations.md

--- a/skills/megalinter-fix/linters/html_djlint.md
+++ b/skills/megalinter-fix/linters/html_djlint.md
@@ -9,7 +9,7 @@
 - Rules index: <https://djlint.com/docs/linter/>
 - Rules configuration: <https://djlint.com/docs/configuration/>
 - How to disable rules inline: <https://djlint.com/docs/ignoring-code/>
-- Error line format (regex): `[A-Z][0-9]{3} `
+- Error line format (regex): `[A-Z][0-9]{3}`
 - MegaLinter tuning variables (in `.mega-linter.yml`):
   - `DISABLE_LINTERS`: add `HTML_DJLINT` to fully disable this linter
   - `HTML_DJLINT_DISABLE_ERRORS: true`: keep the linter active but non-blocking


### PR DESCRIPTION
Follow-up of #8701: update `linter_megalinter_ref_url` in descriptors according to what happened to the suggestion PRs opened on the embedded linters repositories.

## Merged upstream -> ref replaced by the published page

| Linter | Suggestion PR | New ref URL |
| --- | --- | --- |
| cpplint (shared) | cpplint/cpplint#462 | https://github.com/cpplint/cpplint#installation |
| protolint | yoheimuta/protolint#559 | https://github.com/yoheimuta/protolint#ci-integration |
| pyright | microsoft/pyright#11604 | https://microsoft.github.io/pyright/#/ci-integration |
| nbqa | nbQA-dev/nbQA#905 | https://github.com/nbQA-dev/nbQA#-used-by |
| semgrep | semgrep/semgrep-docs#2775 | https://semgrep.dev/docs/extensions/overview |
| kingfisher | mongodb/kingfisher#471 | https://github.com/mongodb/kingfisher#installation |
| snakefmt | snakemake/snakefmt#314 | https://github.com/snakemake/snakefmt#github-actions |
| lychee | lycheeverse/lychee#2277 | https://github.com/lycheeverse/lychee#users |

Every target page was fetched to check the mention is really online, and the anchor comes from the enclosing heading.

## Declined by maintainers -> `"no"`

| Linter | Suggestion PR | Reason |
| --- | --- | --- |
| ansible-lint | ansible/ansible-lint#5144 | they don't list third-party tools in their install docs |
| isort | PyCQA/isort#2620 | they don't advertise other tools in their documentation |
| tflint | terraform-linters/tflint#2624 | they want to keep the README as simple as possible |

## Retargeted

| Linter | Change |
| --- | --- |
| cppcheck (shared) | cppcheck-opensource/cppcheck#8786 closed on maintainer request, replaced by cppcheck-opensource/cppcheck-htdocs#32 to add MegaLinter in the "Clients and plugins" list of the website |

Descriptor values only, no build needed: `linter_megalinter_ref_url` is only rendered in the auto-generated linter documentation pages.
