### PR TITLE
Point at the SARIF report instead of "No output available" in reporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - The **API reporter** variables (`API_REPORTER`, `API_REPORTER_URL`…) are not flagged as **deprecated** anymore in the configuration JSON schema: they were collateral damage of the removal of the `API` descriptor in v10.0.0, and IDEs displayed them as obsolete
 
 - Reporters
+  - Linters reporting in **SARIF** format no longer show **No output available** in Pull Request comments and summaries: the details section now names the SARIF report to open and links the **MegaLinter artifacts** ([#8730](https://github.com/oxsecurity/megalinter/issues/8730))
+    - Applies to the **GitHub**, **GitLab**, **Azure** and **Bitbucket** comment reporters and to the markdown summary
+    - The link points where the reporter already links its detailed reports, so it follows `REPORTERS_ACTION_RUN_URL` when you set it
 
 - Flavors
 

--- a/megalinter/tests/test_megalinter/utils_reporter_test.py
+++ b/megalinter/tests/test_megalinter/utils_reporter_test.py
@@ -7,6 +7,7 @@ Unit tests for utils_reporter
 import unittest
 
 from megalinter.utils_reporter import (
+    _build_missing_output_message,
     _build_table_content,
     _sort_linters_by_icon_severity,
     get_linter_status_icon,
@@ -24,7 +25,15 @@ class FakeLinter:
         total_number_warnings=0,
         disable_errors_if_less_than=None,
         linter_name="fake_linter",
+        can_output_sarif=False,
+        output_sarif=False,
+        sarif_output_file=None,
+        report_folder="/tmp/lint/megalinter-reports",
     ):
+        self.can_output_sarif = can_output_sarif
+        self.output_sarif = output_sarif
+        self.sarif_output_file = sarif_output_file
+        self.report_folder = report_folder
         self.status = status
         self.return_code = return_code
         self.number_errors = number_errors
@@ -147,3 +156,86 @@ class utils_reporter_test(unittest.TestCase):
         self.assertIn("Max errors", table)
         self.assertIn("☑️", table)
         self.assertIn("10", table)
+
+    @staticmethod
+    def sarif_linter():
+        return FakeLinter(
+            linter_name="ruff",
+            can_output_sarif=True,
+            output_sarif=True,
+            sarif_output_file="/tmp/lint/megalinter-reports/sarif/PYTHON_RUFF.sarif",
+        )
+
+    # A SARIF linter writes nothing to stdout: instead of a dead end, the
+    # details section names the report and links the artifacts
+    def test_missing_output_sarif_linter_with_run_url(self):
+        message = _build_missing_output_message(
+            self.sarif_linter(), "https://ci.example/run/1", "No output available"
+        )
+        self.assertIn("reports in SARIF format", message)
+        self.assertIn("[MegaLinter artifacts](https://ci.example/run/1)", message)
+        self.assertIn("`sarif/PYTHON_RUFF.sarif`", message)
+        # The absolute container path must never be shown to the user
+        self.assertNotIn("/tmp/lint", message)
+
+    def test_missing_output_sarif_linter_without_run_url(self):
+        message = _build_missing_output_message(
+            self.sarif_linter(), "", "No output available"
+        )
+        self.assertIn("reports in SARIF format", message)
+        self.assertIn("`sarif/PYTHON_RUFF.sarif`", message)
+        self.assertNotIn("](", message)
+
+    # The hint keys on the linter's SARIF intent, not on the file still being
+    # on disk: SarifReporter runs first and removes it when LOG_FILE is "none"
+    def test_missing_output_sarif_hint_does_not_need_the_file(self):
+        linter = self.sarif_linter()
+        self.assertIn(
+            "sarif/PYTHON_RUFF.sarif",
+            _build_missing_output_message(linter, "", "No output available"),
+        )
+
+    def test_missing_output_applies_to_the_file_not_found_case(self):
+        message = _build_missing_output_message(
+            self.sarif_linter(), "", "Linter output file not found"
+        )
+        self.assertIn("reports in SARIF format", message)
+
+    # Non-SARIF linters keep the previous wording untouched
+    def test_missing_output_non_sarif_linter_unchanged(self):
+        for default_message in ("No output available", "Linter output file not found"):
+            self.assertEqual(
+                default_message,
+                _build_missing_output_message(FakeLinter(), "", default_message),
+            )
+
+    def test_missing_output_sarif_capable_but_not_enabled_unchanged(self):
+        linter = FakeLinter(
+            can_output_sarif=True,
+            output_sarif=False,
+            sarif_output_file="/tmp/lint/megalinter-reports/sarif/PYTHON_RUFF.sarif",
+        )
+        self.assertEqual(
+            "No output available",
+            _build_missing_output_message(linter, "", "No output available"),
+        )
+
+    # report_folder is "" when the linter got no report_folder param: the
+    # message must stay a clean path, not walk out of the reports folder
+    def test_missing_output_sarif_without_report_folder(self):
+        linter = FakeLinter(
+            can_output_sarif=True,
+            output_sarif=True,
+            sarif_output_file="/sarif/PYTHON_RUFF.sarif",
+            report_folder="",
+        )
+        message = _build_missing_output_message(linter, "", "No output available")
+        self.assertIn("`sarif/PYTHON_RUFF.sarif`", message)
+        self.assertNotIn("..", message)
+
+    def test_missing_output_sarif_enabled_without_output_file_unchanged(self):
+        linter = FakeLinter(can_output_sarif=True, output_sarif=True)
+        self.assertEqual(
+            "No output available",
+            _build_missing_output_message(linter, "", "No output available"),
+        )

--- a/megalinter/utils_reporter.py
+++ b/megalinter/utils_reporter.py
@@ -727,6 +727,32 @@ def _build_table_content(linters, reporter_self, action_run_url):
     return str(writer)
 
 
+# A linter reporting in SARIF writes nothing to stdout, so its details section
+# would otherwise be a dead end ("No output available"). Point at the SARIF
+# report to open instead, linked to the artifacts the footer already links to.
+# The condition is the linter's SARIF intent, not the presence of the file:
+# SarifReporter runs first (processing_order -9999) and deletes the per-linter
+# SARIF files when LOG_FILE is "none", so a filesystem check would be flaky
+def _build_missing_output_message(linter, action_run_url, default_message):
+    if (
+        linter.can_output_sarif is not True
+        or linter.output_sarif is not True
+        or linter.sarif_output_file is None
+    ):
+        return default_message
+    # Mirrors how Linter.get_sarif_arguments() builds the path, so the message
+    # stays a clean path inside the report folder even when report_folder is
+    # not set (relpath would then walk out with ../..)
+    sarif_report = f"sarif/{os.path.basename(linter.sarif_output_file)}"
+    message = f"No text output: {linter.linter_name} reports in SARIF format."
+    if action_run_url != "":
+        return (
+            f"{message} Download [MegaLinter artifacts]({action_run_url}) "
+            f"and open `{sarif_report}`"
+        )
+    return f"{message} See `{sarif_report}` in MegaLinter artifacts"
+
+
 def _build_sections_content(
     linters_with_issues, linters_ok, reporter_self, action_run_url, max_total_chars
 ):
@@ -805,11 +831,15 @@ def _build_sections_content(
                         # Escape any HTML in the output and wrap in code block
                         linter_output = f"```\n{linter_output.strip()}\n```"
                     else:
-                        linter_output = "No output available"
+                        linter_output = _build_missing_output_message(
+                            linter, action_run_url, "No output available"
+                        )
             except Exception as e:
                 linter_output = f"Error reading linter output: {str(e)}"
         else:
-            linter_output = "Linter output file not found"
+            linter_output = _build_missing_output_message(
+                linter, action_run_url, "Linter output file not found"
+            )
 
         # Get AI suggestions for this specific linter if available
         ai_suggestion_content = ""


### PR DESCRIPTION
Closes #8730.

## Problem

A linter reporting in SARIF writes nothing to stdout, so its per-linter details section in every reporter was a dead end:

```
No output available
```

## Fix

The details section now names the SARIF report to open and links the artifacts:

| Case | Rendered |
|---|---|
| SARIF linter, run URL known | `No text output: ruff reports in SARIF format. Download [MegaLinter artifacts](…) and open `sarif/PYTHON_RUFF.sarif`` |
| SARIF linter, no run URL | `No text output: ruff reports in SARIF format. See `sarif/PYTHON_RUFF.sarif` in MegaLinter artifacts` |
| Non-SARIF linter | unchanged |

One helper in `utils_reporter`, used by **both** dead ends — `No output available` and `Linter output file not found` — so the **GitHub**, **GitLab**, **Azure** and **Bitbucket** comment reporters and the markdown summary all benefit from a single change, as @bdovaz expected in the issue.

## Three refinements on the issue's proposal

The issue suggested `f"Download the artifact named {linter.sarif_output_file}"` guarded by `os.path.isfile(...)`. Three things came out of checking that against the code:

**1. `sarif_output_file` is not an artifact name.** It is built at `Linter.py:1959` as `{report_folder}/sarif/{LINTER_NAME}.sarif` — an absolute *container* path like `/tmp/lint/megalinter-reports/sarif/PYTHON_RUFF.sarif`. The artifact is named in the user's own `upload-artifact` step (`MegaLinter reports` in the shipped workflow), so MegaLinter cannot know it. The message names the path **relative to the report folder** instead, and a test asserts the absolute path never leaks into it.

**2. `os.path.isfile()` would have been flaky.** `SarifReporter.processing_order = -9999` — it runs *before* the comment reporters, and at `SarifReporter.py:94` it **deletes** each per-linter `.sarif` when `LOG_FILE: none`. A stat at comment-build time would be `False` in exactly that configuration and the hint would silently vanish. The condition is the linter's SARIF intent (`can_output_sarif` + `output_sarif` + `sarif_output_file is not None`) instead.

**3. `Linter output file not found` is the sibling dead end.** It fires when `TEXT_REPORTER` is off or report files cannot be written; a SARIF linter reaches it too, and the same guidance applies.

## On the artifacts link

No new URL is invented. `build_markdown_summary_footer` already renders this exact value as *"See detailed reports in [MegaLinter artifacts](…)"*, and `action_run_url` was **already** a parameter of `_build_sections_content` — so there is no signature change and the link inherits whatever correctness the footer already has, including the `REPORTERS_ACTION_RUN_URL` override.

On Azure it is already a true deep link: the reporter passes `get_artifacts_url()` (the published-artifacts view) by default.

I deliberately did **not** build platform-specific artifact routes such as `{CI_JOB_URL}/artifacts/browse` or a GitHub `#artifacts` anchor: whether artifacts exist at all depends on the user's own CI config, so those would 404 for anyone without an upload step. When no URL is available (the markdown summary passes `""`), the message degrades to naming the file, mirroring the footer's own fallback.

## Testing

9 new cases in `utils_reporter_test.py` (25 pass in the file), covering: the linked and unlinked renderings, both dead-end branches, non-SARIF linters staying byte-identical, SARIF-capable-but-disabled, SARIF-enabled-without-output-file, and no absolute path leaking.

One robustness fix found while testing rather than assumed: `report_folder` can legitimately be `""` (`Linter.py:346-347`), and `os.path.relpath` against it produced `../../tmp/lint/…`. The path is now derived the same way `get_sarif_arguments()` builds it, which cannot walk out of the report folder — with a regression test.

No descriptor touched, so no `make megalinter-build`.
