### PR TITLE
Update schema generator for Betterleaks

### DIFF
--- a/.automation/build.py
+++ b/.automation/build.py
@@ -1664,6 +1664,73 @@ def process_type(linters_by_type, type1, type_label, linters_tables_md):
                 linter_doc_md += [
                     f"| {variable['name']} | {variable['description']} | `{variable['default_value']}` |"
                 ]
+        # Betterleaks has linter-specific PR scan variables that are consumed
+        # by BetterleaksLinter and documented from the descriptor, but they are
+        # not otherwise added to the generated MegaLinter configuration schema.
+        # Keep this narrow until descriptor variables carry enough type metadata
+        # to generate schema entries generically.
+        if linter.name == "REPOSITORY_BETTERLEAKS":
+            add_in_config_schema_file(
+                [
+                    [
+                        "REPOSITORY_BETTERLEAKS_PR_COMMITS_SCAN",
+                        {
+                            "$id": (
+                                "#/properties/"
+                                "REPOSITORY_BETTERLEAKS_PR_COMMITS_SCAN"
+                            ),
+                            "description": (
+                                "REPOSITORY_BETTERLEAKS: Scan only commits in "
+                                "the current Pull Request/Merge Request"
+                            ),
+                            "type": "boolean",
+                            "title": (
+                                f"{title_prefix}REPOSITORY_BETTERLEAKS: "
+                                "Scan Pull Request/Merge Request commits"
+                            ),
+                            "default": False,
+                        },
+                    ],
+                    [
+                        "REPOSITORY_BETTERLEAKS_PR_SOURCE_SHA",
+                        {
+                            "$id": (
+                                "#/properties/"
+                                "REPOSITORY_BETTERLEAKS_PR_SOURCE_SHA"
+                            ),
+                            "description": (
+                                "REPOSITORY_BETTERLEAKS: Source commit SHA of "
+                                "the Pull Request/Merge Request"
+                            ),
+                            "type": "string",
+                            "title": (
+                                f"{title_prefix}REPOSITORY_BETTERLEAKS: "
+                                "Pull Request/Merge Request source SHA"
+                            ),
+                            "default": "",
+                        },
+                    ],
+                    [
+                        "REPOSITORY_BETTERLEAKS_PR_TARGET_SHA",
+                        {
+                            "$id": (
+                                "#/properties/"
+                                "REPOSITORY_BETTERLEAKS_PR_TARGET_SHA"
+                            ),
+                            "description": (
+                                "REPOSITORY_BETTERLEAKS: Target commit SHA of "
+                                "the Pull Request/Merge Request"
+                            ),
+                            "type": "string",
+                            "title": (
+                                f"{title_prefix}REPOSITORY_BETTERLEAKS: "
+                                "Pull Request/Merge Request target SHA"
+                            ),
+                            "default": "",
+                        },
+                    ],
+                ]
+            )
         linter_doc_md += [
             f"| {linter.name}_ARGUMENTS | User custom arguments to add in linter CLI call<br/>"
             f'Ex: `-s --foo "bar"` |  |'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - **Bitbucket Pipelines** is now recognized as a Pull Request context: `PULL_REQUEST` optimizations that were silently skipped there are applied again
     - **REPOSITORY_CHECKOV** and **REPOSITORY_BETTERLEAKS** only analyze the Pull Request changes when asked to
     - Set `BITBUCKET_PR_ID` in your pipeline (Bitbucket provides it on Pull Request builds) to benefit from it
+    - Fixed JSON config schema for Betterleaks
 
 - Reporters
   - Linters reporting in **SARIF** format no longer show **No output available** in Pull Request comments and summaries: the details section now names the SARIF report to open and links the **MegaLinter artifacts** ([#8730](https://github.com/oxsecurity/megalinter/issues/8730))


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #8801 

<!-- markdownlint-restore -->

`REPOSITORY_BETTERLEAKS_PR_COMMITS_SCAN`,
`REPOSITORY_BETTERLEAKS_PR_SOURCE_SHA`,
and `REPOSITORY_BETTERLEAKS_PR_TARGET_SHA` are supported by Betterleaks and
documented from its descriptor, but are absent from the generated MegaLinter
configuration JSON Schema. As a result, schema validators such as v8r reject
otherwise valid .mega-linter.yml configurations.

This change narrowly adds those three Betterleaks-specific variables to the
generated configuration schema. It does not change Betterleaks runtime behavior
or the descriptor format.


## Proposed Changes

1. Update the automation script that builds the JSON schema to include the three missing entries for `REPOSITORY_BETTERLEAKS`
2. Update changelog


## Readiness Checklist

### Author/Contributor
- [x] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
