### PR TITLE
Never build a lint command with an empty list of files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - A run where all linters pass does not **exit with an error** anymore when MegaLinter can not list the files updated by the linters ([#8649](https://github.com/oxsecurity/megalinter/issues/8649))
     - Happens on a **read-only workspace** whose repository uses **git-lfs**: the required LFS filter has nowhere to write its temporary files, so the `git diff` used to detect updated files exits 128
     - MegaLinter now logs a **warning** naming the workspace and the failed command, reports no updated source file, and completes the run. The `UPDATED_SOURCES_REPORTER: false` workaround is not needed anymore
+  - **REPOSITORY_CHECKOV** does not fail anymore with `argument -f/--file: expected at least one argument` in a Pull Request where **no file has been updated** ([#8802](https://github.com/oxsecurity/megalinter/issues/8802))
+    - With `VALIDATE_ALL_CODEBASE: false`, checkov is now **skipped** when the Pull Request contains no updated file, instead of scanning the whole project or building an invalid command
+    - Any linter using the **`list_of_files` lint mode** with no file to analyze is skipped the same way, instead of being called with an empty list of files
 
 - Reporters
   - Linters reporting in **SARIF** format no longer show **No output available** in Pull Request comments and summaries: the details section now names the SARIF report to open and links the **MegaLinter artifacts** ([#8730](https://github.com/oxsecurity/megalinter/issues/8730))

--- a/megalinter/Linter.py
+++ b/megalinter/Linter.py
@@ -990,6 +990,14 @@ class Linter:
                     file_errors_number,
                     file_warnings_number,
                 )
+        elif self.cli_lint_mode == "list_of_files" and len(self.files) == 0:
+            # Nothing to lint: appending an empty list of files to the command
+            # line builds an invalid command (ex: "checkov --file" with no value
+            # after it), and the linter would fail on its own arguments instead
+            # of reporting a lint result
+            logging.info(
+                f"{self.name} has no file to lint, so its command has not been run"
+            )
         else:
             # Lint all workspace in one command
             return_code, stdout = self.process_linter()
@@ -1645,12 +1653,16 @@ class Linter:
 
             cmd += self.cli_lint_mode_file_extra_args_after
         elif self.cli_lint_mode == "list_of_files":
-            self.cli_lint_mode_list_of_files_extra_args_after = self.replace_vars(
-                self.cli_lint_mode_list_of_files_extra_args_after,
-                additional_replace_variables,
-            )
+            # Arguments introducing the list of files (ex: --file) are added
+            # only when there is at least one file to lint, otherwise they would
+            # be left without value and make the linter command invalid
+            if len(self.files) > 0:
+                self.cli_lint_mode_list_of_files_extra_args_after = self.replace_vars(
+                    self.cli_lint_mode_list_of_files_extra_args_after,
+                    additional_replace_variables,
+                )
 
-            cmd += self.cli_lint_mode_list_of_files_extra_args_after
+                cmd += self.cli_lint_mode_list_of_files_extra_args_after
         elif self.cli_lint_mode == "project":
             # Single gate for every excluded-directories forwarding mechanism:
             # native CLI arguments, generated ignore files (report folder or

--- a/megalinter/linters/CheckovLinter.py
+++ b/megalinter/linters/CheckovLinter.py
@@ -45,15 +45,42 @@ class CheckovLinter(Linter):
                 github_conf_dir = ".megalinter_github_conf"
             self._cached_subprocess_env["CKV_GITHUB_CONF_DIR_NAME"] = github_conf_dir
 
-    def build_lint_command(self, file=None) -> list:
-        if (
-            config.get(self.request_id, "VALIDATE_ALL_CODEBASE") == "false"
+    # In project lint mode, checkov scans the whole workspace by itself. During a
+    # pull request run with VALIDATE_ALL_CODEBASE=false, restrict the scan to the
+    # files updated in the pull request. In file and list_of_files lint modes,
+    # MegaLinter already sends only the updated files to checkov.
+    def is_pr_diff_scan(self) -> bool:
+        return (
+            self.cli_lint_mode == "project"
+            and config.get(self.request_id, "VALIDATE_ALL_CODEBASE") == "false"
             and utils.is_pr()
-        ):
-            if "--file" not in self.cli_lint_extra_args_after:
+        )
+
+    # Files updated in the pull request. Defensive on purpose: master can be
+    # absent when the linter is run standalone or instantiated in unit tests
+    def get_pr_diff_files(self) -> list:
+        master = getattr(self, "master", None)
+        return getattr(master, "all_diff_files", None) or []
+
+    def collect_files(self, all_files):
+        super().collect_files(all_files)
+        # No file updated in the pull request means there is nothing for checkov
+        # to scan: skip it, instead of scanning the whole project (which the user
+        # opted out of with VALIDATE_ALL_CODEBASE=false)
+        if self.is_pr_diff_scan() and len(self.get_pr_diff_files()) == 0:
+            logging.info(
+                "[Checkov] Skipped, as no file has been updated in the pull request"
+            )
+            self.is_active = False
+
+    def build_lint_command(self, file=None) -> list:
+        if self.is_pr_diff_scan():
+            diff_files = self.get_pr_diff_files()
+            # Never append --file without any value: checkov would fail on its
+            # own arguments ("expected at least one argument") instead of linting
+            if len(diff_files) > 0 and "--file" not in self.cli_lint_extra_args_after:
                 self.cli_lint_extra_args_after.append("--file")
-                for file_to_lint in self.master.all_diff_files:
-                    self.cli_lint_extra_args_after.append(file_to_lint)
+                self.cli_lint_extra_args_after += diff_files
 
         cmd = super().build_lint_command(file)
 

--- a/megalinter/tests/test_megalinter/checkov_linter_test.py
+++ b/megalinter/tests/test_megalinter/checkov_linter_test.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 """
-Unit tests for CheckovLinter automatic secrets framework delegation.
+Unit tests for CheckovLinter automatic secrets framework delegation and
+pull request diff scan.
 
 When another active linter of the run is a dedicated secret scanner
 (betterleaks, kingfisher, secretlint, trufflehog), checkov must be called
 with "--skip-framework secrets" to avoid duplicating the secrets scan,
 unless the user already expressed a framework intent through
 REPOSITORY_CHECKOV_ARGUMENTS or the checkov config file.
+
+In a pull request run with VALIDATE_ALL_CODEBASE=false, checkov scans only the
+files updated in the pull request, and must never be called with an empty
+--file argument (issue #8802).
 """
 
 import os
@@ -14,6 +19,7 @@ import tempfile
 import unittest
 import uuid
 from types import SimpleNamespace
+from unittest import mock
 
 from megalinter import config, linter_factory, utils
 
@@ -40,9 +46,10 @@ def _build_checkov_linter(request_id, workspace, extra_config=None):
     return linter_factory.build_linter("REPOSITORY", "checkov", base_params)
 
 
-def _master_with_active_linters(linter_names):
+def _master_with_active_linters(linter_names, all_diff_files=None):
     return SimpleNamespace(
-        active_linters=[SimpleNamespace(name=name) for name in linter_names]
+        active_linters=[SimpleNamespace(name=name) for name in linter_names],
+        all_diff_files=all_diff_files if all_diff_files is not None else [],
     )
 
 
@@ -183,6 +190,83 @@ class CheckovLinterTest(unittest.TestCase):
             self.assertEqual(first_cmd.count("--skip-framework"), 1)
             self.assertEqual(second_cmd.count("--skip-framework"), 1)
             self.assertEqual(second_cmd.count("secrets"), 1)
+
+
+class CheckovLinterPullRequestTest(unittest.TestCase):
+    def setUp(self):
+        self.request_id = str(uuid.uuid1())
+
+    def tearDown(self):
+        config.delete(self.request_id)
+
+    def _build_pr_checkov(self, workspace, all_diff_files, extra_config=None):
+        pr_config = {"VALIDATE_ALL_CODEBASE": "false"}
+        if extra_config is not None:
+            pr_config.update(extra_config)
+        checkov = _build_checkov_linter(self.request_id, workspace, pr_config)
+        checkov.master = _master_with_active_linters(
+            ["REPOSITORY_CHECKOV"], all_diff_files
+        )
+        return checkov
+
+    def test_pull_request_updated_files_are_scanned(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            checkov = self._build_pr_checkov(workspace, ["infra/main.tf"])
+            with mock.patch("megalinter.utils.is_pr", return_value=True):
+                cmd = checkov.build_lint_command()
+            self.assertIn("--file", cmd)
+            self.assertEqual(cmd[cmd.index("--file") + 1], "infra/main.tf")
+
+    def test_pull_request_without_updated_file_does_not_add_file_argument(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            checkov = self._build_pr_checkov(workspace, [])
+            with mock.patch("megalinter.utils.is_pr", return_value=True):
+                cmd = checkov.build_lint_command()
+            self.assertNotIn("--file", cmd)
+            self.assertIn("--directory", cmd)
+
+    def test_pull_request_without_updated_file_deactivates_checkov(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            checkov = self._build_pr_checkov(workspace, [])
+            with mock.patch("megalinter.utils.is_pr", return_value=True):
+                checkov.collect_files([])
+            self.assertFalse(checkov.is_active)
+
+    def test_pull_request_with_updated_files_keeps_checkov_active(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            checkov = self._build_pr_checkov(workspace, ["infra/main.tf"])
+            with mock.patch("megalinter.utils.is_pr", return_value=True):
+                checkov.collect_files(["infra/main.tf"])
+            self.assertTrue(checkov.is_active)
+
+    def test_updated_files_are_not_added_outside_project_lint_mode(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            checkov = self._build_pr_checkov(
+                workspace,
+                ["infra/main.tf"],
+                {"REPOSITORY_CHECKOV_CLI_LINT_MODE": "list_of_files"},
+            )
+            with mock.patch("megalinter.utils.is_pr", return_value=True):
+                cmd = checkov.build_lint_command()
+            # MegaLinter sends the files it kept itself in list_of_files mode,
+            # and there is none here, so no --file argument must be built
+            self.assertNotIn("--file", cmd)
+
+    def test_lint_command_is_not_run_without_file_in_list_of_files_mode(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            checkov = _build_checkov_linter(
+                self.request_id,
+                workspace,
+                {"REPOSITORY_CHECKOV_CLI_LINT_MODE": "list_of_files"},
+            )
+            checkov.master = _master_with_active_linters(["REPOSITORY_CHECKOV"])
+            checkov.reporters = []
+            checkov.files = []
+            with mock.patch.object(checkov, "process_linter") as process_linter_mock:
+                checkov.run()
+            process_linter_mock.assert_not_called()
+            self.assertEqual(checkov.status, "success")
+            self.assertEqual(checkov.return_code, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Root cause

`REPOSITORY_CHECKOV` runs in `project` lint mode, and the `REPOSITORY` descriptor declares `lint_all_files: true`, so the linter stays active even when MegaLinter kept **0 files**.

`CheckovLinter.build_lint_command()` appends `--file` + `master.all_diff_files` as soon as `VALIDATE_ALL_CODEBASE=false` and the run is a Pull Request, without checking that the list contains anything. In a PR where `git diff` returns no file (`Kept [0] files on [0] found files`), the built command ends with a dangling `--file`, and checkov fails on its own arguments:

```
checkov --config-file /action/lib/.automation/.checkov.yml --file --directory .
checkov: error: argument -f/--file: expected at least one argument
```

The same weakness exists generically: any linter whose descriptor declares `lint_all_files` (all `REPOSITORY` linters) and that is set to `list_of_files` lint mode stays active with zero file, and `cli_lint_mode_list_of_files_extra_args_after` (`--file` for checkov, `--input` for `KOTLIN_KTLINT`, `-E --source-code` for `REPOSITORY_DEVSKIM`) is added with no value after it.

Note: the lint mode is never silently switched from `project` to `list_of_files`. What looked like a mode switch is this checkov-specific "scan only the PR files" behavior (#7119) applying inside `project` mode.

## Fix

Generic, in `megalinter/Linter.py`:

- `run()`: a linter in `list_of_files` mode with an empty file list does not run its command at all — it is skipped with a log line instead of producing an invalid command.
- `build_lint_command()`: `cli_lint_mode_list_of_files_extra_args_after` is only appended when there is at least one file to lint.

In `megalinter/linters/CheckovLinter.py`:

- `--file` is added only when the Pull Request actually contains updated files, and only in `project` lint mode — in `file` / `list_of_files` modes MegaLinter already passes the updated files it kept, so the extra unfiltered list was redundant (and produced a duplicated `--file`).
- When the Pull Request contains no updated file at all, checkov is deactivated for the run, instead of falling back to scanning the whole project, which the user explicitly opted out of with `VALIDATE_ALL_CODEBASE: false`.

## Verification

Unit tests added to `megalinter/tests/test_megalinter/checkov_linter_test.py` (no Docker needed):

- PR with updated files: `--file <file>` is built as before
- PR without updated file: no `--file` argument, `--directory .` kept
- PR without updated file: checkov is deactivated at file collection
- PR with updated files: checkov stays active
- `list_of_files` lint mode: the PR diff files are not injected
- `list_of_files` lint mode with no file: `process_linter()` is not called, status stays `success`

The 4 tests covering the new behavior fail on `main` and pass with this change:

```
$ python -m pytest megalinter/tests/test_megalinter/checkov_linter_test.py -q
16 passed
```

`megalinter/tests/test_megalinter/linter_test.py` and `utils_test.py` still pass; `black`, `flake8` and `isort` are clean on the changed files.

## Not verified

The checkov linter test suite itself (`repository_checkov_test`) requires the Docker image and was not run locally.

Fixes #8802
