### PR TITLE
chore(deps): update npm-package-json-lint to v11 and its config-default to v10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -277,7 +277,7 @@ ARG NPM_PRANTLF_JSONLINT_VERSION=17.0.1
 # renovate: datasource=npm depName=v8r
 ARG NPM_V8R_VERSION=6.1.0
 # renovate: datasource=npm depName=npm-package-json-lint
-ARG NPM_PACKAGE_JSON_LINT_VERSION=10.5.1
+ARG NPM_PACKAGE_JSON_LINT_VERSION=11.0.0
 # renovate: datasource=npm depName=npm-package-json-lint-config-default
 ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=9.0.1
 # renovate: datasource=npm depName=@eslint-react/eslint-plugin

--- a/Dockerfile
+++ b/Dockerfile
@@ -279,7 +279,7 @@ ARG NPM_V8R_VERSION=6.1.0
 # renovate: datasource=npm depName=npm-package-json-lint
 ARG NPM_PACKAGE_JSON_LINT_VERSION=11.0.0
 # renovate: datasource=npm depName=npm-package-json-lint-config-default
-ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=9.0.1
+ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=10.0.0
 # renovate: datasource=npm depName=@eslint-react/eslint-plugin
 ARG NPM_ESLINT_REACT_ESLINT_PLUGIN_VERSION=5.18.6
 # renovate: datasource=github-tags depName=pinterest/ktlint

--- a/flavors/cupcake/Dockerfile
+++ b/flavors/cupcake/Dockerfile
@@ -218,7 +218,7 @@ ARG NPM_V8R_VERSION=6.1.0
 # renovate: datasource=npm depName=npm-package-json-lint
 ARG NPM_PACKAGE_JSON_LINT_VERSION=11.0.0
 # renovate: datasource=npm depName=npm-package-json-lint-config-default
-ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=9.0.1
+ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=10.0.0
 # renovate: datasource=npm depName=@eslint-react/eslint-plugin
 ARG NPM_ESLINT_REACT_ESLINT_PLUGIN_VERSION=5.18.6
 # renovate: datasource=github-tags depName=pinterest/ktlint

--- a/flavors/cupcake/Dockerfile
+++ b/flavors/cupcake/Dockerfile
@@ -216,7 +216,7 @@ ARG NPM_PRANTLF_JSONLINT_VERSION=17.0.1
 # renovate: datasource=npm depName=v8r
 ARG NPM_V8R_VERSION=6.1.0
 # renovate: datasource=npm depName=npm-package-json-lint
-ARG NPM_PACKAGE_JSON_LINT_VERSION=10.5.1
+ARG NPM_PACKAGE_JSON_LINT_VERSION=11.0.0
 # renovate: datasource=npm depName=npm-package-json-lint-config-default
 ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=9.0.1
 # renovate: datasource=npm depName=@eslint-react/eslint-plugin

--- a/flavors/dotnet/Dockerfile
+++ b/flavors/dotnet/Dockerfile
@@ -180,7 +180,7 @@ ARG NPM_PRETTIER_VERSION=3.9.6
 # renovate: datasource=npm depName=npm-package-json-lint
 ARG NPM_PACKAGE_JSON_LINT_VERSION=11.0.0
 # renovate: datasource=npm depName=npm-package-json-lint-config-default
-ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=9.0.1
+ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=10.0.0
 # renovate: datasource=github-tags depName=pinterest/ktlint
 ARG KTLINT_VERSION=1.8.0
 

--- a/flavors/dotnet/Dockerfile
+++ b/flavors/dotnet/Dockerfile
@@ -178,7 +178,7 @@ ARG NPM_V8R_VERSION=6.1.0
 # renovate: datasource=npm depName=prettier
 ARG NPM_PRETTIER_VERSION=3.9.6
 # renovate: datasource=npm depName=npm-package-json-lint
-ARG NPM_PACKAGE_JSON_LINT_VERSION=10.5.1
+ARG NPM_PACKAGE_JSON_LINT_VERSION=11.0.0
 # renovate: datasource=npm depName=npm-package-json-lint-config-default
 ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=9.0.1
 # renovate: datasource=github-tags depName=pinterest/ktlint

--- a/flavors/dotnetweb/Dockerfile
+++ b/flavors/dotnetweb/Dockerfile
@@ -206,7 +206,7 @@ ARG NPM_V8R_VERSION=6.1.0
 # renovate: datasource=npm depName=npm-package-json-lint
 ARG NPM_PACKAGE_JSON_LINT_VERSION=11.0.0
 # renovate: datasource=npm depName=npm-package-json-lint-config-default
-ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=9.0.1
+ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=10.0.0
 # renovate: datasource=npm depName=@eslint-react/eslint-plugin
 ARG NPM_ESLINT_REACT_ESLINT_PLUGIN_VERSION=5.18.6
 # renovate: datasource=github-tags depName=pinterest/ktlint

--- a/flavors/dotnetweb/Dockerfile
+++ b/flavors/dotnetweb/Dockerfile
@@ -204,7 +204,7 @@ ARG NPM_PRANTLF_JSONLINT_VERSION=17.0.1
 # renovate: datasource=npm depName=v8r
 ARG NPM_V8R_VERSION=6.1.0
 # renovate: datasource=npm depName=npm-package-json-lint
-ARG NPM_PACKAGE_JSON_LINT_VERSION=10.5.1
+ARG NPM_PACKAGE_JSON_LINT_VERSION=11.0.0
 # renovate: datasource=npm depName=npm-package-json-lint-config-default
 ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=9.0.1
 # renovate: datasource=npm depName=@eslint-react/eslint-plugin

--- a/flavors/javascript/Dockerfile
+++ b/flavors/javascript/Dockerfile
@@ -185,7 +185,7 @@ ARG NPM_V8R_VERSION=6.1.0
 # renovate: datasource=npm depName=npm-package-json-lint
 ARG NPM_PACKAGE_JSON_LINT_VERSION=11.0.0
 # renovate: datasource=npm depName=npm-package-json-lint-config-default
-ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=9.0.1
+ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=10.0.0
 # renovate: datasource=npm depName=@eslint-react/eslint-plugin
 ARG NPM_ESLINT_REACT_ESLINT_PLUGIN_VERSION=5.18.6
 # renovate: datasource=github-tags depName=pinterest/ktlint

--- a/flavors/javascript/Dockerfile
+++ b/flavors/javascript/Dockerfile
@@ -183,7 +183,7 @@ ARG NPM_PRANTLF_JSONLINT_VERSION=17.0.1
 # renovate: datasource=npm depName=v8r
 ARG NPM_V8R_VERSION=6.1.0
 # renovate: datasource=npm depName=npm-package-json-lint
-ARG NPM_PACKAGE_JSON_LINT_VERSION=10.5.1
+ARG NPM_PACKAGE_JSON_LINT_VERSION=11.0.0
 # renovate: datasource=npm depName=npm-package-json-lint-config-default
 ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=9.0.1
 # renovate: datasource=npm depName=@eslint-react/eslint-plugin

--- a/flavors/salesforce/Dockerfile
+++ b/flavors/salesforce/Dockerfile
@@ -165,7 +165,7 @@ ARG NPM_PRETTIER_VERSION=3.9.6
 # renovate: datasource=npm depName=npm-package-json-lint
 ARG NPM_PACKAGE_JSON_LINT_VERSION=11.0.0
 # renovate: datasource=npm depName=npm-package-json-lint-config-default
-ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=9.0.1
+ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=10.0.0
 # renovate: datasource=github-tags depName=pinterest/ktlint
 ARG KTLINT_VERSION=1.8.0
 

--- a/flavors/salesforce/Dockerfile
+++ b/flavors/salesforce/Dockerfile
@@ -163,7 +163,7 @@ ARG NPM_V8R_VERSION=6.1.0
 # renovate: datasource=npm depName=prettier
 ARG NPM_PRETTIER_VERSION=3.9.6
 # renovate: datasource=npm depName=npm-package-json-lint
-ARG NPM_PACKAGE_JSON_LINT_VERSION=10.5.1
+ARG NPM_PACKAGE_JSON_LINT_VERSION=11.0.0
 # renovate: datasource=npm depName=npm-package-json-lint-config-default
 ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=9.0.1
 # renovate: datasource=github-tags depName=pinterest/ktlint

--- a/linters/json_npm_package_json_lint/Dockerfile
+++ b/linters/json_npm_package_json_lint/Dockerfile
@@ -64,7 +64,7 @@ ARG TARGETARCH
 # renovate: datasource=npm depName=npm-package-json-lint
 ARG NPM_PACKAGE_JSON_LINT_VERSION=11.0.0
 # renovate: datasource=npm depName=npm-package-json-lint-config-default
-ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=9.0.1
+ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=10.0.0
 #ARG__END
 
 ####################

--- a/linters/json_npm_package_json_lint/Dockerfile
+++ b/linters/json_npm_package_json_lint/Dockerfile
@@ -62,7 +62,7 @@ RUN python -c 'import sys; assert sys.version_info >= (3, 14, 7), "Python 3.14.7
 ARG TARGETPLATFORM
 ARG TARGETARCH
 # renovate: datasource=npm depName=npm-package-json-lint
-ARG NPM_PACKAGE_JSON_LINT_VERSION=10.5.1
+ARG NPM_PACKAGE_JSON_LINT_VERSION=11.0.0
 # renovate: datasource=npm depName=npm-package-json-lint-config-default
 ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=9.0.1
 #ARG__END

--- a/megalinter/descriptors/json.megalinter-descriptor.yml
+++ b/megalinter/descriptors/json.megalinter-descriptor.yml
@@ -176,7 +176,7 @@ linters:
       dockerfile:
         - |-
           # renovate: datasource=npm depName=npm-package-json-lint
-          ARG NPM_PACKAGE_JSON_LINT_VERSION=10.5.1
+          ARG NPM_PACKAGE_JSON_LINT_VERSION=11.0.0
         - |-
           # renovate: datasource=npm depName=npm-package-json-lint-config-default
           ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=9.0.1

--- a/megalinter/descriptors/json.megalinter-descriptor.yml
+++ b/megalinter/descriptors/json.megalinter-descriptor.yml
@@ -179,7 +179,7 @@ linters:
           ARG NPM_PACKAGE_JSON_LINT_VERSION=11.0.0
         - |-
           # renovate: datasource=npm depName=npm-package-json-lint-config-default
-          ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=9.0.1
+          ARG NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION=10.0.0
       npm:
         - "npm-package-json-lint@${NPM_PACKAGE_JSON_LINT_VERSION}"
         - "npm-package-json-lint-config-default@${NPM_PACKAGE_JSON_LINT_CONFIG_DEFAULT_VERSION}"

--- a/renovate.json5
+++ b/renovate.json5
@@ -135,6 +135,22 @@
         'betterleaks/betterleaks',
       ],
     },
+    {
+      // npm-package-json-lint-config-default majors require the matching
+      // npm-package-json-lint major (config-default v10 needs linter v11), so
+      // separate PRs can never be merged on their own: group them together.
+      groupName: 'npm-package-json-lint',
+      matchPackageNames: [
+        'npm-package-json-lint',
+        'npm-package-json-lint-config-default',
+      ],
+      matchUpdateTypes: [
+        'digest',
+        'patch',
+        'minor',
+        'major',
+      ],
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
Combines two Renovate PRs that can only be merged together, and prevents the split from happening again.

## Updates

| Package | Change | Renovate PR |
|---|---|---|
| npm-package-json-lint | `10.5.1` → `11.0.0` | #8746 |
| npm-package-json-lint-config-default | `9.0.1` → `10.0.0` | #8790 |

`npm-package-json-lint-config-default` v10 is a major bump whose only content is "Update to npm-package-json-lint v11", so neither PR can be merged on its own.

Breaking change in npm-package-json-lint v11: the `--allowEmptyTargets` CLI option was removed, and behavior changed when no targets are provided. The `JSON_NPM_PACKAGE_JSON_LINT` descriptor never used that option and always passes `.` as target (`cli_lint_mode_project_extra_args_after`), so no descriptor change is needed.

## Renovate grouping

Added a `npm-package-json-lint` group in `renovate.json5` so both packages are raised in a single PR from now on.

Dependabot is not involved here: these two packages are pinned in `megalinter/descriptors/json.megalinter-descriptor.yml` and only tracked by the Renovate custom manager. Dependabot's npm scope in this repo is `/mega-linter-runner` and the test fixtures.
