### PR TITLE
fix(renovate-rebase): force UTF-8 console output in tick_dashboard

### DIFF
--- a/.claude/skills/renovate-rebase/tick_dashboard.py
+++ b/.claude/skills/renovate-rebase/tick_dashboard.py
@@ -15,6 +15,7 @@
 #   python tick_dashboard.py --issue 3630 --repo oxsecurity/megalinter
 
 import argparse
+import io
 import json
 import os
 import re
@@ -25,7 +26,8 @@ import tempfile
 # Renovate labels checkboxes with emoji; the Windows console defaults to cp1252
 # and would crash printing them.
 for _stream in (sys.stdout, sys.stderr):
-    _stream.reconfigure(encoding="utf-8", errors="replace")
+    if isinstance(_stream, io.TextIOWrapper):
+        _stream.reconfigure(encoding="utf-8", errors="replace")
 
 DASHBOARD_TITLE_DEFAULT = "Dependency Dashboard"
 RENOVATE_AUTHORS = ("app/renovate", "renovate[bot]", "renovate-bot")

--- a/.claude/skills/renovate-rebase/tick_dashboard.py
+++ b/.claude/skills/renovate-rebase/tick_dashboard.py
@@ -22,6 +22,11 @@ import subprocess
 import sys
 import tempfile
 
+# Renovate labels checkboxes with emoji; the Windows console defaults to cp1252
+# and would crash printing them.
+for _stream in (sys.stdout, sys.stderr):
+    _stream.reconfigure(encoding="utf-8", errors="replace")
+
 DASHBOARD_TITLE_DEFAULT = "Dependency Dashboard"
 RENOVATE_AUTHORS = ("app/renovate", "renovate[bot]", "renovate-bot")
 


### PR DESCRIPTION
## What

`tick_dashboard.py` reconfigures `stdout`/`stderr` to UTF-8 with `errors="replace"` at startup.

## Why

Renovate labels its Dependency Dashboard checkboxes with emoji. On a Windows console defaulting to cp1252, printing them raises `UnicodeEncodeError` and the script crashes before it can tick any checkbox.

## Scope

Agent-skill tooling only (`.claude/skills/renovate-rebase/`) — no impact on the MegaLinter image, linters or descriptors.