### PR TITLE
fix(ci): install zensical in the auto-update linters container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@ Note: Can be used with `oxsecurity/megalinter@beta` in your GitHub Action mega-l
   - New **Check agent plugins manifests** workflow validating the agent plugin manifests on every change to them or to `skills/`: `.automation/validate_agent_plugins.py` checks the root `plugin.json` against the published Agent Plugins 1.0 schema and keeps the per-vendor manifests consistent with it, then `claude plugin validate ./ --strict` checks the Claude Code marketplace and plugin manifests
   - The auto-update workflow patch-bumps the agent plugin version when it regenerates the skills: the plugin follows its own release train, since its fix guides change far more often than MegaLinter is released. `plugin.json` is the single source of truth, mirrored into the per-vendor manifests by `.automation/agent_plugin_manifests.py` (called by `build.py`)
   - The test workflows forward the **`SFDX_AUTH_URL`** repository secret to the test container, so the **SALESFORCE_CODE_ANALYZER_APEXGURU** lint tests can reach a connected org. The secret is not exposed on pull requests from forked repositories, where those tests skip themselves
+  - The **Auto-Update Linters** workflow is fixed: `entrypoint.sh` still installed the MkDocs documentation stack, so `build.sh` aborted with `zensical: command not found` since the Zensical migration and no linter version update pull request could be created
 
 - Linter versions upgrades (N)
   - [editorconfig-checker](https://editorconfig-checker.github.io/) from 3.10.0 to **3.11.1** on 2026-08-09

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,8 +43,8 @@ if [ "${UPGRADE_LINTERS_VERSION}" == "true" ]; then
   pytest --reruns 3 --reruns-delay 1 -v --durations=0 -k _get_linter_version megalinter/
   # Run only get_linter_help test methods
   pytest --reruns 3 --reruns-delay 1 -v --durations=0 -k _get_linter_help megalinter/
-  # Reinstall mkdocs-material because of broken dependency
-  pip3 install --upgrade markdown mike mkdocs-material pymdown-extensions mkdocs-glightbox mdx_truly_sane_lists jsonschema json-schema-for-humans giturlparse webpreview github-dependents-info
+  # Install the documentation build dependencies (kept in sync with .config/python/dev/requirements.txt)
+  pip3 install --upgrade markdown zensical pymdown-extensions mdx_truly_sane_lists jsonschema json-schema-for-humans giturlparse webpreview github-dependents-info
   cd /tmp/lint || exit 1
   chmod +x build.sh
   GITHUB_TOKEN="${GITHUB_TOKEN}" GEMINI_API_KEY="${GEMINI_API_KEY}" bash build.sh --doc --dependents --stats


### PR DESCRIPTION
## Problem

The **Auto-Update Linters** workflow has failed on every run since the [MkDocs → Zensical migration](https://github.com/oxsecurity/megalinter/pull/8848):

```
build.sh: line 20: zensical: command not found
##[error]Process completed with exit code 127.
```

Failing runs: [33835656037](https://github.com/oxsecurity/megalinter/actions/runs/33835656037), [33851245685](https://github.com/oxsecurity/megalinter/actions/runs/33851245685), [33929280561](https://github.com/oxsecurity/megalinter/actions/runs/33929280561), [33948123307](https://github.com/oxsecurity/megalinter/actions/runs/33948123307).

`build.sh` builds the documentation site with `zensical build` since the migration, but `entrypoint.sh` still installed the MkDocs stack (`mike`, `mkdocs-material`, `mkdocs-glightbox`) before calling it. The failure happens at the very last step, after the linter versions and the docs have already been regenerated — so the job never reached the "Create Pull Request" step and no linter version update PR has been opened for the last 4 days.

## Fix

Swap the three now-unused MkDocs packages for `zensical` in the `UPGRADE_LINTERS_VERSION` branch of `entrypoint.sh`, keeping the list in sync with `.config/python/dev/requirements.txt` as its header asks.

`zensical` publishes a `musllinux_1_2_x86_64` abi3 wheel and depends only on pure-Python packages, so it installs cleanly on the `python:3.14-alpine` base image.

## Other post-migration checks

Swept the repository for other leftovers of the migration:

- `entrypoint.sh` was the **only** remaining place installing or invoking MkDocs
- `test-docs.yml`, `build-deploy-docs.yml`, `deploy-RELEASE.yml` and `build-command.yml` all install `.config/python/dev/requirements.txt`, which pins `zensical==0.0.57` — all green
- no script still references `site/search/search_index.json` (the MkDocs-only search index)
- remaining `mkdocs.yml` references in `build.py` are expected: Zensical reads that configuration file unchanged