### PR TITLE
Support loading config from a project-level .config subfolder

### DIFF
--- a/TEMPLATES/README.md
+++ b/TEMPLATES/README.md
@@ -1,6 +1,6 @@
 # TEMPLATES
 
-The files in this folder are template rules for the linters that will run against your code base. If you chose to copy these to your local repository in the directory: `.github/linters` they will be used at runtime. If they're not present, they will be used by default in the linter run.
+The files in this folder are template rules for the linters that will run against your code base. If you chose to copy these to your local repository in the directory: `.github/linters` (or `.config`) they will be used at runtime. If they're not present, they will be used by default in the linter run.
 
 The file(s) will be parsed at run time on the local branch to load all rules needed to run the **MegaLinter** **GitHub** Action.
 The **GitHub** Action will inform the user via the **Checks API** on the status and success of the process.

--- a/megalinter/Linter.py
+++ b/megalinter/Linter.py
@@ -398,6 +398,14 @@ class Linter:
                             f"{self.workspace}{os.path.sep}{self.linter_rules_path}"
                             + f"{os.path.sep}{file_to_check}"
                         )
+                    # in user repo ./config folder (https://dot-config.github.io)
+                    elif os.path.isfile(
+                        f"{self.workspace}{os.path.sep}.config{os.path.sep}{file_to_check}"
+                    ):
+                        found_file = (
+                            f"{self.workspace}{os.path.sep}.config"
+                            + f"{os.path.sep}{file_to_check}"
+                        )
                     elif os.path.isfile(
                         f"{self.workspace}{os.path.sep}{self.files_sub_directory}{os.path.sep}{file_to_check}"
                     ):
@@ -637,7 +645,8 @@ class Linter:
         # 2: repo + config_file_name
         # 3: linter_rules_path + config_file_name
         # 4: workspace root + linter_rules_path + config_file_name
-        # 5: mega-linter default rules path + config_file_name
+        # 5: workspace root + .config + config_file_name (https://dot-config.github.io)
+        # 6: mega-linter default rules path + config_file_name
         if (
             self.config_file_name is not None
             and self.config_file_name != "LINTER_DEFAULT"
@@ -692,6 +701,21 @@ class Linter:
                     + os.path.sep
                     + self.config_file_name
                 )
+            # in user repo ./config folder (https://dot-config.github.io)
+            elif os.path.isfile(
+                self.workspace
+                + os.path.sep
+                + ".config"
+                + os.path.sep
+                + self.config_file_name
+            ):
+                self.config_file = (
+                    self.workspace
+                    + os.path.sep
+                    + ".config"
+                    + os.path.sep
+                    + self.config_file_name
+                )
             # in user repo directory provided in <Linter>RULES_PATH or LINTER_RULES_PATH
             elif os.path.isfile(
                 self.default_rules_location + os.path.sep + self.config_file_name
@@ -716,7 +740,8 @@ class Linter:
         # 2: repo + ignore_file_name
         # 3: linter_rules_path + ignore_file_name
         # 4: workspace root + linter_rules_path + ignore_file_name
-        # 5: mega-linter default rules path + ignore_file_name
+        # 5: workspace root + .config + ignore_file_name (https://dot-config.github.io)
+        # 6: mega-linter default rules path + ignore_file_name
         if (
             self.ignore_file_name is not None
             and self.ignore_file_name != "LINTER_DEFAULT"
@@ -768,6 +793,21 @@ class Linter:
                     self.workspace
                     + os.path.sep
                     + self.linter_rules_path
+                    + os.path.sep
+                    + self.ignore_file_name
+                )
+            # in user repo ./config folder (https://dot-config.github.io)
+            elif os.path.isfile(
+                self.workspace
+                + os.path.sep
+                + ".config"
+                + os.path.sep
+                + self.ignore_file_name
+            ):
+                self.ignore_file = (
+                    self.workspace
+                    + os.path.sep
+                    + ".config"
                     + os.path.sep
                     + self.ignore_file_name
                 )

--- a/megalinter/config.py
+++ b/megalinter/config.py
@@ -125,6 +125,16 @@ def init_config(request_id, workspace=None, params=None):
             ".megalinter.yml",
             ".mega-linter.yaml",
             ".megalinter.yaml",
+            # Also support the project-level .config subfolder convention
+            # (https://dot-config.github.io), with or without the leading dot
+            ".config/mega-linter.yml",
+            ".config/megalinter.yml",
+            ".config/mega-linter.yaml",
+            ".config/megalinter.yaml",
+            ".config/.mega-linter.yml",
+            ".config/.megalinter.yml",
+            ".config/.mega-linter.yaml",
+            ".config/.megalinter.yaml",
         ]:
             if os.path.isfile(workspace + os.path.sep + candidate):
                 config_file = workspace + os.path.sep + candidate

--- a/megalinter/tests/test_megalinter/config_test.py
+++ b/megalinter/tests/test_megalinter/config_test.py
@@ -9,6 +9,7 @@ import glob
 import io
 import os
 import re
+import tempfile
 import unittest
 import uuid
 from unittest.mock import patch
@@ -76,6 +77,45 @@ class config_test(unittest.TestCase):
             )
         finally:
             self.restore_branch_in_input_files(changed_files)
+
+    def test_local_config_dot_config_folder_success(self):
+        # A .mega-linter.yml-style config file placed under the project-level
+        # .config subfolder (https://dot-config.github.io) must be picked up
+        # when no config file is present at the workspace root.
+        with tempfile.TemporaryDirectory() as tmp_workspace:
+            dot_config_dir = tmp_workspace + os.path.sep + ".config"
+            os.makedirs(dot_config_dir, exist_ok=True)
+            with open(
+                dot_config_dir + os.path.sep + "megalinter.yaml",
+                "w",
+                encoding="utf-8",
+            ) as f:
+                f.write('FILTER_REGEX_INCLUDE: "(dot-config)"\n')
+            request_id = str(uuid.uuid1())
+            config.init_config(request_id, tmp_workspace, {})
+            self.assertEqual(
+                "(dot-config)", config.get(request_id, "FILTER_REGEX_INCLUDE")
+            )
+            config.delete(request_id)
+
+    def test_local_config_dot_config_folder_dotted_filename_success(self):
+        # Some dot-config adopters keep the leading dot on the filename
+        # (e.g. .config/.megalinter.yaml): that variant must be supported too.
+        with tempfile.TemporaryDirectory() as tmp_workspace:
+            dot_config_dir = tmp_workspace + os.path.sep + ".config"
+            os.makedirs(dot_config_dir, exist_ok=True)
+            with open(
+                dot_config_dir + os.path.sep + ".megalinter.yaml",
+                "w",
+                encoding="utf-8",
+            ) as f:
+                f.write('FILTER_REGEX_INCLUDE: "(dotted-dot-config)"\n')
+            request_id = str(uuid.uuid1())
+            config.init_config(request_id, tmp_workspace, {})
+            self.assertEqual(
+                "(dotted-dot-config)", config.get(request_id, "FILTER_REGEX_INCLUDE")
+            )
+            config.delete(request_id)
 
     def test_local_config_extends_success(self):
         changed_files = self.replace_branch_in_input_files()

--- a/megalinter/tests/test_megalinter/mega_linter_1_test.py
+++ b/megalinter/tests/test_megalinter/mega_linter_1_test.py
@@ -280,6 +280,51 @@ class mega_linter_1_test(unittest.TestCase):
                 linter_rules_path + os.path.sep + "vale.ini",
             )
 
+    def test_dot_config_folder_resolves_active_only_if_file_found(self):
+        self.before_start()
+        with tempfile.TemporaryDirectory() as tmp_workspace:
+            # No .github/linters folder here: config files live directly in
+            # the project-level .config subfolder (https://dot-config.github.io)
+            dot_config_dir = tmp_workspace + os.path.sep + ".config"
+            os.makedirs(dot_config_dir, exist_ok=True)
+            with open(
+                dot_config_dir + os.path.sep + "ls-lint.yaml", "w", encoding="utf-8"
+            ) as f:
+                f.write("ls:\n  .js: regex:...[a-z]+\n")
+
+            config.set_value(
+                self.request_id, "REPOSITORY_LS_LINT_CONFIG_FILE", "ls-lint.yaml"
+            )
+
+            linter_rules_path = (
+                tmp_workspace + os.path.sep + ".github" + os.path.sep + "linters"
+            )
+            default_rules_location = utils.get_default_rules_location()
+            base_params = {
+                "default_linter_activation": True,
+                "enable_descriptors": [],
+                "enable_linters": [],
+                "disable_descriptors": [],
+                "disable_linters": [],
+                "disable_errors_linters": [],
+                "github_workspace": tmp_workspace,
+                "workspace": tmp_workspace,
+                "linter_rules_path": linter_rules_path,
+                "default_rules_location": default_rules_location,
+                "post_linter_status": True,
+                "request_id": self.request_id,
+            }
+
+            ls_lint = linter_factory.build_linter("REPOSITORY", "ls-lint", base_params)
+            self.assertTrue(
+                ls_lint.is_active,
+                "REPOSITORY_LS_LINT should be active when config exists under .config",
+            )
+            self.assertEqual(
+                ls_lint.config_file,
+                dot_config_dir + os.path.sep + "ls-lint.yaml",
+            )
+
     def test_override_linter_rules_path_remote(self):
         self.before_start()
         mega_linter, output = utilstest.call_mega_linter(


### PR DESCRIPTION
## What

MegaLinter's own configuration file (`.mega-linter.yml` / `.megalinter.yml` / etc.), as well as per-linter configuration and ignore files, can now also be loaded from a project-level `.config` subfolder, in addition to the repository root and `.github/linters`. This follows the [dot-config](https://dot-config.github.io) convention.

Both filename variants are supported for MegaLinter's own config file:

- Non-dotted: `.config/megalinter.yaml`, `.config/mega-linter.yml`, ...
- Dotted: `.config/.megalinter.yaml`, `.config/.mega-linter.yml`, ...

Per-linter config/ignore files (e.g. `SPELL_CSPELL_CONFIG_FILE`) and the `active_only_if_file_found` activation check now also fall back to `.config/<filename>`, mirroring the existing `.github/linters` (`LINTER_RULES_PATH`) lookup.

## Why

Fixes #8814. As discussed in https://github.com/oxsecurity/megalinter/issues/8814#issuecomment-5562310165, since MegaLinter already supports `.github/linters` for decluttering the repo root, supporting `.config` as well is a reasonable, low-risk extension.

## Changes

- `megalinter/config.py`: added `.config/...` candidates when searching for MegaLinter's own config file.
- `megalinter/Linter.py`: added a `.config` fallback to the per-linter config file / ignore file resolution, and to the `active_only_if_file_found` activation check.
- `TEMPLATES/README.md`: mention `.config` as an alternative destination for template rule files.
- Added unit tests covering the new `.config` fallback (including the dotted filename variant) in `config_test.py` and `mega_linter_1_test.py`.

## Testing

- Ran the affected unit test files locally with pytest (all passing, aside from pre-existing unrelated failures in `config_test.py` caused by sandbox environment limitations around git-repo detection/remote fetches, which fail identically on `main`).
- Built the `repository_ls_lint` linter image and ran the relevant tests inside the container per the project's Docker-based test workflow; all passed.